### PR TITLE
Improves the error message to explain which are the roads involved in…

### DIFF
--- a/maliput_malidrive/src/maliput_malidrive/xodr/db_manager.cc
+++ b/maliput_malidrive/src/maliput_malidrive/xodr/db_manager.cc
@@ -426,7 +426,7 @@ class DBManager::Impl {
                              road_header_link.id.string() +
                              (link.contact_point.value() == RoadLink::ContactPoint::kEnd
                                   ? ") but its successor is not reciprocal. It points to RoadHeader("
-                                  : ")but its predecessor  is not reciprocal. It points to RoadHeader(") +
+                                  : ") but its predecessor is not reciprocal. It points to RoadHeader(") +
                              link_s_road_link->element_id.string() + ")");
     } else {
       MALIDRIVE_VALIDATE(Junction::Id(link_s_road_link->element_id.string()) == Junction::Id(road_header.junction),


### PR DESCRIPTION
… the assertion.

Part of #65 

Old error message:

```sh
terminate called after throwing an instance of 'maliput::common::assertion_error'
  what():  db_manager.cc:VerifyLinkingIsReciprocal:430: JunctionId: 106 is different from -1
```

New error message:

```sh
db_manager.cc:VerifyLinkingIsReciprocal:436: RoadHeader(14) has a link pointing to RoadHeader(13) but its successor is not reciprocal. It points to JunctionId(106) and RoadHeader(14) has JunctionId(-1)
```

Once a full implementation of #65 is done, the exception message can be used for a log string.