### PR TITLE
Expose RoadNetwork configuration builder keys.

### DIFF
--- a/maliput_malidrive/include/maliput_malidrive/builder/params.h
+++ b/maliput_malidrive/include/maliput_malidrive/builder/params.h
@@ -1,0 +1,138 @@
+// Copyright 2021 Toyota Research Institute
+#pragma once
+
+namespace malidrive {
+namespace builder {
+namespace params {
+
+/// @defgroup road_network_configuration_builder_keys RoadNetwork configuration builder keys
+///
+/// Parameters used during the RoadNetwork building process.
+///
+/// When parameters are omitted the default value will be used.
+///
+/// Example of use:
+/// @code{cpp}
+/// const std::map<std::string, std::string> road_network_configuration {
+///   {"malidrive::builder::params::kRoadGeometryId", "appian_way_road_geometry"},
+///   {"malidrive::builder::params::kOpendriveFile", "appian_way.xodr"},
+///   {"malidrive::builder::params::kLinearTolerance", "1e-3"},
+///   {"malidrive::builder::params::kAngularTolerance", "1e-3"},
+///   {"malidrive::builder::params::kInertialToBackendFrameTranslation", "{2.0, 2.0, 0.0}"},
+/// };
+/// auto road_network = malidrive::loader::Load<malidrive::builder::RoadNetworkBuilder>(road_network_configuration);
+/// @endcode
+///
+/// Parameters related to the creation of the RoadGeometry can be seen at @ref road_geometry_configuration_builder_keys.
+///
+/// Parameters for passing filepath to road rulebook, traffic light book, phase ring book and intersection book are
+/// listed below.
+/// @{
+
+/// Path to the configuration file to load a RoadRulebook
+///   - Default: ""
+static constexpr char const* kRoadRuleBook{"road_rule_book"};
+
+/// Path to the configuration file to load a TrafficLightBook
+///   - Default: ""
+static constexpr char const* kTrafficLightBook{"traffic_light_book"};
+
+/// Path to the configuration file to load a PhaseRingBook
+///   - Default: ""
+static constexpr char const* kPhaseRingBook{"phase_ring_book"};
+
+/// Path to the configuration file to load a IntersectionBook
+///   - Default: ""
+static constexpr char const* kIntersectionBook{"intersection_book"};
+
+/// @}
+
+/// @defgroup road_geometry_configuration_builder_keys RoadGeometry configuration builder keys
+/// Parameters used during the RoadGeometry building process.
+/// See @ref road_network_configuration_builder_keys for further information.
+///
+/// @ingroup road_network_configuration_builder_keys
+/// @{
+
+/// A string that works as ID of the RoadGeometry.
+///   - Default: @e "maliput"
+static constexpr char const* kRoadGeometryId{"road_geometry_id"};
+
+/// Path to the XODR file to be loaded.
+///   - Default: ""
+static constexpr char const* kOpendriveFile{"opendrive_file"};
+
+/// RoadGeometry's linear tolerance.
+///   - Default: By default it isn't set. When `max_linear_tolerance` isn't also set then @e "5e-2"
+///   (#malidrive::constants::kLinearTolerance) is used.
+static constexpr char const* kLinearTolerance{"linear_tolerance"};
+
+/// A maximum allowed linear tolerance.
+/// When this parameter is passed, the linear tolerance the builder will use
+/// is defined within the range [`linear_tolerance`, `max_linear_tolerance`].
+/// The builder is expected to iteratively try higher linear tolerances until it either finds
+/// a value that works, or reaches this maximum value, at which point it will abort with a
+/// failure.
+/// When `linear_tolerance` isn't set, the minimum value of the range will be defined by
+/// #malidrive::constants::kBaseLinearTolerance. It is recommended to define the minimum
+/// value using the `linear_tolerance` parameter to hint the builder to a valid range,
+/// otherwise this method could demand a considerable extra time while it tries out
+/// relatively small linear tolerances.
+///   - Default: By default it isn't set. The builder will try only `linear_tolerance`.
+static constexpr char const* kMaxLinearTolerance{"max_linear_tolerance"};
+
+/// RoadGeometry's angular tolerance.
+///   - Default: @e "1e-3" (#malidrive::constants::kAngularTolerance)
+static constexpr char const* kAngularTolerance{"angular_tolerance"};
+
+/// RoadGeometry's scale length.
+///   - Default: @e "1.0" (#malidrive::constants::kScaleLength)
+static constexpr char const* kScaleLength{"scale_length"};
+
+/// Translation from maliput to malidrive inertial frame.
+/// The format of the 3-dimensional vector that is expected to be passed
+/// should be {X , Y , Z}. Same format as maliput::math::Vector3 is
+/// serialized.
+///   - Default: @e "{0., 0., 0.}"
+static constexpr char const* kInertialToBackendFrameTranslation{"inertial_to_backend_frame_translation"};
+
+/// Determines the use of concurrency when building the RoadGeometry.
+///   - Options:
+///     - 1. @e "sequential"
+///     - 2. @e "parallel"
+///   - Default: @e "sequential"
+static constexpr char const* kBuildPolicy{"build_policy"};
+
+/// Indicates the number of threads to be used to build the RoadGeometry when `build_policy` flag is
+/// set to `parallel`.
+///    - Default: std::thread::hardware_concurrency() minus one (running thread).
+static constexpr char const* kNumThreads{"num_threads"};
+
+/// Determines geometries simplification for the XODR's roads.
+///   - Options:
+///     - 1. @e "none"
+///     - 2. @e "simplify"
+///   - Default: @e "none"
+static constexpr char const* kSimplificationPolicy{"simplification_policy"};
+
+/// Indicates how permissive builder should be with the XODR description.
+///   - Options:
+///    - 1. @e "strict" : Do not permit any errors.
+///    - 2. @e "allow_schema_errors" : Allow schema syntax errors.
+///    - 3. @e "allow_semantic_errors" : Allow semantic errors.
+///    - 4. @e "permissive": Allow all previous violations.
+///   - Default: @e "permissive"
+static constexpr char const* kStandardStrictnessPolicy{"standard_strictness_policy"};
+
+/// True for omitting building non-drivable lanes. False otherwise
+///   - Options:
+///     - 1. <em> "true", "True", "TRUE", "on", "On", "ON" </em>
+///     - 2. <em> "false", "False",  "FALSE", "off", "Off", "OFF" </em>
+///   - Default: @e "true"
+static constexpr char const* kOmitNonDrivableLanes{"omit_nondrivable_lanes"};
+
+/// @}
+
+}  // namespace params
+}  // namespace builder
+}  // namespace malidrive

--- a/maliput_malidrive/include/maliput_malidrive/loader/loader.h
+++ b/maliput_malidrive/include/maliput_malidrive/loader/loader.h
@@ -18,82 +18,8 @@ namespace loader {
 /// @param road_network_configuration A string-string map containing information about the RoadNetwork configuration
 /// used during the loading process.
 ///
-/// @details The parameters that can be set are the following:
-/// - @b road_geometry_id : A string that works as ID of the RoadGeometry.
-///   - Default: @e "maliput"
-/// - @b opendrive_file : Path to the XODR file to be loaded.
-///   - Default: ""
-/// - @b linear_tolerance : RoadGeometry's linear tolerance.
-///   - Default: By default it isn't set. When `max_linear_tolerance` isn't also set then @e "5e-2"
-///   (#malidrive::constants::kLinearTolerance) is used.
-/// - @b max_linear_tolerance : A maximum allowed linear tolerance.
-///                            When this parameter is passed, the linear tolerance the builder will use
-///                            is defined within the range [`linear_tolerance`, `max_linear_tolerance`].
-///                            The builder is expected to iteratively try higher linear tolerances until it either finds
-///                            a value that works, or reaches this maximum value, at which point it will abort with a
-///                            failure.
-///                            When `linear_tolerance` isn't set, the minimum value of the range will be defined by
-///                            #malidrive::constants::kBaseLinearTolerance. It is recommended to define the minimum
-///                            value using the `linear_tolerance` parameter to hint the builder to a valid range,
-///                            otherwise this method could demand a considerable extra time while it tries out
-///                            relatively small linear tolerances.
-///   - Default: By default it isn't set. The builder will try only `linear_tolerance`.
-/// - @b angular_tolerance : RoadGeometry's angular tolerance.
-///   - Default: @e "1e-3" (#malidrive::constants::kAngularTolerance)
-/// - @b scale_length : RoadGeometry's scale length.
-///   - Default: @e "1.0" (#malidrive::constants::kScaleLength)
-/// - @b inertial_to_backend_frame_translation : Translation from maliput to malidrive inertial frame.
-///                                             The format of the 3-dimensional vector that is expected to be passed
-///                                             should be {X , Y , Z}. Same format as maliput::math::Vector3 is
-///                                             serialized.
-///   - Default: @e "{0., 0., 0.}"
-/// - @b build_policy : Determines the use of concurrency when building the RoadGeometry.
-///   - Options:
-///     - 1. @e "sequential"
-///     - 2. @e "parallel"
-///   - Default: @e "sequential"
-/// - @b num_threads : Indicates the number of threads to be used to build the RoadGeometry when `build_policy` flag is
-/// set to `parallel`.
-///    - Default: std::thread::hardware_concurrency() minus one (running thread).
-/// - @b simplification_policy : Determines geometries simplification for the XODR's roads.
-///   - Options:
-///     - 1. @e "none"
-///     - 2. @e "simplify"
-///   - Default: @e "none"
-/// - @b standard_strictness_policy : Indicates how permissive builder should be with the XODR description.
-///   - Options:
-///    - 1. @e "strict" : Do not permit any errors.
-///    - 2. @e "allow_schema_errors" : Allow schema syntax errors.
-///    - 3. @e "allow_semantic_errors" : Allow semantic errors.
-///    - 4. @e "permissive": Allow all previous violations.
-///   - Default: @e "permissive"
-/// - @b omit_nondrivable_lanes : True for omitting building non-drivable lanes. False otherwise
-///   - Options:
-///     - 1. <em> "true", "True", "TRUE", "on", "On", "ON" </em>
-///     - 2. <em> "false", "False",  "FALSE", "off", "Off", "OFF" </em>
-///   - Default: @e "true"
-/// - @b road_rule_book : Path to the configuration file to load a RoadRulebook
-///   - Default: ""
-/// - @b traffic_light_book : Path to the configuration file to load a TrafficLightBook
-///   - Default: ""
-/// - @b phase_ring_book : Path to the configuration file to load a PhaseRingBook
-///   - Default: ""
-/// - @b intersection_book : Path to the configuration file to load a IntersectionBook
-///   - Default: ""
+/// @details The parameters that can be set are listed at @ref road_network_configuration_builder_keys.
 ///
-/// When parameters are omitted the default value will be used.
-///
-/// Example of use:
-/// @code{cpp}
-/// const std::map<std::string, std::string> road_network_configuration {
-///   {"road_geometry_id", "appian_way_road_geometry"},
-///   {"opendrive_file", "appian_way.xodr"},
-///   {"linear_tolerance", "1e-3"},
-///   {"angular_tolerance", "1e-3"},
-///   {"inertial_to_backend_frame_translation", "{2.0, 2.0, 0.0}"},
-/// };
-/// auto road_network = malidrive::loader::Load<malidrive::builder::RoadNetworkBuilder>(road_network_configuration);
-/// @endcode
 ///
 /// @return An unique_ptr to a RoadNetwork.
 /// @tparam RoadNetworkBuilderT One of opendrive::builder::RoadNetworkBuilder or

--- a/maliput_malidrive/src/maliput_malidrive/builder/road_geometry_configuration.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/road_geometry_configuration.cc
@@ -4,6 +4,7 @@
 #include <map>
 #include <sstream>
 
+#include "maliput_malidrive/builder/params.h"
 #include "maliput_malidrive/common/macros.h"
 
 namespace malidrive {
@@ -79,61 +80,61 @@ bool ParseBoolean(const std::string& bool_str) {
 RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(
     const std::map<std::string, std::string>& road_geometry_configuration) {
   RoadGeometryConfiguration rg_config{};
-  auto it = road_geometry_configuration.find(kStrRoadGeometryId);
+  auto it = road_geometry_configuration.find(params::kRoadGeometryId);
   if (it != road_geometry_configuration.end()) {
     rg_config.id = maliput::api::RoadGeometryId{it->second};
   }
 
-  it = road_geometry_configuration.find(kStrOpendriveFile);
+  it = road_geometry_configuration.find(params::kOpendriveFile);
   if (it != road_geometry_configuration.end()) {
     rg_config.opendrive_file = it->second;
   }
 
-  it = road_geometry_configuration.find(kStrLinearTolerance);
+  it = road_geometry_configuration.find(params::kLinearTolerance);
   if (it != road_geometry_configuration.end()) {
     rg_config.tolerances.linear_tolerance = std::stod(it->second);
   }
 
-  it = road_geometry_configuration.find(kStrMaxLinearTolerance);
+  it = road_geometry_configuration.find(params::kMaxLinearTolerance);
   if (it != road_geometry_configuration.end()) {
     rg_config.tolerances.max_linear_tolerance = std::stod(it->second);
   }
 
-  it = road_geometry_configuration.find(kStrAngularTolerance);
+  it = road_geometry_configuration.find(params::kAngularTolerance);
   if (it != road_geometry_configuration.end()) {
     rg_config.tolerances.angular_tolerance = std::stod(it->second);
   }
 
-  it = road_geometry_configuration.find(kStrScaleLength);
+  it = road_geometry_configuration.find(params::kScaleLength);
   if (it != road_geometry_configuration.end()) {
     rg_config.scale_length = std::stod(it->second);
   }
 
-  it = road_geometry_configuration.find(kStrInertialToBackendFrameTranslation);
+  it = road_geometry_configuration.find(params::kInertialToBackendFrameTranslation);
   if (it != road_geometry_configuration.end()) {
     rg_config.inertial_to_backend_frame_translation = maliput::math::Vector3::FromStr(it->second);
   }
 
-  it = road_geometry_configuration.find(kStrBuildPolicy);
+  it = road_geometry_configuration.find(params::kBuildPolicy);
   if (it != road_geometry_configuration.end()) {
     const BuildPolicy::Type build_policy_type = BuildPolicy::FromStrToType(it->second);
-    it = road_geometry_configuration.find(kStrNumThreads);
+    it = road_geometry_configuration.find(params::kNumThreads);
     const std::optional<int> num_threads{
         it != road_geometry_configuration.end() ? std::make_optional(std::stoi(it->second)) : std::nullopt};
     rg_config.build_policy = BuildPolicy{build_policy_type, num_threads};
   }
 
-  it = road_geometry_configuration.find(kStrSimplificationPolicy);
+  it = road_geometry_configuration.find(params::kSimplificationPolicy);
   if (it != road_geometry_configuration.end()) {
     rg_config.simplification_policy = FromStrToSimplificationPolicy(it->second);
   }
 
-  it = road_geometry_configuration.find(kStrStandardStrictnessPolicy);
+  it = road_geometry_configuration.find(params::kStandardStrictnessPolicy);
   if (it != road_geometry_configuration.end()) {
     rg_config.standard_strictness_policy = FromStrToStandardStrictnessPolicy(it->second);
   }
 
-  it = road_geometry_configuration.find(kStrOmitNonDrivableLanes);
+  it = road_geometry_configuration.find(params::kOmitNonDrivableLanes);
   if (it != road_geometry_configuration.end()) {
     rg_config.omit_nondrivable_lanes = ParseBoolean(it->second);
   }
@@ -142,23 +143,23 @@ RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(
 
 std::map<std::string, std::string> RoadGeometryConfiguration::ToStringMap() const {
   std::map<std::string, std::string> config_map{};
-  config_map.emplace(kStrRoadGeometryId, id.string());
-  config_map.emplace(kStrOpendriveFile, opendrive_file);
+  config_map.emplace(params::kRoadGeometryId, id.string());
+  config_map.emplace(params::kOpendriveFile, opendrive_file);
   if (tolerances.linear_tolerance.has_value()) {
-    config_map.emplace(kStrLinearTolerance, std::to_string(tolerances.linear_tolerance.value()));
+    config_map.emplace(params::kLinearTolerance, std::to_string(tolerances.linear_tolerance.value()));
   }
   if (tolerances.max_linear_tolerance.has_value()) {
-    config_map.emplace(kStrMaxLinearTolerance, std::to_string(tolerances.max_linear_tolerance.value()));
+    config_map.emplace(params::kMaxLinearTolerance, std::to_string(tolerances.max_linear_tolerance.value()));
   }
-  config_map.emplace(kStrAngularTolerance, std::to_string(tolerances.angular_tolerance));
-  config_map.emplace(kStrScaleLength, std::to_string(scale_length));
-  config_map.emplace(kStrInertialToBackendFrameTranslation, inertial_to_backend_frame_translation.to_str());
-  config_map.emplace(kStrSimplificationPolicy, FromSimplificationPolicyToStr(simplification_policy));
-  config_map.emplace(kStrStandardStrictnessPolicy, FromStandardStrictnessPolicyToStr(standard_strictness_policy));
-  config_map.emplace(kStrOmitNonDrivableLanes, omit_nondrivable_lanes ? "true" : "false");
-  config_map.emplace(kStrBuildPolicy, BuildPolicy::FromTypeToStr(build_policy.type));
+  config_map.emplace(params::kAngularTolerance, std::to_string(tolerances.angular_tolerance));
+  config_map.emplace(params::kScaleLength, std::to_string(scale_length));
+  config_map.emplace(params::kInertialToBackendFrameTranslation, inertial_to_backend_frame_translation.to_str());
+  config_map.emplace(params::kSimplificationPolicy, FromSimplificationPolicyToStr(simplification_policy));
+  config_map.emplace(params::kStandardStrictnessPolicy, FromStandardStrictnessPolicyToStr(standard_strictness_policy));
+  config_map.emplace(params::kOmitNonDrivableLanes, omit_nondrivable_lanes ? "true" : "false");
+  config_map.emplace(params::kBuildPolicy, BuildPolicy::FromTypeToStr(build_policy.type));
   if (build_policy.num_threads.has_value()) {
-    config_map.emplace(kStrNumThreads, std::to_string(build_policy.num_threads.value()));
+    config_map.emplace(params::kNumThreads, std::to_string(build_policy.num_threads.value()));
   }
   return config_map;
 }

--- a/maliput_malidrive/src/maliput_malidrive/builder/road_geometry_configuration.h
+++ b/maliput_malidrive/src/maliput_malidrive/builder/road_geometry_configuration.h
@@ -40,23 +40,6 @@ struct BuildPolicy {
 
 /// RoadGeometry construction parameters.
 struct RoadGeometryConfiguration {
-  /// @name Road Geometry configuration's keys used in string map.
-  ///
-  /// @{
-  static constexpr char const* kStrRoadGeometryId = "road_geometry_id";
-  static constexpr char const* kStrOpendriveFile = "opendrive_file";
-  static constexpr char const* kStrLinearTolerance = "linear_tolerance";
-  static constexpr char const* kStrMaxLinearTolerance = "max_linear_tolerance";
-  static constexpr char const* kStrAngularTolerance = "angular_tolerance";
-  static constexpr char const* kStrScaleLength = "scale_length";
-  static constexpr char const* kStrInertialToBackendFrameTranslation = "inertial_to_backend_frame_translation";
-  static constexpr char const* kStrBuildPolicy = "build_policy";
-  static constexpr char const* kStrNumThreads = "num_threads";
-  static constexpr char const* kStrSimplificationPolicy = "simplification_policy";
-  static constexpr char const* kStrStandardStrictnessPolicy = "standard_strictness_policy";
-  static constexpr char const* kStrOmitNonDrivableLanes = "omit_nondrivable_lanes";
-  /// @}
-
   /// Level of flexibility in terms of adhering to the OpenDrive standard
   /// when constructing a RoadGeometry. This is useful when working with
   /// .xodr files that violate the OpenDrive standard. The policy is
@@ -106,6 +89,7 @@ struct RoadGeometryConfiguration {
   static std::string FromStandardStrictnessPolicyToStr(const StandardStrictnessPolicy& policy);
 
   /// Creates a RoadGeometryConfiguration out of a string dictionary.
+  /// @details The keys of the map are listed at @ref road_geometry_configuration_builder_keys.
   /// @param road_geometry_configuration A string-string map containing the configuration for the builder.
   static RoadGeometryConfiguration FromMap(const std::map<std::string, std::string>& road_geometry_configuration);
 
@@ -137,6 +121,7 @@ struct RoadGeometryConfiguration {
     double angular_tolerance{constants::kAngularTolerance};
   };
 
+  /// @details The keys of the map are listed at @ref road_geometry_configuration_builder_keys.
   /// @returns A string-string map containing the RoadGeometry configuration.
   std::map<std::string, std::string> ToStringMap() const;
 

--- a/maliput_malidrive/src/maliput_malidrive/builder/road_network_configuration.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/road_network_configuration.cc
@@ -2,6 +2,8 @@
 
 #include "maliput_malidrive/builder/road_network_configuration.h"
 
+#include "maliput_malidrive/builder/params.h"
+
 namespace malidrive {
 namespace builder {
 
@@ -9,19 +11,19 @@ RoadNetworkConfiguration RoadNetworkConfiguration::FromMap(
     const std::map<std::string, std::string>& road_network_configuration) {
   RoadNetworkConfiguration rn_config{RoadGeometryConfiguration::FromMap(road_network_configuration)};
 
-  auto it = road_network_configuration.find(kStrRoadRuleBook);
+  auto it = road_network_configuration.find(params::kRoadRuleBook);
   if (it != road_network_configuration.end()) {
     rn_config.road_rule_book = std::make_optional(it->second);
   }
-  it = road_network_configuration.find(kStrTrafficLightBook);
+  it = road_network_configuration.find(params::kTrafficLightBook);
   if (it != road_network_configuration.end()) {
     rn_config.traffic_light_book = std::make_optional(it->second);
   }
-  it = road_network_configuration.find(kStrPhaseRingBook);
+  it = road_network_configuration.find(params::kPhaseRingBook);
   if (it != road_network_configuration.end()) {
     rn_config.phase_ring_book = std::make_optional(it->second);
   }
-  it = road_network_configuration.find(kStrIntersectionBook);
+  it = road_network_configuration.find(params::kIntersectionBook);
   if (it != road_network_configuration.end()) {
     rn_config.intersection_book = std::make_optional(it->second);
   }
@@ -31,16 +33,16 @@ RoadNetworkConfiguration RoadNetworkConfiguration::FromMap(
 std::map<std::string, std::string> RoadNetworkConfiguration::ToStringMap() const {
   auto rg_config = road_geometry_configuration.ToStringMap();
   if (road_rule_book.has_value()) {
-    rg_config.emplace(kStrRoadRuleBook, road_rule_book.value());
+    rg_config.emplace(params::kRoadRuleBook, road_rule_book.value());
   }
   if (traffic_light_book.has_value()) {
-    rg_config.emplace(kStrTrafficLightBook, traffic_light_book.value());
+    rg_config.emplace(params::kTrafficLightBook, traffic_light_book.value());
   }
   if (phase_ring_book.has_value()) {
-    rg_config.emplace(kStrPhaseRingBook, phase_ring_book.value());
+    rg_config.emplace(params::kPhaseRingBook, phase_ring_book.value());
   }
   if (intersection_book.has_value()) {
-    rg_config.emplace(kStrIntersectionBook, intersection_book.value());
+    rg_config.emplace(params::kIntersectionBook, intersection_book.value());
   }
   return rg_config;
 }

--- a/maliput_malidrive/src/maliput_malidrive/builder/road_network_configuration.h
+++ b/maliput_malidrive/src/maliput_malidrive/builder/road_network_configuration.h
@@ -12,19 +12,12 @@ namespace builder {
 
 /// Structure to hold file paths for multiple RoadNetwork structures.
 struct RoadNetworkConfiguration {
-  /// @name Road Network configuration's keys used in string map.
-  ///
-  /// @{
-  static constexpr char const* kStrRoadRuleBook = "road_rule_book";
-  static constexpr char const* kStrTrafficLightBook = "traffic_light_book";
-  static constexpr char const* kStrPhaseRingBook = "phase_ring_book";
-  static constexpr char const* kStrIntersectionBook = "intersection_book";
-  /// @}
-
   /// Creates a RoadNetworkConfiguration out of a string dictionary.
+  /// @details The keys of the map are listed at @ref road_network_configuration_builder_keys.
   /// @param road_network_configuration A string-string map containing the configuration for the builder.
   static RoadNetworkConfiguration FromMap(const std::map<std::string, std::string>& road_network_configuration);
 
+  /// @details The keys of the map are listed at @ref road_network_configuration_builder_keys.
   /// @returns A string-string map containing the RoadGeometry configuration.
   std::map<std::string, std::string> ToStringMap() const;
 

--- a/maliput_malidrive/test/regression/builder/road_geometry_configuration_test.cc
+++ b/maliput_malidrive/test/regression/builder/road_geometry_configuration_test.cc
@@ -3,6 +3,8 @@
 
 #include <gtest/gtest.h>
 
+#include "maliput_malidrive/builder/params.h"
+
 namespace malidrive {
 namespace builder {
 namespace test {
@@ -53,20 +55,19 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       kOmitNondrivableLanes};
 
   const std::map<std::string, std::string> rg_config_map{
-      {RoadGeometryConfiguration::kStrRoadGeometryId, kRgId},
-      {RoadGeometryConfiguration::kStrOpendriveFile, kOpendriveFile},
-      {RoadGeometryConfiguration::kStrLinearTolerance, std::to_string(kLinearTolerance)},
-      {RoadGeometryConfiguration::kStrMaxLinearTolerance, std::to_string(kMaxLinearTolerance)},
-      {RoadGeometryConfiguration::kStrAngularTolerance, std::to_string(kAngularTolerance)},
-      {RoadGeometryConfiguration::kStrScaleLength, std::to_string(kScaleLength)},
-      {RoadGeometryConfiguration::kStrInertialToBackendFrameTranslation, kRandomVector.to_str()},
-      {RoadGeometryConfiguration::kStrBuildPolicy, BuildPolicy::FromTypeToStr(kBuildPolicy.type)},
-      {RoadGeometryConfiguration::kStrNumThreads, std::to_string(kBuildPolicy.num_threads.value())},
-      {RoadGeometryConfiguration::kStrSimplificationPolicy,
-       RoadGeometryConfiguration::FromSimplificationPolicyToStr(kSimplificationPolicy)},
-      {RoadGeometryConfiguration::kStrStandardStrictnessPolicy,
+      {params::kRoadGeometryId, kRgId},
+      {params::kOpendriveFile, kOpendriveFile},
+      {params::kLinearTolerance, std::to_string(kLinearTolerance)},
+      {params::kMaxLinearTolerance, std::to_string(kMaxLinearTolerance)},
+      {params::kAngularTolerance, std::to_string(kAngularTolerance)},
+      {params::kScaleLength, std::to_string(kScaleLength)},
+      {params::kInertialToBackendFrameTranslation, kRandomVector.to_str()},
+      {params::kBuildPolicy, BuildPolicy::FromTypeToStr(kBuildPolicy.type)},
+      {params::kNumThreads, std::to_string(kBuildPolicy.num_threads.value())},
+      {params::kSimplificationPolicy, RoadGeometryConfiguration::FromSimplificationPolicyToStr(kSimplificationPolicy)},
+      {params::kStandardStrictnessPolicy,
        RoadGeometryConfiguration::FromStandardStrictnessPolicyToStr(kStandardStrictnessPolicy)},
-      {RoadGeometryConfiguration::kStrOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
+      {params::kOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
   };
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(rg_config_map)};

--- a/maliput_malidrive/test/regression/builder/road_network_configuration_test.cc
+++ b/maliput_malidrive/test/regression/builder/road_network_configuration_test.cc
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include "maliput_malidrive/builder/params.h"
+
 namespace malidrive {
 namespace builder {
 namespace test {
@@ -75,23 +77,22 @@ TEST_F(RoadNetworkConfigurationTest, Constructor) {
   RoadNetworkConfiguration dut1{rg_config, kRoadRuleBook, kTrafficLightBook, kPhaseRingBook, kIntersectionBook};
 
   const std::map<std::string, std::string> rn_config_map{
-      {RoadGeometryConfiguration::kStrRoadGeometryId, kRgId},
-      {RoadGeometryConfiguration::kStrOpendriveFile, kOpendriveFile},
-      {RoadGeometryConfiguration::kStrLinearTolerance, std::to_string(kLinearTolerance)},
-      {RoadGeometryConfiguration::kStrMaxLinearTolerance, std::to_string(kMaxLinearTolerance)},
-      {RoadGeometryConfiguration::kStrAngularTolerance, std::to_string(kAngularTolerance)},
-      {RoadGeometryConfiguration::kStrScaleLength, std::to_string(kScaleLength)},
-      {RoadGeometryConfiguration::kStrInertialToBackendFrameTranslation, kRandomVector.to_str()},
-      {RoadGeometryConfiguration::kStrBuildPolicy, BuildPolicy::FromTypeToStr(kBuildPolicy.type)},
-      {RoadGeometryConfiguration::kStrSimplificationPolicy,
-       RoadGeometryConfiguration::FromSimplificationPolicyToStr(kSimplificationPolicy)},
-      {RoadGeometryConfiguration::kStrStandardStrictnessPolicy,
+      {params::kRoadGeometryId, kRgId},
+      {params::kOpendriveFile, kOpendriveFile},
+      {params::kLinearTolerance, std::to_string(kLinearTolerance)},
+      {params::kMaxLinearTolerance, std::to_string(kMaxLinearTolerance)},
+      {params::kAngularTolerance, std::to_string(kAngularTolerance)},
+      {params::kScaleLength, std::to_string(kScaleLength)},
+      {params::kInertialToBackendFrameTranslation, kRandomVector.to_str()},
+      {params::kBuildPolicy, BuildPolicy::FromTypeToStr(kBuildPolicy.type)},
+      {params::kSimplificationPolicy, RoadGeometryConfiguration::FromSimplificationPolicyToStr(kSimplificationPolicy)},
+      {params::kStandardStrictnessPolicy,
        RoadGeometryConfiguration::FromStandardStrictnessPolicyToStr(kStandardStrictnessPolicy)},
-      {RoadGeometryConfiguration::kStrOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
-      {RoadNetworkConfiguration::kStrRoadRuleBook, kRoadRuleBook.value()},
-      {RoadNetworkConfiguration::kStrTrafficLightBook, kTrafficLightBook.value()},
-      {RoadNetworkConfiguration::kStrPhaseRingBook, kPhaseRingBook.value()},
-      {RoadNetworkConfiguration::kStrIntersectionBook, kIntersectionBook.value()},
+      {params::kOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
+      {params::kRoadRuleBook, kRoadRuleBook.value()},
+      {params::kTrafficLightBook, kTrafficLightBook.value()},
+      {params::kPhaseRingBook, kPhaseRingBook.value()},
+      {params::kIntersectionBook, kIntersectionBook.value()},
   };
 
   const RoadNetworkConfiguration dut2{RoadNetworkConfiguration::FromMap(rn_config_map)};

--- a/maliput_malidrive/test/regression/loader/loader_test.cc
+++ b/maliput_malidrive/test/regression/loader/loader_test.cc
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include "maliput_malidrive/builder/params.h"
 #include "maliput_malidrive/builder/road_geometry_configuration.h"
 #include "maliput_malidrive/builder/road_network_builder.h"
 #include "maliput_malidrive/builder/road_network_configuration.h"
@@ -20,9 +21,12 @@ namespace {
 class LoaderTestSingleLane : public ::testing::Test {
  protected:
   const std::map<std::string, std::string> road_geometry_configuration_{
-      {"road_geometry_id", "test_id"}, {"opendrive_file", utility::FindResource("odr/SingleLane.xodr")},
-      {"linear_tolerance", "1e-3"},    {"angular_tolerance", "1e-3"},
-      {"scale_length", "1"},           {"omit_nondrivable_lanes", "false"},
+      {builder::params::kRoadGeometryId, "test_id"},
+      {builder::params::kOpendriveFile, utility::FindResource("odr/SingleLane.xodr")},
+      {builder::params::kLinearTolerance, "1e-3"},
+      {builder::params::kAngularTolerance, "1e-3"},
+      {builder::params::kScaleLength, "1"},
+      {builder::params::kOmitNonDrivableLanes, "false"},
   };
 
   const int kNumLanes{2};
@@ -34,7 +38,7 @@ TEST_F(LoaderTestSingleLane, LoadARoadNetwork) {
   const std::unique_ptr<maliput::api::RoadNetwork> dut =
       loader::Load<builder::RoadNetworkBuilder>(road_geometry_configuration_);
   const auto rg = dut->road_geometry();
-  EXPECT_EQ(road_geometry_configuration_.at("road_geometry_id"), rg->id().string());
+  EXPECT_EQ(road_geometry_configuration_.at(builder::params::kRoadGeometryId), rg->id().string());
   const auto lane_id_lane = rg->ById().GetLanes();
   EXPECT_EQ(kNumLanes, lane_id_lane.size());
   EXPECT_NE(lane_id_lane.at(kLaneId1), nullptr);


### PR DESCRIPTION
### Summary

Related to https://github.com/ToyotaResearchInstitute/maliput_malidrive/issues/187

- Expose RoadNetwork configuration builder keys. --> 
   -  `#include malidrive/builder/params.h` defines the keys
- Docstring related to `load` method was refactored:
 
   - ` malidrive::loader::Load` doc:
![image](https://user-images.githubusercontent.com/53065142/138519868-848be347-184a-4e0f-84cd-2b2f66510f94.png)
  --> Links to `RoadNetwork configuration builder keys` group
  
   - `RoadNetwork configuration builder keys` group under `malidrive::builder::params`:
![image](https://user-images.githubusercontent.com/53065142/138520070-dd3fb1bb-26ae-49ac-80f8-e0e1f35d2d86.png)
  --> There is a submodule " `RoadGeometry configuration builder keys` "
   
    -  `RoadGeometry configuration builder keys` group
  ![image](https://user-images.githubusercontent.com/53065142/138520196-94b181a9-5053-4707-9971-3b777c7f8cca.png)
