### PR TITLE
Lets disconnected Roads within a Junction to exist

### DIFF
--- a/maliput_malidrive/CMakeLists.txt
+++ b/maliput_malidrive/CMakeLists.txt
@@ -89,6 +89,7 @@ install (FILES resources/ArcLane.xodr
                resources/Crossing8Course.xodr
                resources/CrossingComplex8Course.xodr
                resources/DriveableAndPedestrian.xodr
+               resources/DisconnectedRoadInJunction.xodr
                resources/Figure8.xodr
                resources/Highway.xodr
                resources/kpit_map.xodr

--- a/maliput_malidrive/resources/DisconnectedRoadInJunction.xodr
+++ b/maliput_malidrive/resources/DisconnectedRoadInJunction.xodr
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="4" name="" version="1" date="2021-05-19T12:00:00" north="0.0" south="0.0" east="0.0" west="0.0" vendor="TRI">
+    </header>
+    <road name="Road 0" length="5.0e+1" id="0" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="2"/>
+        </link>
+        <type s="0.0000000000000000e+0" type="town">
+            <speed max="40" unit="mph"/>
+        </type>
+        <planView>
+            <geometry s="0.0e+0" x="0.0e+0" y="0.0e+0" hdg="0.0e+0" length="5.0e+1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0e+0" a="0.0e+0" b="0.0e+0" c="0.0e+0" d="0.0e+0"/>
+            <laneSection s="0.0e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0e+0" a="3.5e+0" b="0.0e+0" c="0.0e+0" d="0.0e+0"/>
+                        <roadMark sOffset="0.0e+0" type="solid" material="standard" color="white" width="1.25e-1"/>
+                        <userData>
+                            <vectorLane travelDir="forward"/>
+                        </userData>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0e+0" type="solid solid" material="standard" color="yellow" width="1.25e-1"/>
+                        <roadMark sOffset="4.6e+1" type="none" material="standard" color="white"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+    </road>
+    <road name="Road 1" length="5.0e+1" id="1" junction="2">
+        <link>
+            <predecessor elementType="road" elementId="0" contactPoint="end"/>
+        </link>
+        <type s="0.0e+0" type="town">
+            <speed max="40" unit="mph"/>
+        </type>
+        <planView>
+            <geometry s="0.0e+0" x="5.0e+1" y="0.0e+0" hdg="0.0e+0" length="5.0e+1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0e+0" a="0.0e+0" b="0.0e+0" c="0.0e+0" d="0.0e+0"/>
+            <laneSection s="0.0e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0e+0" a="3.5e+0" b="0.0e+0" c="0.0e+0" d="0.0e+0"/>
+                        <roadMark sOffset="0.0e+0" type="solid" material="standard" color="white" width="1.25e-1"/>
+                        <userData>
+                            <vectorLane travelDir="forward"/>
+                        </userData>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0e+0" type="solid solid" material="standard" color="yellow" width="1.25e-1"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+    </road>
+    <junction id="2" name="Junction 2">
+        <connection id="0" incomingRoad="0" connectingRoad="1" contactPoint="start">
+            <laneLink from="1" to="1"/>
+        </connection>
+    </junction>
+</OpenDRIVE>

--- a/maliput_malidrive/src/maliput_malidrive/builder/builder_tools.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/builder_tools.cc
@@ -166,9 +166,15 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsWithinJunction(
   const std::optional<xodr::RoadLink::LinkAttributes> road_link =
       connection_type == XodrConnectionType::kSuccessor ? xodr_lane_properties.road_header->road_link.successor
                                                         : xodr_lane_properties.road_header->road_link.predecessor;
-  MALIDRIVE_THROW_UNLESS(road_link != std::nullopt);
+  if (road_link == std::nullopt) {
+    maliput::log()->debug("Trying to connect xodr Road: {}, lane: {} {} endpoint but it lacks of a {}.",
+                          xodr_lane_properties.road_header->id.string(), xodr_lane_properties.lane->id.string(),
+                          connection_type == XodrConnectionType::kSuccessor ? "end" : "start",
+                          connection_type == XodrConnectionType::kSuccessor ? "successor" : "predecessor");
+    return {};
+  }
   if (road_link->element_type == xodr::RoadLink::ElementType::kJunction) {
-    MALIDRIVE_THROW_MESSAGE(std::string("Junctions connected to junctions are not supported."));
+    MALIDRIVE_THROW_MESSAGE("Junctions connected to junctions are not supported.");
   }
   return SolveLaneEndsForConnectingRoad(rg, xodr_lane_properties, road_headers, connection_type);
 }

--- a/maliput_malidrive/src/maliput_malidrive/builder/builder_tools.h
+++ b/maliput_malidrive/src/maliput_malidrive/builder/builder_tools.h
@@ -91,8 +91,7 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsForJunction(
 
 /// Searches which LaneEnds connect to `xodr_lane_properties.lane` in `connection_type` direction
 /// considering the LaneEnd belongs to an external interface. The XODR Road that contains the LaneEnd is
-/// assumed to live within an XODR Junction and it could connect either to
-/// another XODR Road.
+/// assumed to live within an XODR Junction and it *could* connect to another XODR Road.
 ///
 /// @param rg Is the pointer to the RoadGeometry is being built. It must not be
 ///        nullptr.
@@ -102,7 +101,6 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsForJunction(
 ///        is solved.
 ///
 /// @throws maliput::common::assertion_error When either `rg` is nullptr.
-/// @throws maliput::common::assertion_error When there isn't a valid RoadLink.
 /// @throws maliput::common::assertion_error When the RoadLink links to a junction.
 std::vector<maliput::api::LaneEnd> SolveLaneEndsWithinJunction(
     const maliput::api::RoadGeometry* rg, const MalidriveXodrLaneProperties& xodr_lane_properties,

--- a/maliput_malidrive/test/regression/builder/road_geometry_builder_test.cc
+++ b/maliput_malidrive/test/regression/builder/road_geometry_builder_test.cc
@@ -152,172 +152,197 @@ struct RoadGeometryBuilderTestParameters {
 
 // Returns a vector of test parameters for the Builder test.
 std::vector<RoadGeometryBuilderTestParameters> InstantiateBuilderParameters() {
-  return {/*
-            SingleLane map has the following structure:
-                              (0.,0.,0.)         (100.,0.,0.)
-            Driving   | L: 1  |-------->---------| Width: 2.0m
-            Track lane| L: 0  |========>=========| Width: 0m
-            Driving   | L: -1 |-------->---------| Width: 2.0m
-                              Road 1
-                              Section 0
-          */
-          {"SingleLane",
-           "odr/SingleLane.xodr",
-           {{1 /* road_id */, 0.0 /* heading */}},
-           {{JunctionId("1_0"), {{{SegmentId("1_0"), 0, 100.}, {{1, 0, -1}, {1, 0, 1}}}}}}},
-          /*
-            ArcLane map has the following structure:
-                                    (23.9388857642, 72.0457446219, 0.)
-            Road 1                               \  \  \
-            Section 0                             |  |  |
-            - Curvature:0.025                     |  |  |
-            - Length:100                          |  |  |
-                                (0.,0.,0.)      _.'  /  /
-            Driving   |Width: 2.0 m| L: 1 ....-'  _.'  /
-            Track lane|Width: 0.0 m| L: 0 .....- ' _.'
-            Driving   |Width: 2.0 m| L: -1......- '
-          */
-          {"ArcLane",
-           "odr/ArcLane.xodr",
-           {{1 /* road_id */, 0.0 /* heading */}},
-           {{JunctionId("1_0"), {{{SegmentId("1_0"), 0, 100.}, {{1, 0, -1}, {1, 0, 1}}}}}}},
-          /*
-            SShapeRoad map has the following structure:
-              - 1 Road
-                - 1 Lane Section.
-                  - 3 Lanes: {-1 <Right, Driving>, 0 <Center, Track>, 1 <Left, Driving>}
-                    - Width: 2m each, except the center lane.
-                - 3 geometries:
-                  - Arc: start: [x: 0., y: 0., h: 0.], curvature: 0.025m, length: 125.663706144m
-                  - Line: start: [x: 0., y: 80., h: π], length: 20.m
-                  - Arc: start: [x: -20., y: 80., h: π], curvature: -0.025m, length: 125.663706144m
-          */
-          {"SShapeRoad",
-           "odr/SShapeRoad.xodr",
-           {{1 /* road_id */, 0.0 /* heading */}},
-           {{JunctionId("1_0"), {{{SegmentId("1_0"), 0, 271.327412287}, {{1, 0, -1}, {1, 0, 1}}}}}}},
-          /*
-            LShapeRoad map has the following structure:
-              - 3 Roads
-                - 1 Lane Section.
-                  - 2 Lanes: {0 <Center, Track>, 1 <Left, Driving>}
-                    - Width: 2m each, except the center lane.
-                - 3 geometries(1 per road):
-                  - Line: start: [x: 0., y: 0., h: 0.], length: 100.m
-                  - Arc: start: [x: 100., y: 0., h: 0.], curvature: 0.025, length: 62.831853072m
-                  - Line: start: [x: 140., y: 40., h: π/2], length: 100.m
-          */
-          {"LShapeRoad",
-           "odr/LShapeRoad.xodr",
-           {{1 /* road_id */, 0.0 /* heading */},
-            {2 /* road_id */, 0.0 /* heading */},
-            {3 /* road_id */, 1.570796327 /* heading */}},
-           {{JunctionId("1_0"), {{{SegmentId("1_0"), 0, 100.}, {{1, 0, 1}}}}},
-            {JunctionId("2_0"), {{{SegmentId("2_0"), 0, 62.831853072}, {{2, 0, 1}}}}},
-            {JunctionId("3_0"), {{{SegmentId("3_0"), 0, 100.}, {{3, 0, 1}}}}}}},
-          /*
-            TShapeRoad map has the following structure:
-              - 3 Roads that don't belong to a Junction.
-              - 6 Roads that belong to a Junction.
-              - 1 Lane Section per Road.
-              - 3 Lanes(Only counting center and driving lanes.): {-1 <Right, Driving>, 0 <Center, Track>, 1 <Left,
-            Driving>}
-                    - Width: 3.5m each, except the center lane.
-          */
-          {"TShapeRoad",
-           "odr/TShapeRoad.xodr",
-           {{0 /* road_id */, 0.0 /* heading */},
-            {1 /* road_id */, 0.0 /* heading */},
-            {2 /* road_id */, 1.5707963267948966 /* heading */},
-            {4 /* road_id */, 0.0 /* heading */},
-            {5 /* road_id */, 0.0 /* heading */},
-            {6 /* road_id */, 3.1415926535897931 /* heading */},
-            {7 /* road_id */, 1.5707963267948966 /* heading */},
-            {8 /* road_id */, 1.5707963267948966 /* heading */},
-            {9 /* road_id */, 0.0 /* heading */}},
-           {
-               {JunctionId("0_0"),
-                {{{SegmentId("0_0"), 0, 46.},
-                  {/* left { */ {0, 0, 4},
-                   {0, 0, 3},
-                   {0, 0, 2},
-                   {0, 0, 1} /* } left */,
-                   /* right { */ {0, 0, -1},
-                   {0, 0, -2},
-                   {0, 0, -3},
-                   {0, 0, -4} /* } right */}}}},
-               {JunctionId("1_0"),
-                {{{SegmentId("1_0"), 0, 46.},
-                  {/* left { */ {1, 0, 4},
-                   {1, 0, 3},
-                   {1, 0, 2},
-                   {1, 0, 1} /* } left */,
-                   /* right { */ {1, 0, -1},
-                   {1, 0, -2},
-                   {1, 0, -3},
-                   {1, 0, -4} /* } right */}}}},
-               {JunctionId("2_0"),
-                {{{SegmentId("2_0"), 0, 46.},
-                  {/* left { */ {2, 0, 4},
-                   {2, 0, 3},
-                   {2, 0, 2},
-                   {2, 0, 1} /* } left */,
-                   /* right { */ {2, 0, -1},
-                   {2, 0, -2},
-                   {2, 0, -3},
-                   {2, 0, -4} /* } right */}}}},
-               {JunctionId("3"),
-                {{{SegmentId("4_0"), 0, 8.}, {{4, 0, 1}}},
-                 {{SegmentId("5_0"), 0, 8.}, {{5, 0, -1}}},
-                 {{SegmentId("6_0"), 0, 6.31248635281257}, {{6, 0, -1}}},
-                 {{SegmentId("7_0"), 0, 6.312486352812575}, {{7, 0, -1}}},
-                 {{SegmentId("8_0"), 0, 6.3124863528125745}, {{8, 0, -1}}},
-                 {{SegmentId("9_0"), 0, 6.312486352812572}, {{9, 0, -1}}}}},
-           }},
-          /*
-            LineMultpleSections map has the following structure:
-              - 1 Road
-                - 3 Lane Section.
-                  - 2 Driveable Lanes: {-1 <right, Driving>, 0 <Center, Track>, 1 <Left, Driving>}
-                    - Width: 2m each, except the center lane.
-                - 3 geometries(1 per road):
-                  - Line: start: [x: 0., y: 0., h: 0.], length: 33.3m
-                  - Line: start: [x: 33.3, y: 0., h: 0.], length: 33.3m
-                  - Line: start: [x: 66.6, y: 0., h: 0], length: 33.4m
-          */
-          {"LineMultipleSections",
-           "odr/LineMultipleSections.xodr",
-           {{1 /* road_id */, 0.0 /* heading */}},
-           {{JunctionId("1_0"),
-             {{{SegmentId("1_0"), 0, 33.3},
-               {/* left { */ {1, 0, 4},
-                {1, 0, 3},
-                {1, 0, 2},
-                {1, 0, 1} /* } left */,
-                /* right { */ {1, 0, -1},
-                {1, 0, -2},
-                {1, 0, -3},
-                {1, 0, -4} /* } right */}}}},
-            {JunctionId("1_1"),
-             {{{SegmentId("1_1"), 33.3, 66.6},
-               {/* left { */ {1, 1, 4},
-                {1, 1, 3},
-                {1, 1, 2},
-                {1, 1, 1} /* } left */,
-                /* right { */ {1, 1, -1},
-                {1, 1, -2},
-                {1, 1, -3},
-                {1, 1, -4} /* } right */}}}},
-            {JunctionId("1_2"),
-             {{{SegmentId("1_2"), 66.6, 100.},
-               {/* left { */ {1, 2, 4},
-                {1, 2, 3},
-                {1, 2, 2},
-                {1, 2, 1} /* } left */,
-                /* right { */ {1, 2, -1},
-                {1, 2, -2},
-                {1, 2, -3},
-                {1, 2, -4} /* } right */}}}}}}};
+  return {
+      /*
+        SingleLane map has the following structure:
+                          (0.,0.,0.)         (100.,0.,0.)
+        Driving   | L: 1  |-------->---------| Width: 2.0m
+        Track lane| L: 0  |========>=========| Width: 0m
+        Driving   | L: -1 |-------->---------| Width: 2.0m
+                          Road 1
+                          Section 0
+      */
+      {"SingleLane",
+       "odr/SingleLane.xodr",
+       {{1 /* road_id */, 0.0 /* heading */}},
+       {{JunctionId("1_0"), {{{SegmentId("1_0"), 0, 100.}, {{1, 0, -1}, {1, 0, 1}}}}}}},
+      /*
+        ArcLane map has the following structure:
+                                (23.9388857642, 72.0457446219, 0.)
+        Road 1                               \  \  \
+        Section 0                             |  |  |
+        - Curvature:0.025                     |  |  |
+        - Length:100                          |  |  |
+                            (0.,0.,0.)      _.'  /  /
+        Driving   |Width: 2.0 m| L: 1 ....-'  _.'  /
+        Track lane|Width: 0.0 m| L: 0 .....- ' _.'
+        Driving   |Width: 2.0 m| L: -1......- '
+      */
+      {"ArcLane",
+       "odr/ArcLane.xodr",
+       {{1 /* road_id */, 0.0 /* heading */}},
+       {{JunctionId("1_0"), {{{SegmentId("1_0"), 0, 100.}, {{1, 0, -1}, {1, 0, 1}}}}}}},
+      /*
+        SShapeRoad map has the following structure:
+          - 1 Road
+            - 1 Lane Section.
+              - 3 Lanes: {-1 <Right, Driving>, 0 <Center, Track>, 1 <Left, Driving>}
+                - Width: 2m each, except the center lane.
+            - 3 geometries:
+              - Arc: start: [x: 0., y: 0., h: 0.], curvature: 0.025m, length: 125.663706144m
+              - Line: start: [x: 0., y: 80., h: π], length: 20.m
+              - Arc: start: [x: -20., y: 80., h: π], curvature: -0.025m, length: 125.663706144m
+      */
+      {"SShapeRoad",
+       "odr/SShapeRoad.xodr",
+       {{1 /* road_id */, 0.0 /* heading */}},
+       {{JunctionId("1_0"), {{{SegmentId("1_0"), 0, 271.327412287}, {{1, 0, -1}, {1, 0, 1}}}}}}},
+      /*
+        LShapeRoad map has the following structure:
+          - 3 Roads
+            - 1 Lane Section.
+              - 2 Lanes: {0 <Center, Track>, 1 <Left, Driving>}
+                - Width: 2m each, except the center lane.
+            - 3 geometries(1 per road):
+              - Line: start: [x: 0., y: 0., h: 0.], length: 100.m
+              - Arc: start: [x: 100., y: 0., h: 0.], curvature: 0.025, length: 62.831853072m
+              - Line: start: [x: 140., y: 40., h: π/2], length: 100.m
+      */
+      {"LShapeRoad",
+       "odr/LShapeRoad.xodr",
+       {{1 /* road_id */, 0.0 /* heading */},
+        {2 /* road_id */, 0.0 /* heading */},
+        {3 /* road_id */, 1.570796327 /* heading */}},
+       {{JunctionId("1_0"), {{{SegmentId("1_0"), 0, 100.}, {{1, 0, 1}}}}},
+        {JunctionId("2_0"), {{{SegmentId("2_0"), 0, 62.831853072}, {{2, 0, 1}}}}},
+        {JunctionId("3_0"), {{{SegmentId("3_0"), 0, 100.}, {{3, 0, 1}}}}}}},
+      /*
+        TShapeRoad map has the following structure:
+          - 3 Roads that don't belong to a Junction.
+          - 6 Roads that belong to a Junction.
+          - 1 Lane Section per Road.
+          - 3 Lanes(Only counting center and driving lanes.): {-1 <Right, Driving>, 0 <Center, Track>, 1 <Left,
+        Driving>}
+                - Width: 3.5m each, except the center lane.
+      */
+      {"TShapeRoad",
+       "odr/TShapeRoad.xodr",
+       {{0 /* road_id */, 0.0 /* heading */},
+        {1 /* road_id */, 0.0 /* heading */},
+        {2 /* road_id */, 1.5707963267948966 /* heading */},
+        {4 /* road_id */, 0.0 /* heading */},
+        {5 /* road_id */, 0.0 /* heading */},
+        {6 /* road_id */, 3.1415926535897931 /* heading */},
+        {7 /* road_id */, 1.5707963267948966 /* heading */},
+        {8 /* road_id */, 1.5707963267948966 /* heading */},
+        {9 /* road_id */, 0.0 /* heading */}},
+       {
+           {JunctionId("0_0"),
+            {{{SegmentId("0_0"), 0, 46.},
+              {/* left { */ {0, 0, 4},
+               {0, 0, 3},
+               {0, 0, 2},
+               {0, 0, 1} /* } left */,
+               /* right { */ {0, 0, -1},
+               {0, 0, -2},
+               {0, 0, -3},
+               {0, 0, -4} /* } right */}}}},
+           {JunctionId("1_0"),
+            {{{SegmentId("1_0"), 0, 46.},
+              {/* left { */ {1, 0, 4},
+               {1, 0, 3},
+               {1, 0, 2},
+               {1, 0, 1} /* } left */,
+               /* right { */ {1, 0, -1},
+               {1, 0, -2},
+               {1, 0, -3},
+               {1, 0, -4} /* } right */}}}},
+           {JunctionId("2_0"),
+            {{{SegmentId("2_0"), 0, 46.},
+              {/* left { */ {2, 0, 4},
+               {2, 0, 3},
+               {2, 0, 2},
+               {2, 0, 1} /* } left */,
+               /* right { */ {2, 0, -1},
+               {2, 0, -2},
+               {2, 0, -3},
+               {2, 0, -4} /* } right */}}}},
+           {JunctionId("3"),
+            {{{SegmentId("4_0"), 0, 8.}, {{4, 0, 1}}},
+             {{SegmentId("5_0"), 0, 8.}, {{5, 0, -1}}},
+             {{SegmentId("6_0"), 0, 6.31248635281257}, {{6, 0, -1}}},
+             {{SegmentId("7_0"), 0, 6.312486352812575}, {{7, 0, -1}}},
+             {{SegmentId("8_0"), 0, 6.3124863528125745}, {{8, 0, -1}}},
+             {{SegmentId("9_0"), 0, 6.312486352812572}, {{9, 0, -1}}}}},
+       }},
+      /*
+        LineMultpleSections map has the following structure:
+          - 1 Road
+            - 3 Lane Section.
+              - 2 Driveable Lanes: {-1 <right, Driving>, 0 <Center, Track>, 1 <Left, Driving>}
+                - Width: 2m each, except the center lane.
+            - 3 geometries(1 per road):
+              - Line: start: [x: 0., y: 0., h: 0.], length: 33.3m
+              - Line: start: [x: 33.3, y: 0., h: 0.], length: 33.3m
+              - Line: start: [x: 66.6, y: 0., h: 0], length: 33.4m
+      */
+      {"LineMultipleSections",
+       "odr/LineMultipleSections.xodr",
+       {{1 /* road_id */, 0.0 /* heading */}},
+       {{JunctionId("1_0"),
+         {{{SegmentId("1_0"), 0, 33.3},
+           {/* left { */ {1, 0, 4},
+            {1, 0, 3},
+            {1, 0, 2},
+            {1, 0, 1} /* } left */,
+            /* right { */ {1, 0, -1},
+            {1, 0, -2},
+            {1, 0, -3},
+            {1, 0, -4} /* } right */}}}},
+        {JunctionId("1_1"),
+         {{{SegmentId("1_1"), 33.3, 66.6},
+           {/* left { */ {1, 1, 4},
+            {1, 1, 3},
+            {1, 1, 2},
+            {1, 1, 1} /* } left */,
+            /* right { */ {1, 1, -1},
+            {1, 1, -2},
+            {1, 1, -3},
+            {1, 1, -4} /* } right */}}}},
+        {JunctionId("1_2"),
+         {{{SegmentId("1_2"), 66.6, 100.},
+           {/* left { */ {1, 2, 4},
+            {1, 2, 3},
+            {1, 2, 2},
+            {1, 2, 1} /* } left */,
+            /* right { */ {1, 2, -1},
+            {1, 2, -2},
+            {1, 2, -3},
+            {1, 2, -4} /* } right */}}}}}},
+      /*
+        DisconnectedRoadInJunction map has the following structure:
+          - Road 0 - no Junction, connects to Road 1
+            - 1 Lane Section.
+              - 1 Driveable Lanes: {-1 <left, Driving>, 0 <Center, Track>}
+                - Width: 3.5m each, except the center lane.
+            - 1 geometry:  Line: start: [x: 0., y: 0., h: 0.], length: 50.0m
+          - Road 1 - Junction 2, connects to Road 1
+            - 1 Lane Section.
+              - 1 Driveable Lanes: {-1 <left, Driving>, 0 <Center, Track>}
+                - Width: 3.5m each, except the center lane.
+            - 1 geometry:  Line: start: [x: 0., y: 0., h: 0.], length: 50.0m
+          - Junction 2
+            - 1 connection: Road0:L1 -> Road1:L1.
+
+        This road shows how a road inside a Junction might not be connected
+        to anything in one of its endpoints.
+      */
+      {"DisconnectedRoadInJunction",
+       "odr/DisconnectedRoadInJunction.xodr",
+       {{0 /* road_id */, 0.0 /* heading */}, {1 /* road_id */, 0.0 /* heading */}},
+       {{JunctionId("0_0"), {{{SegmentId("0_0"), 0., 50.}, {{0, 0, 1}}}}},
+        {JunctionId("2"), {{{SegmentId("1_0"), 0., 50.}, {{1, 0, 1}}}}}}},
+  };
 }
 
 // Builder test that evaluates Junction, Segment and Lane construction.


### PR DESCRIPTION
Solves #53 

- Removes the constraint in the builder and allows Xodr Roads in a Xodr Junction to be connected on one end only.
- Adds a sample Xodr to test the case.