### PR TITLE
Fixes RoWR zone in SingleRoadPedestrianCrosswalk.yaml file.

### DIFF
--- a/maliput_malidrive/resources/SingleRoadPedestrianCrosswalk.yaml
+++ b/maliput_malidrive/resources/SingleRoadPedestrianCrosswalk.yaml
@@ -69,7 +69,7 @@ RoadRulebook:
   - id: "Vehicle-Stop-In-Zone-Behavior Rule Type/EastToWest"
     type: "Vehicle-Stop-In-Zone-Behavior Rule Type"
     zone:
-      - lane_id: 1_1_1
+      - lane_id: 1_2_1
         # s_range: [0, 10] # It is commented out as I would like to cover the entire lane.
     values:
       - value: "DoNotStop"
@@ -81,7 +81,7 @@ RoadRulebook:
   - id: "Right-Of-Way Rule Type/EastToWest"
     type: "Right-Of-Way Rule Type"
     zone:
-      - lane_id: 1_1_1
+      - lane_id: 1_2_1
     values:
       - value: "Go"
         severity: 0


### PR DESCRIPTION
The Right of Way Rule's zone for the lane in which direction usage is `against_s` wasn't correctly set.

![image](https://user-images.githubusercontent.com/53065142/157869345-28bff7cf-ad48-434e-ab55-5d4138c31406.png)

Related to https://github.com/ToyotaResearchInstitute/delphyne_demos/issues/38