### PR TITLE
pybind11 is not needed in CI

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -3,7 +3,3 @@ repositories:
     type: git
     url: https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen
     version: main
-  pybind11:
-    type: git
-    url: https://github.com/RobotLocomotion/pybind11.git
-    version: 69a5d92a5ff9fe84581a1edeb6051a8c21d9eb97

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,7 @@ jobs:
       working-directory: ${{ env.ROS_WS }}
       run: |
         rosdep update;
-        rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "pybind11" \
-          --from-paths src
+        rosdep install  -i -y --rosdistro ${ROS_DISTRO} --from-paths src
     - name: install drake
       shell: bash
       working-directory: ${{ env.ROS_WS }}/src/drake_vendor

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -81,9 +81,7 @@ jobs:
       working-directory: ${{ env.ROS_WS }}
       run: |
         rosdep update;
-        rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "pybind11" \
-          --from-paths src
+        rosdep install  -i -y --rosdistro ${ROS_DISTRO} --from-paths src
     - name: install drake
       shell: bash
       working-directory: ${{ env.ROS_WS }}/src/drake_vendor

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -66,9 +66,7 @@ jobs:
       working-directory: ${{ env.ROS_WS }}
       run: |
         rosdep update;
-        rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "pybind11" \
-          --from-paths src
+        rosdep install  -i -y --rosdistro ${ROS_DISTRO} --from-paths src
     - name: install drake
       shell: bash
       working-directory: ${{ env.ROS_WS }}/src/drake_vendor


### PR DESCRIPTION
This package doesn't depend on pybind11 anymore, so remove it from CI.

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196