### PR TITLE
Uses phase based discrete value rule provider instead of the manual one

### DIFF
--- a/maliput_malidrive/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.cc
@@ -1,7 +1,7 @@
 // Copyright 2020 Toyota Research Institute
 #include "maliput_malidrive/builder/discrete_value_rule_state_provider_builder.h"
 
-#include "maliput/base/manual_discrete_value_rule_state_provider.h"
+#include "maliput/base/phase_based_right_of_way_discrete_value_rule_state_provider.h"
 
 namespace malidrive {
 namespace builder {
@@ -13,7 +13,7 @@ namespace {
 // @throws maliput::common::assertion_error When `state_provider` is
 //         nullptr.
 void PopulateDiscreteValueRuleStates(const std::map<Rule::Id, DiscreteValueRule>& discrete_value_rules,
-                                     maliput::ManualDiscreteValueRuleStateProvider* state_provider) {
+                                     maliput::PhaseBasedRightOfWayDiscreteValueRuleStateProvider* state_provider) {
   MALIDRIVE_THROW_UNLESS(state_provider != nullptr);
   for (const auto& rule_id_rule : discrete_value_rules) {
     state_provider->SetState(rule_id_rule.first, rule_id_rule.second.values().front(), std::nullopt, std::nullopt);
@@ -24,7 +24,8 @@ void PopulateDiscreteValueRuleStates(const std::map<Rule::Id, DiscreteValueRule>
 
 std::unique_ptr<maliput::api::rules::DiscreteValueRuleStateProvider> DiscreteValueRuleStateProviderBuilder::operator()()
     const {
-  auto state_provider = std::make_unique<maliput::ManualDiscreteValueRuleStateProvider>(rulebook_);
+  auto state_provider = std::make_unique<maliput::PhaseBasedRightOfWayDiscreteValueRuleStateProvider>(
+      rulebook_, phase_ring_book_, phase_provider_);
   const maliput::api::rules::RoadRulebook::QueryResults all_rules = rulebook_->Rules();
   PopulateDiscreteValueRuleStates(all_rules.discrete_value_rules, state_provider.get());
   return state_provider;

--- a/maliput_malidrive/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.h
+++ b/maliput_malidrive/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.h
@@ -1,8 +1,9 @@
 // Copyright 2020 Toyota Research Institute
-
 #include <memory>
 
 #include "maliput/api/rules/discrete_value_rule_state_provider.h"
+#include "maliput/api/rules/phase_provider.h"
+#include "maliput/api/rules/phase_ring_book.h"
 #include "maliput/api/rules/road_rulebook.h"
 #include "maliput_malidrive/common/macros.h"
 
@@ -21,18 +22,29 @@ class DiscreteValueRuleStateProviderBuilder {
   ///
   /// @param rulebook A RoadRulebook to feed the DiscreteValueRuleStateProvider.
   ///        It must not be nullptr.
+  /// @param phase_ring_book A PhaseRingBook to feed the
+  ///        DiscreteValueRuleStateProvider. It must not be nullptr.
+  /// @param phase_provider A PhaseProvider to feed the
+  ///        DiscreteValueRuleStateProvider. It must not be nullptr.
   ///
-  /// @throws maliput::common::assertion_error When `rulebook` is nullptr.
-  explicit DiscreteValueRuleStateProviderBuilder(const maliput::api::rules::RoadRulebook* rulebook)
-      : rulebook_(rulebook) {
+  /// @throws maliput::common::assertion_error When `rulebook`,
+  ///         `phase_ring_book` or `phase_provider` are nullptr.
+  explicit DiscreteValueRuleStateProviderBuilder(const maliput::api::rules::RoadRulebook* rulebook,
+                                                 const maliput::api::rules::PhaseRingBook* phase_ring_book,
+                                                 const maliput::api::rules::PhaseProvider* phase_provider)
+      : rulebook_(rulebook), phase_ring_book_(phase_ring_book), phase_provider_(phase_provider) {
     MALIDRIVE_DEMAND(rulebook_ != nullptr);
+    MALIDRIVE_DEMAND(phase_ring_book_ != nullptr);
+    MALIDRIVE_DEMAND(phase_provider_ != nullptr);
   }
 
-  /// Builds a DiscreteValueRuleStateProvider.
+  /// Builds a maliput::PhaseBasedRightOfWayDiscreteValueRuleStateProvider.
   std::unique_ptr<maliput::api::rules::DiscreteValueRuleStateProvider> operator()() const;
 
  private:
   const maliput::api::rules::RoadRulebook* rulebook_{};
+  const maliput::api::rules::PhaseRingBook* phase_ring_book_{};
+  const maliput::api::rules::PhaseProvider* phase_provider_{};
 };
 
 }  // namespace builder

--- a/maliput_malidrive/src/maliput_malidrive/builder/road_network_builder.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/road_network_builder.cc
@@ -64,14 +64,6 @@ std::unique_ptr<maliput::api::RoadNetwork> RoadNetworkBuilder::operator()() cons
                                        direction_usages, speed_limits)();
   maliput::log()->trace("Built RuleRoadBook.");
 
-  maliput::log()->trace("Building DiscreteValueRuleStateProvider...");
-  auto discrete_value_rule_state_provider = DiscreteValueRuleStateProviderBuilder(rule_book.get())();
-  maliput::log()->trace("Built DiscreteValueRuleStateProvider.");
-
-  maliput::log()->trace("Building RangeValueRuleStateProvider...");
-  auto range_value_rule_state_provider = RangeValueRuleStateProviderBuilder(rule_book.get())();
-  maliput::log()->trace("Built RangeValueRuleStateProvider.");
-
   maliput::log()->trace("Building TrafficLightBook...");
   auto traffic_light_book =
       !road_network_configuration_.traffic_light_book.has_value()
@@ -89,6 +81,15 @@ std::unique_ptr<maliput::api::RoadNetwork> RoadNetworkBuilder::operator()() cons
   maliput::log()->trace("Building PhaseProvider...");
   auto manual_phase_provider = std::make_unique<maliput::ManualPhaseProvider>();
   maliput::log()->trace("Built PhaseProvider.");
+
+  maliput::log()->trace("Building DiscreteValueRuleStateProvider...");
+  auto discrete_value_rule_state_provider =
+      DiscreteValueRuleStateProviderBuilder(rule_book.get(), phase_ring_book.get(), manual_phase_provider.get())();
+  maliput::log()->trace("Built DiscreteValueRuleStateProvider.");
+
+  maliput::log()->trace("Building RangeValueRuleStateProvider...");
+  auto range_value_rule_state_provider = RangeValueRuleStateProviderBuilder(rule_book.get())();
+  maliput::log()->trace("Built RangeValueRuleStateProvider.");
 
   maliput::log()->trace("Building IntersectionBook...");
   auto intersection_book =


### PR DESCRIPTION
Uses `PhaseBasedRightOfWayDiscreteValueRuleStateProvider` instead of `ManualDiscreteValueRuleStateProvider`.

Part of https://github.com/ToyotaResearchInstitute/malidrive/issues/738