### PR TITLE
Removes ament_target_dependencies from libraries.

### DIFF
--- a/maliput_malidrive/src/applications/CMakeLists.txt
+++ b/maliput_malidrive/src/applications/CMakeLists.txt
@@ -16,7 +16,7 @@ install(
 add_executable(xodr_query xodr_query.cc)
 target_link_libraries(
   xodr_query
-  PUBLIC
+  PRIVATE
     gflags
     maliput::common
     utility
@@ -34,7 +34,7 @@ install(
 add_executable(xodr_validate xodr_validate.cc)
 target_link_libraries(
   xodr_validate
-  PUBLIC
+  PRIVATE
     gflags
     maliput::common
     utility

--- a/maliput_malidrive/src/maliput_malidrive/base/CMakeLists.txt
+++ b/maliput_malidrive/src/maliput_malidrive/base/CMakeLists.txt
@@ -18,11 +18,6 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-ament_target_dependencies(base
-  "drake"
-  "maliput"
-)
-
 target_link_libraries(
   base
     drake::drake

--- a/maliput_malidrive/src/maliput_malidrive/builder/CMakeLists.txt
+++ b/maliput_malidrive/src/maliput_malidrive/builder/CMakeLists.txt
@@ -33,10 +33,6 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-ament_target_dependencies(builder
-  "maliput"
-)
-
 target_link_libraries(
   builder
     drake::drake

--- a/maliput_malidrive/src/maliput_malidrive/common/CMakeLists.txt
+++ b/maliput_malidrive/src/maliput_malidrive/common/CMakeLists.txt
@@ -17,12 +17,6 @@ target_include_directories(
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-
-ament_target_dependencies(common
-  PUBLIC
-    "maliput"
-)
-
 target_link_libraries(common
   PUBLIC
     maliput::common

--- a/maliput_malidrive/src/maliput_malidrive/loader/CMakeLists.txt
+++ b/maliput_malidrive/src/maliput_malidrive/loader/CMakeLists.txt
@@ -17,10 +17,6 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-ament_target_dependencies(loader
-  "maliput"
-)
-
 target_link_libraries(
   loader
     maliput::api

--- a/maliput_malidrive/src/maliput_malidrive/road_curve/CMakeLists.txt
+++ b/maliput_malidrive/src/maliput_malidrive/road_curve/CMakeLists.txt
@@ -25,11 +25,6 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-ament_target_dependencies(road_curve
-  "drake"
-  "maliput"
-)
-
 target_link_libraries(
   road_curve
     drake::drake

--- a/maliput_malidrive/src/maliput_malidrive/xodr/CMakeLists.txt
+++ b/maliput_malidrive/src/maliput_malidrive/xodr/CMakeLists.txt
@@ -34,10 +34,6 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-ament_target_dependencies(xodr
-  "maliput"
-)
-
 target_link_libraries(
   xodr
     maliput::math

--- a/maliput_malidrive/src/plugin/CMakeLists.txt
+++ b/maliput_malidrive/src/plugin/CMakeLists.txt
@@ -10,10 +10,6 @@ set_target_properties(road_network
     OUTPUT_NAME maliput_malidrive_road_network
 )
 
-ament_target_dependencies(road_network
-    "maliput"
-)
-
 target_link_libraries(road_network
   maliput::api
   maliput::common


### PR DESCRIPTION
It's implementation in foxy changed, and now it is
linking against the exported targets from the package.
That becomes a problem because maliput::test_utilities
is an incomplete library that finalizes symbol discovery
when linked against gtest and gmock via ament_cmake_*.


Part of ToyotaResearchInstitute/maliput_infrastructure#196

Linked to https://github.com/ToyotaResearchInstitute/malidrive/pull/767

See https://github.com/ToyotaResearchInstitute/maliput/pull/428 for information about the linkers.