### PR TITLE
Fixes CI's wrong main branch.

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -3,7 +3,7 @@ name: clang
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -3,7 +3,7 @@ name: scan_build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:


### PR DESCRIPTION
`santiziers` node and `scan build` node weren't running on `main` branch when PR is merged.