### PR TITLE
Use <doc_depend> for ament_cmake_doxygen dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="andrew.best@tri.global">Andrew Best</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>ament_cmake_doxygen</build_depend>
+  <doc_depend>ament_cmake_doxygen</doc_depend>
 
   <depend>fmt</depend>
   <depend>maliput</depend>


### PR DESCRIPTION
Part of https://github.com/maliput/maliput_infrastructure/issues/273
Related to https://github.com/maliput/maliput_infrastructure/issues/269

Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>