### PR TITLE
Adds missing SingleRoadPedestrianCrosswalk.yaml.

### DIFF
--- a/maliput_malidrive/CMakeLists.txt
+++ b/maliput_malidrive/CMakeLists.txt
@@ -124,6 +124,7 @@ install (FILES resources/ArcLane.xodr
                resources/SingleRoadNanValues.xodr
                resources/SingleRoadNegativeWidth.xodr
                resources/SingleRoadPedestrianCrosswalk.xodr
+               resources/SingleRoadPedestrianCrosswalk.yaml
                resources/SingleRoadTinyGeometry.xodr
                resources/SingleRoadTwoGeometries.xodr
                resources/SpiralRoad.xodr


### PR DESCRIPTION
We were missing installing the `yaml` file for this map.