### PR TITLE
Replaces push by workflow_dispatch event in gcc build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: gcc
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 env:
   PACKAGE_NAME: maliput_malidrive


### PR DESCRIPTION
To improve remove the duplicate workflows in CI and to enable manual checks without a PR.
