### PR TITLE
Append library dirs to plugin test.

### DIFF
--- a/maliput_malidrive/test/CMakeLists.txt
+++ b/maliput_malidrive/test/CMakeLists.txt
@@ -35,7 +35,7 @@ macro(maliput_malidrive_build_tests)
       endif()
     endif()
 
-    ament_add_gtest(${BINARY_NAME} ${GTEST_SOURCE_file} APPEND_LIBRARY_DIRS ${LIBRARY_DIRS}
+    ament_add_gtest(${BINARY_NAME} ${GTEST_SOURCE_file} APPEND_LIBRARY_DIRS ${MALIPUT_MALIDRIVE_PLUGIN_LIBRARY_DIRS}
       TIMEOUT 240)
 
     target_include_directories(${BINARY_NAME}

--- a/maliput_malidrive/test/regression/plugin/CMakeLists.txt
+++ b/maliput_malidrive/test/regression/plugin/CMakeLists.txt
@@ -13,7 +13,10 @@ set(UNIT_PLUGIN_TEST_SOURCES
   road_network_plugin_test.cc
 )
 
-set (LIBRARY_DIRS ${CMAKE_INSTALL_PREFIX}/../maliput_dragway/lib ${CMAKE_INSTALL_PREFIX}/../maliput_multilane/lib)
+set (MALIPUT_MALIDRIVE_PLUGIN_LIBRARY_DIRS
+  ${CMAKE_INSTALL_PREFIX}/../maliput_dragway/lib
+  ${CMAKE_INSTALL_PREFIX}/../maliput_multilane/lib
+)
 # The following test uses the maliput::plugin::MaliputPluginManager entity to load all the availables plugins.
 # Given that the LD_LIBRARY_PATH environment variable isn't correctly set up until setup.bash is sourced,
 # and to avoid sourcing that file just to run one test we should append the paths.


### PR DESCRIPTION
A bit of context:
 For each backend, a `libmaliput_xxxx_road_network.so` dynamic library is installed at the default location(`install/maliput/lib/maliput/plugins`), which is ok.

The problem comes when you for example run a `maliput_malidrive` test that loads the dragway plugin dynamic library using the `MaliputPluginManager`.
Let's say that for example, you are loading `libmaliput_dragway_road_network.so`
 then this is the error that you would see: `libmaliput_dragway.so`: cannot open shared object file: No such file or directory
 
Of course, the `maliput_dragway_road_network` library that holds a plugin implementation links internally to `maliput_dragway`   which can't be found because the env var `LD_LIBRARY_PATH` doesn't contain the `install/maliput_dragway/lib` path. It is added when doing source install/setup.bash.

**Solution:** Update the paths during test configuration.

Pairs with:
https://github.com/ToyotaResearchInstitute/maliput-dragway/pull/26
https://github.com/ToyotaResearchInstitute/maliput-multilane/pull/36