### PR TITLE
Improves throw message: Print range of tolerances evaluated

### DIFF
--- a/maliput_malidrive/include/maliput_malidrive/constants.h
+++ b/maliput_malidrive/include/maliput_malidrive/constants.h
@@ -20,9 +20,11 @@ static constexpr double kDefaultMinSpeedLimit{0.};         // [m/s]
 static constexpr double kDefaultMaxSpeedLimit{40. / 3.6};  // [m/s] --> 40km/h
 /// Number of trials the Builder will run with different tolerances.
 /// Using default linear tolerance value it is expected that the builder tries with
-/// tolerances in a range between 0.05 and 0.49. (`kLinearTolerance` and @f$ kLinearTolerance*1.1^24 @f$)
+/// tolerances in a range between 0.05 and 0.49. (#kLinearTolerance and #kLinearTolerance * #kIncreasingToleranceStep ^
+/// #kMaxToleranceSelectionRounds )
 static constexpr int kMaxToleranceSelectionRounds{24};
-
+/// Step used to increase the tolerance by the Builder. See #kMaxToleranceSelectionRounds.
+static constexpr double kIncreasingToleranceStep{1.1};
 /// TODO(#701): Remove the following two constants once #701 is merged.
 static constexpr double kExplorationRadius{1.};  // [m]
 static constexpr int kNumIterations{200};        // [u]

--- a/maliput_malidrive/src/maliput_malidrive/builder/road_geometry_builder.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/road_geometry_builder.cc
@@ -333,11 +333,10 @@ std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryBuilder::operator(
   angular_tolerances[0] = rg_config_.angular_tolerance;
   scale_lengths[0] = rg_config_.scale_length;
 
-  const double kIncreasingToleranceStep{1.1};
   // Populates the vector with higher tolerance values but always use the same scale length.
   for (size_t i = 1; i < linear_tolerances.size(); ++i) {
-    linear_tolerances[i] = linear_tolerances[i - 1] * kIncreasingToleranceStep;
-    angular_tolerances[i] = angular_tolerances[i - 1] * kIncreasingToleranceStep;
+    linear_tolerances[i] = linear_tolerances[i - 1] * constants::kIncreasingToleranceStep;
+    angular_tolerances[i] = angular_tolerances[i - 1] * constants::kIncreasingToleranceStep;
     scale_lengths[i] = constants::kScaleLength;
   }
   Reset(linear_tolerances[0], angular_tolerances[0], scale_lengths[0]);
@@ -382,11 +381,11 @@ std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryBuilder::operator(
   const std::string linear_tolerance_description =
       "Used linear tolerances are in the range [" + std::to_string(linear_tolerances[0]) + ", " +
       std::to_string(linear_tolerances.back()) + "] with an increasing step of " +
-      std::to_string(static_cast<int>((kIncreasingToleranceStep - 1) * 100)) + "% per iteration";
+      std::to_string(static_cast<int>((constants::kIncreasingToleranceStep - 1) * 100)) + "% per iteration.";
   const std::string angular_tolerance_description =
       "Used angular tolerances are in the range [" + std::to_string(angular_tolerances[0]) + ", " +
       std::to_string(angular_tolerances.back()) + "] with an increasing step of " +
-      std::to_string(static_cast<int>((kIncreasingToleranceStep - 1) * 100)) + "% per iteration";
+      std::to_string(static_cast<int>((constants::kIncreasingToleranceStep - 1) * 100)) + "% per iteration.";
   MALIDRIVE_THROW_MESSAGE("None of the tolerances(" + std::to_string(constants::kMaxToleranceSelectionRounds + 1) +
                           ") worked to build a RoadGeometry " + file_description + ".\n\t" +
                           linear_tolerance_description + "\n\t" + angular_tolerance_description);


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/maliput_malidrive/issues/156

New message example: 
```
terminate called after throwing an instance of 'maliput::common::assertion_error'
  what():  road_geometry_builder.cc:operator():392: None of the tolerances(25) worked to build a RoadGeometry from xodr_files/leghorn.xodr.
	Used linear tolerances are in the range [0.050000, 0.492487] with an increasing step of 10% per iteration
	Used angular tolerances are in the range [0.010000, 0.098497] with an increasing step of 10% per iteration
Aborted (core dumped)
```
