### PR TITLE
Piecwise GroundCurve: Use epsilon instead of tolerance at range validation

### DIFF
--- a/maliput_malidrive/src/maliput_malidrive/road_curve/piecewise_ground_curve.cc
+++ b/maliput_malidrive/src/maliput_malidrive/road_curve/piecewise_ground_curve.cc
@@ -75,7 +75,7 @@ PiecewiseGroundCurve::PiecewiseGroundCurve(std::vector<std::unique_ptr<GroundCur
   }
   p0_ = 0.;
   p1_ = cumulative_p;
-  MALIDRIVE_THROW_UNLESS(p1_ - p0_ >= linear_tolerance_);
+  MALIDRIVE_THROW_UNLESS(p1_ - p0_ >= kEpsilon);
   validate_p_ = OpenRangeValidator::GetRelativeEpsilonValidator(p0_, p1_, linear_tolerance_, kEpsilon);
 }
 


### PR DESCRIPTION
We weren't consistent in the verification of the range:
 - When creating GroundCurves we check that `p1_ - p0_ >= GroundCurve::kEpsilon`
 - When creating PiecewiseGroundCurve we were checking that `p1_ - p0_ >= linear_tolerance_`
 
 Which besides not being consistent it was causing that Roads that are smaller than linear tolerance weren't being able to be loaded.