### PR TITLE
Include XODR file name in error message

### DIFF
--- a/maliput_malidrive/src/maliput_malidrive/builder/road_geometry_builder.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/road_geometry_builder.cc
@@ -267,7 +267,9 @@ std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryBuilder::operator(
                                           XodrParserConfigurationFromRoadGeometryConfiguration(rg_config_));
     // @}
   }
-  MALIDRIVE_THROW_MESSAGE("None of the tolerances worked to build the RoadGeometry.");
+  const std::string file_description =
+      rg_config_.opendrive_file ? ("from " + rg_config_.opendrive_file.value()) : "(No OpenDRIVE file specified)";
+  MALIDRIVE_THROW_MESSAGE("None of the tolerances worked to build a RoadGeometry " + file_description + ".");
   // @}
 }
 


### PR DESCRIPTION
Include the XODR file name, if possible, when no workable tolerance
is found. Useful for debugging purposes.