### PR TITLE
Removes constraint of `p` being in range of lane_offset's domain.

### DIFF
--- a/maliput_malidrive/src/maliput_malidrive/road_curve/road_curve.cc
+++ b/maliput_malidrive/src/maliput_malidrive/road_curve/road_curve.cc
@@ -61,6 +61,10 @@ maliput::math::Vector3 RoadCurve::WDot(const maliput::math::Vector3& prh, const 
   MALIDRIVE_THROW_UNLESS(lane_offset != nullptr);
   MALIDRIVE_IS_IN_RANGE(prh.x(), ground_curve_->p0() - ground_curve_->linear_tolerance(),
                         ground_curve_->p1() + ground_curve_->linear_tolerance());
+  MALIDRIVE_IS_IN_RANGE(lane_offset->p0(), ground_curve_->p0() - ground_curve_->linear_tolerance(),
+                        ground_curve_->p1() + ground_curve_->linear_tolerance());
+  MALIDRIVE_IS_IN_RANGE(lane_offset->p1(), ground_curve_->p0() - ground_curve_->linear_tolerance(),
+                        ground_curve_->p1() + ground_curve_->linear_tolerance());
   const double p = maliput::math::saturate(prh.x(), lane_offset->p0(), lane_offset->p1());
   const double r = prh.y();
   const double h = prh.z();

--- a/maliput_malidrive/src/maliput_malidrive/road_curve/road_curve.h
+++ b/maliput_malidrive/src/maliput_malidrive/road_curve/road_curve.h
@@ -140,6 +140,8 @@ class RoadCurve {
   /// @return The derivative of @f$ W @f$ with respect to @f$ p @f$ at @p prh.
   /// @throw maliput::common::assertion_error When @p lane_offset is nullptr.
   /// @throw maliput::common::assertion_error When @p prh .x() is not in range [p0, p1].
+  /// @throw maliput::common::assertion_error When @p lane_offset ->p0() is not in range [p0, p1].
+  /// @throw maliput::common::assertion_error When @p lane_offset ->p1() is not in range [p0, p1].
   maliput::math::Vector3 WDot(const maliput::math::Vector3& prh, const Function* lane_offset) const;
 
   /// Evaluates the orientation in the INERTIAL Frame of the RoadCurve at @p p,


### PR DESCRIPTION
Instead, it uses the domain to saturate the value of `p` -argument-
to [p0; p1]. That prevents faulty calls when integrators provide
off range values by small differences.