### PR TITLE
Changed values() and ranges() method from Rules to states()

### DIFF
--- a/maliput_malidrive/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.cc
@@ -8,7 +8,7 @@ namespace builder {
 namespace {
 
 // Sets to `state_provider` the first value in each
-// DiscreteValueRule::values() in `discrete_value_rules` as the default
+// DiscreteValueRule::states() in `discrete_value_rules` as the default
 // state.
 // @throws maliput::common::assertion_error When `state_provider` is
 //         nullptr.
@@ -16,7 +16,7 @@ void PopulateDiscreteValueRuleStates(const std::map<Rule::Id, DiscreteValueRule>
                                      maliput::PhaseBasedRightOfWayDiscreteValueRuleStateProvider* state_provider) {
   MALIDRIVE_THROW_UNLESS(state_provider != nullptr);
   for (const auto& rule_id_rule : discrete_value_rules) {
-    state_provider->SetState(rule_id_rule.first, rule_id_rule.second.values().front(), std::nullopt, std::nullopt);
+    state_provider->SetState(rule_id_rule.first, rule_id_rule.second.states().front(), std::nullopt, std::nullopt);
   }
 }
 

--- a/maliput_malidrive/src/maliput_malidrive/builder/range_value_rule_state_provider_builder.cc
+++ b/maliput_malidrive/src/maliput_malidrive/builder/range_value_rule_state_provider_builder.cc
@@ -8,14 +8,14 @@ namespace builder {
 namespace {
 
 // Sets to `state_provider` the first range in each
-// RangeValueRule::ranges() in `range_value_rules` as the default state.
+// RangeValueRule::states() in `range_value_rules` as the default state.
 // @throws maliput::common::assertion_error When `state_provider` is
 //         nullptr.
 void PopulateRangeValueRuleStates(const std::map<Rule::Id, RangeValueRule>& range_value_rules,
                                   maliput::ManualRangeValueRuleStateProvider* state_provider) {
   MALIDRIVE_THROW_UNLESS(state_provider != nullptr);
   for (const auto& rule_id_rule : range_value_rules) {
-    state_provider->SetState(rule_id_rule.first, rule_id_rule.second.ranges().front(), std::nullopt, std::nullopt);
+    state_provider->SetState(rule_id_rule.first, rule_id_rule.second.states().front(), std::nullopt, std::nullopt);
   }
 }
 

--- a/maliput_malidrive/test/regression/builder/road_network_builder_test.cc
+++ b/maliput_malidrive/test/regression/builder/road_network_builder_test.cc
@@ -646,10 +646,10 @@ TEST_P(DirectionUsageTest, DirectionUsageRuleTest) {
     EXPECT_EQ(static_cast<int>(dut.zone().ranges().size()), 1);
     CompareLaneSRange(dut.zone().ranges()[0], LaneSRange{reference_value.lane_id, {reference_value.s_range}},
                       kLinearTolerance);
-    EXPECT_EQ(static_cast<int>(dut.values().size()), 1);
-    EXPECT_EQ(dut.values()[0].severity, reference_value.severity);
-    EXPECT_EQ(reference_value.state_type, dut.values()[0].value);
-    EXPECT_TRUE(dut.values()[0].related_rules.empty());
+    EXPECT_EQ(static_cast<int>(dut.states().size()), 1);
+    EXPECT_EQ(dut.states()[0].severity, reference_value.severity);
+    EXPECT_EQ(reference_value.state_type, dut.states()[0].value);
+    EXPECT_TRUE(dut.states()[0].related_rules.empty());
   }
 }
 
@@ -747,10 +747,10 @@ TEST_P(VehicleRulesTest, VehicleRulesTest) {
 
   auto test_rule = [&](const DiscreteValueRule& rule, const VehicleRulesReferenceValue& reference_value) {
     EXPECT_EQ(rule.type_id(), reference_value.rule_type);
-    EXPECT_EQ(static_cast<int>(rule.values().size()), 1);
-    EXPECT_EQ(rule.values()[0].severity, reference_value.state_severity);
-    EXPECT_EQ(rule.values()[0].related_rules.size(), reference_value.related_rules.size());
-    for (const auto& rule_group_rule_ids : rule.values()[0].related_rules) {
+    EXPECT_EQ(static_cast<int>(rule.states().size()), 1);
+    EXPECT_EQ(rule.states()[0].severity, reference_value.state_severity);
+    EXPECT_EQ(rule.states()[0].related_rules.size(), reference_value.related_rules.size());
+    for (const auto& rule_group_rule_ids : rule.states()[0].related_rules) {
       ASSERT_TRUE(reference_value.related_rules.find(rule_group_rule_ids.first) != reference_value.related_rules.end());
       for (const Rule::Id& rule_id : rule_group_rule_ids.second) {
         EXPECT_TRUE(std::find(reference_value.related_rules.at(rule_group_rule_ids.first).begin(),
@@ -758,7 +758,7 @@ TEST_P(VehicleRulesTest, VehicleRulesTest) {
                               rule_id) != reference_value.related_rules.at(rule_group_rule_ids.first).end());
       }
     }
-    EXPECT_EQ(rule.values()[0].value, reference_value.discrete_value);
+    EXPECT_EQ(rule.states()[0].value, reference_value.discrete_value);
     EXPECT_EQ(static_cast<int>(rule.zone().ranges().size()), 1);
     CompareLaneSRange(rule.zone().ranges()[0], LaneSRange(reference_value.lane_id, reference_value.s_range),
                       rn->road_geometry()->linear_tolerance());
@@ -853,7 +853,7 @@ TEST_P(VehicleRulesStateProviderTest, DiscreteValueRuleStateProviderTest) {
         rn->discrete_value_rule_state_provider()->GetState(rule_id);
     EXPECT_TRUE(state_result.has_value());
     EXPECT_FALSE(state_result->next.has_value());
-    EXPECT_EQ(state_result->state, rule.values().front());
+    EXPECT_EQ(state_result->state, rule.states().front());
   }
 }
 
@@ -1097,11 +1097,11 @@ TEST_P(SpeedLimitRuleBuilderTest, SpeedLimitRulesTest) {
       EXPECT_EQ(static_cast<int>(dut.zone().ranges().size()), 1);
       CompareLaneSRange(dut.zone().ranges()[0], LaneSRange{reference_value.lane_id, index_value_range.second.s_range},
                         kLinearTolerance);
-      EXPECT_EQ(static_cast<int>(dut.ranges().size()), 1);
-      EXPECT_EQ(dut.ranges()[0].severity, reference_value.state_severity);
-      EXPECT_TRUE(dut.ranges()[0].related_rules.empty());
-      EXPECT_DOUBLE_EQ(dut.ranges()[0].min, constants::kDefaultMinSpeedLimit);
-      EXPECT_NEAR(dut.ranges()[0].max, index_value_range.second.max, kSpeedTolerance);
+      EXPECT_EQ(static_cast<int>(dut.states().size()), 1);
+      EXPECT_EQ(dut.states()[0].severity, reference_value.state_severity);
+      EXPECT_TRUE(dut.states()[0].related_rules.empty());
+      EXPECT_DOUBLE_EQ(dut.states()[0].min, constants::kDefaultMinSpeedLimit);
+      EXPECT_NEAR(dut.states()[0].max, index_value_range.second.max, kSpeedTolerance);
     }
   }
 }
@@ -1175,7 +1175,7 @@ TEST_P(RangeValueRuleStateProviderTest, RangeValueRuleStateProviderTest) {
         rn->range_value_rule_state_provider()->GetState(rule_id);
     EXPECT_TRUE(state_result.has_value());
     EXPECT_FALSE(state_result->next.has_value());
-    EXPECT_EQ(state_result->state, rule.ranges().front());
+    EXPECT_EQ(state_result->state, rule.states().front());
   }
 }
 

--- a/maliput_malidrive/test/regression/builder/road_rulebook_builder_test.cc
+++ b/maliput_malidrive/test/regression/builder/road_rulebook_builder_test.cc
@@ -75,11 +75,11 @@ inline ::testing::AssertionResult IsEqual(const T& rule_a, const T& rule_b, doub
     }
   }
   if constexpr (std::is_base_of<DiscreteValueRule, T>::value) {
-    if (rule_a.values() != rule_b.values()) {
+    if (rule_a.states() != rule_b.states()) {
       return ::testing::AssertionFailure() << "DiscreteValues of " << rule_a.id().string() << " are different";
     }
   } else {
-    if (rule_a.ranges() != rule_b.ranges()) {
+    if (rule_a.states() != rule_b.states()) {
       return ::testing::AssertionFailure() << "Ranges of " << rule_a.id().string() << " are different";
     }
   }


### PR DESCRIPTION
This PR is a follow up of the [PR](https://github.com/ToyotaResearchInstitute/maliput/pull/484) that solves https://github.com/ToyotaResearchInstitute/maliput/issues/472

**Description**
Exactly what the tittle says. Changes the method name of `DiscreteValueRule::values()` to `DiscreteValueRule::states()` and `RangeValueRule::ranges()` to `RangeValueRule::states()`.
