### PR TITLE
Increases kMaxToleranceSelectionRounds to 24.

### DIFF
--- a/maliput_malidrive/include/maliput_malidrive/constants.h
+++ b/maliput_malidrive/include/maliput_malidrive/constants.h
@@ -18,8 +18,10 @@ static constexpr double kStrictAngularTolerance{1e-12};  // [rad]
 static constexpr double kSpeedTolerance{1e-4};             // [m/s]
 static constexpr double kDefaultMinSpeedLimit{0.};         // [m/s]
 static constexpr double kDefaultMaxSpeedLimit{40. / 3.6};  // [m/s] --> 40km/h
-// Number of trials the Builder will run with different tolerances.
-static constexpr int kMaxToleranceSelectionRounds{20};
+/// Number of trials the Builder will run with different tolerances.
+/// Using default linear tolerance value it is expected that the builder tries with
+/// tolerances in a range between 0.05 and 0.49. (`kLinearTolerance` and @f$ kLinearTolerance*1.1^24 @f$)
+static constexpr int kMaxToleranceSelectionRounds{24};
 
 /// TODO(#701): Remove the following two constants once #701 is merged.
 static constexpr double kExplorationRadius{1.};  // [m]


### PR DESCRIPTION

**Overview:** Updates `kMaxToleranceSelectionRounds` constant from 20 to 24 to guarantee
a tolerance between 0.05 and ~0.50 when automatic tolerance selection is enabled.

### Context 
By default, :
 - the linear tolerance is malidrive::kLinearTolerance(2e-5)
 - the automatic selection policy is set as automatic.
 
Therefore, up to `kMaxToleranceSelectionRounds` times the tolerance will be increased by 10% if the tolerance isn't enough to build the RoadNetwork.

So. when using default values the tolerance that the RoadNetwork may take will be narrowed down betwen
 - min: `malidrive::kLinearTolerance`  = 5e-2
 - max: `malidrive::kLinearTolerance` * 1.1 ^ `kMaxToleranceSelectionRounds` = 2e-5 * 1.1 ^ 24 = 0.4925
 -----> `linear tolerance ∈ [0.05 ; 0.4925)`


