### PR TITLE
Uses compile definitions to avoid having to source install when running the tests.

### DIFF
--- a/src/maliput_malidrive/test_utilities/road_geometry_configuration_for_xodrs.cc
+++ b/src/maliput_malidrive/test_utilities/road_geometry_configuration_for_xodrs.cc
@@ -52,7 +52,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SingleLane.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineSingleLane"},
-           {"odr/SingleLane.xodr"},
+           {"SingleLane.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -64,7 +64,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"ArcLane.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"ArcSingleLane"},
-           {"odr/ArcLane.xodr"},
+           {"ArcLane.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -76,7 +76,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"BikingLineLane.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"BikingLineLane"},
-           {"odr/BikingLineLane.xodr"},
+           {"BikingLineLane.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -88,7 +88,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"DisconnectedRoadInJunction.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"DisconnectedRoadInJunction"},
-           {"odr/DisconnectedRoadInJunction.xodr"},
+           {"DisconnectedRoadInJunction.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -100,7 +100,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SShapeRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SShapeRoad"},
-           {"odr/SShapeRoad.xodr"},
+           {"SShapeRoad.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -112,7 +112,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"LShapeRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LShapeRoad"},
-           {"odr/LShapeRoad.xodr"},
+           {"LShapeRoad.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -124,7 +124,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"LShapeRoadVariableLanes.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LShapeRoadVariableLanes"},
-           {"odr/LShapeRoadVariableLanes.xodr"},
+           {"LShapeRoadVariableLanes.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -136,7 +136,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"LineMultipleSections.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineMultipleSections"},
-           {"odr/LineMultipleSections.xodr"},
+           {"LineMultipleSections.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -148,7 +148,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"LineMultipleSectionsMoreCases.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineMultipleSectionsMoreCases"},
-           {"odr/LineMultipleSectionsMoreCases.xodr"},
+           {"LineMultipleSectionsMoreCases.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -160,7 +160,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"LineMultipleSpeeds.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineMultipleSpeeds"},
-           {"odr/LineMultipleSpeeds.xodr"},
+           {"LineMultipleSpeeds.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -172,7 +172,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"LineVariableOffset.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineVariableOffset"},
-           {"odr/LineVariableOffset.xodr"},
+           {"LineVariableOffset.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -184,7 +184,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"LineVariableWidth.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineVariableWidth"},
-           {"odr/LineVariableWidth.xodr"},
+           {"LineVariableWidth.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -196,7 +196,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"ParkingGarageRamp.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"ParkingGarageRamp"},
-           {"odr/ParkingGarageRamp.xodr"},
+           {"ParkingGarageRamp.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -208,7 +208,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"RRLongRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"RRLongRoad"},
-           {"odr/RRLongRoad.xodr"},
+           {"RRLongRoad.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -220,7 +220,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SShapeSuperelevatedRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SShapeSuperelevatedRoad"},
-           {"odr/SShapeSuperelevatedRoad.xodr"},
+           {"SShapeSuperelevatedRoad.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -232,7 +232,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"TShapeRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"TShapeRoad"},
-           {"odr/TShapeRoad.xodr"},
+           {"TShapeRoad.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -244,7 +244,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"Highway.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"Highway"},
-           {"odr/Highway.xodr"},
+           {"Highway.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -256,7 +256,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"Figure8.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"Figure8"},
-           {"odr/Figure8.xodr"},
+           {"Figure8.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                1e-3 /* linear_tolerance */, 1e-2 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -267,7 +267,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kOmitNondrivableLanes}},
       {"RRFigure8.xodr",
        builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"RRFigure8"},
-                                          {"odr/RRFigure8.xodr"},
+                                          {"RRFigure8.xodr"},
                                           builder::RoadGeometryConfiguration::BuildTolerance{
                                               5e-1 /* linear_tolerance */, 1e-3 /* angular_tolerance */},
                                           constants::kScaleLength,
@@ -279,7 +279,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"StraightForward.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"StraightForward"},
-           {"odr/StraightForward.xodr"},
+           {"StraightForward.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                1e-3 /* linear_tolerance */, 1e-2 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -291,7 +291,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SingleRoadComplexDescription.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadComplexDescription"},
-           {"odr/SingleRoadComplexDescription.xodr"},
+           {"SingleRoadComplexDescription.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -303,7 +303,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SingleRoadComplexDescription2.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadComplexDescription2"},
-           {"odr/SingleRoadComplexDescription2.xodr"},
+           {"SingleRoadComplexDescription2.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -315,7 +315,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SingleRoadNanValues.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadNanValues"},
-           {"odr/SingleRoadNanValues.xodr"},
+           {"SingleRoadNanValues.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -327,7 +327,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SingleRoadNegativeWidth.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadNegativeWidth"},
-           {"odr/SingleRoadNegativeWidth.xodr"},
+           {"SingleRoadNegativeWidth.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -339,7 +339,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SingleRoadHighCoefficients.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadHighCoefficients"},
-           {"odr/SingleRoadHighCoefficients.xodr"},
+           {"SingleRoadHighCoefficients.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -351,7 +351,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SingleRoadTinyGeometry.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadTinyGeometry"},
-           {"odr/SingleRoadTinyGeometry.xodr"},
+           {"SingleRoadTinyGeometry.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -363,7 +363,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"SingleRoadTwoGeometries.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadTwoGeometries"},
-           {"odr/SingleRoadTwoGeometries.xodr"},
+           {"SingleRoadTwoGeometries.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -375,7 +375,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       {"FlatTown01.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"FlatTown01"},
-           {"odr/FlatTown01.xodr"},
+           {"FlatTown01.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -385,7 +385,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes}},
       {"Town01.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town01"},
-                                                         {"odr/Town01.xodr"},
+                                                         {"Town01.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
                                                              5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/,
                                                              1e-3 /* angular_tolerance */},
@@ -396,7 +396,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes}},
       {"Town02.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town02"},
-                                                         {"odr/Town02.xodr"},
+                                                         {"Town02.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
                                                              5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/,
                                                              1e-3 /* angular_tolerance */},
@@ -407,7 +407,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes}},
       {"Town03.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town03"},
-                                                         {"odr/Town03.xodr"},
+                                                         {"Town03.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
                                                              5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/,
                                                              1e-3 /* angular_tolerance */},
@@ -421,7 +421,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
        /* linear tolerance restricted by 0.052m elevation gap in Road 735 */
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"Town04"},
-           {"odr/Town04.xodr"},
+           {"Town04.xodr"},
            builder::RoadGeometryConfiguration::BuildTolerance{
                6e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
            constants::kScaleLength,
@@ -431,7 +431,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes}},
       {"Town05.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town05"},
-                                                         {"odr/Town05.xodr"},
+                                                         {"Town05.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
                                                              5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/,
                                                              1e-3 /* angular_tolerance */},
@@ -442,7 +442,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes}},
       {"Town06.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town06"},
-                                                         {"odr/Town06.xodr"},
+                                                         {"Town06.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
                                                              5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/,
                                                              1e-3 /* angular_tolerance */},
@@ -453,7 +453,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes}},
       {"Town07.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town07"},
-                                                         {"odr/Town07.xodr"},
+                                                         {"Town07.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
                                                              5e-2 /* linear_tolerance */, 5e-1 /*max_linear_tolerance*/,
                                                              1e-3 /* angular_tolerance */},
@@ -465,7 +465,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kOmitNondrivableLanes}},
       {"GapInElevationNonDrivableRoad.xodr",
        builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"GapInElevationNonDrivableRoad"},
-                                          {"odr/GapInElevationNonDrivableRoad.xodr"},
+                                          {"GapInElevationNonDrivableRoad.xodr"},
                                           builder::RoadGeometryConfiguration::BuildTolerance{
                                               5e-2 /* linear_tolerance */, 1e-3 /* angular_tolerance */},
                                           constants::kScaleLength,
@@ -476,7 +476,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                           kOmitNondrivableLanes}},
       {"GapInSuperelevationNonDrivableRoad.xodr",
        builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"GapInSuperelevationNonDrivableRoad"},
-                                          {"odr/GapInSuperelevationNonDrivableRoad.xodr"},
+                                          {"GapInSuperelevationNonDrivableRoad.xodr"},
                                           builder::RoadGeometryConfiguration::BuildTolerance{
                                               5e-2 /* linear_tolerance */, 1e-3 /* angular_tolerance */},
                                           constants::kScaleLength,
@@ -487,7 +487,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                           kOmitNondrivableLanes}},
       {"GapInLaneWidthNonDrivableLane.xodr",
        builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"GapInLaneWidthNonDrivableLane"},
-                                          {"odr/GapInLaneWidthNonDrivableLane.xodr"},
+                                          {"GapInLaneWidthNonDrivableLane.xodr"},
                                           builder::RoadGeometryConfiguration::BuildTolerance{
                                               5e-2 /* linear_tolerance */, 1e-3 /* angular_tolerance */},
                                           constants::kScaleLength,

--- a/src/utility/resources.cc
+++ b/src/utility/resources.cc
@@ -65,10 +65,17 @@ std::string AppendPath(const std::string& base_path, const std::string& relative
 }  // namespace
 
 std::string FindResourceInPath(const std::string& resource_name, const std::string& path_to_resources) {
+  const std::string file_path = AppendPath(path_to_resources, resource_name);
+  if (std::ifstream(file_path)) {
+    return file_path;
+  }
+  throw std::runtime_error(std::string("Resource: ") + resource_name + std::string(" couldn't be found."));
+}
+
+std::string FindResourceInEnvPath(const std::string& resource_name, const std::string& path_to_resources) {
   const std::vector<std::string> env_paths = GetAllPathDirectories(path_to_resources);
-  const std::string resources_folder{"resources"};
   for (const std::string& env_path : env_paths) {
-    const std::string file_path = AppendPath(env_path, AppendPath(resources_folder, resource_name));
+    const std::string file_path = AppendPath(env_path, resource_name);
     if (std::ifstream(file_path)) {
       return file_path;
     }
@@ -77,7 +84,8 @@ std::string FindResourceInPath(const std::string& resource_name, const std::stri
 }
 
 std::string FindResource(const std::string& resource_name) {
-  return FindResourceInPath(resource_name, kMalidriveEnvVariable);
+  const std::string resources_folder{"resources"};
+  return FindResourceInEnvPath(AppendPath(resources_folder, resource_name), kMalidriveEnvVariable);
 }
 
 }  // namespace utility

--- a/src/utility/resources.h
+++ b/src/utility/resources.h
@@ -48,14 +48,23 @@ std::string FindResource(const std::string& resource_name);
 
 // Finds a resource file by its `resource_name` name.
 //
-// The first valid file within path_directory/`resource_name` is returned.
-// Where path_directory is indicated by the path that the env variable `path_to_resources` holds.
-// Path delimeter is assumed to be `/`.
+// The first valid `resource_name` file within the paths pointed by the environment variable `path_to_resources` is
+// returned. Path delimeter is assumed to be `/`.
+//
 // @param resource_name The name of the file.
-// @param path_to_resources Env variable holding a directory path.
+// @param path_to_resources Env variable holding one or many directory path.
 // @return The complete file path to the resource.
-// @throws std::runtime_error When the resource cannot be found under any
-// of the possible combinations of 'path_directory/resource_name'.
+// @throws std::runtime_error When the resource cannot be found for any path.
+std::string FindResourceInEnvPath(const std::string& resource_name, const std::string& path_to_resources);
+
+// Finds a resource file by its `resource_name` name.
+//
+// The first valid `resource_name` file within `path_to_resources`.
+//
+// @param resource_name The name of the file.
+// @param path_to_resources Env variable holding one or many directory path.
+// @return The complete file path to the resource.
+// @throws std::runtime_error When the resource cannot be found for any path.
 std::string FindResourceInPath(const std::string& resource_name, const std::string& path_to_resources);
 
 }  // namespace utility

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,8 @@ macro(maliput_malidrive_plugin_tests)
   foreach(GTEST_SOURCE_file ${ARGN})
     string(REGEX REPLACE ".cc" "" BINARY_NAME ${GTEST_SOURCE_file})
     set(BINARY_NAME ${TEST_TYPE}_${BINARY_NAME})
+    set(RESOURCE_FILE_PREFIX ${PROJECT_SOURCE_DIR}/resources/)
+    set(ROAD_NETWORK_PLUGIN ${CMAKE_INSTALL_PREFIX}/lib/plugins/)
 
     ament_add_gtest(${BINARY_NAME} ${GTEST_SOURCE_file} APPEND_LIBRARY_DIRS ${MALIPUT_MALIDRIVE_PLUGIN_LIBRARY_DIRS}
       TIMEOUT 240)
@@ -46,6 +48,12 @@ macro(maliput_malidrive_plugin_tests)
     # Remove a warning in GTest.
     target_compile_options(${BINARY_NAME} PRIVATE "-Wno-sign-compare")
 
+    target_compile_definitions(${BINARY_NAME}
+      PRIVATE
+        DEF_MALIDRIVE_RESOURCES="${RESOURCE_FILE_PREFIX}"
+        DEF_ROAD_NETWORK_PLUGIN="${ROAD_NETWORK_PLUGIN}"
+    )
+
   endforeach()
 endmacro()
 
@@ -54,14 +62,7 @@ macro(maliput_malidrive_build_tests)
   foreach(GTEST_SOURCE_file ${ARGN})
     string(REGEX REPLACE ".cc" "" BINARY_NAME ${GTEST_SOURCE_file})
     set(BINARY_NAME ${TEST_TYPE}_${BINARY_NAME})
-
-    # When integration tests are disabled, we just skip adding them.
-    if(NOT MALIDRIVE_INTEGRATION_TESTS)
-      if(${TEST_TYPE} MATCHES "INTEGRATION")
-        message(STATUS "Integration tests are disarmed, skipping: " ${BINARY_NAME})
-        continue()
-      endif()
-    endif()
+    set(RESOURCE_FILE_PREFIX ${PROJECT_SOURCE_DIR}/resources/)
 
     ament_add_gtest(${BINARY_NAME} ${GTEST_SOURCE_file} TIMEOUT 240)
 
@@ -93,6 +94,11 @@ macro(maliput_malidrive_build_tests)
 
     # Remove a warning in GTest.
     target_compile_options(${BINARY_NAME} PRIVATE "-Wno-sign-compare")
+
+    target_compile_definitions(${BINARY_NAME}
+      PRIVATE
+        DEF_MALIDRIVE_RESOURCES="${RESOURCE_FILE_PREFIX}"
+    )
 
   endforeach()
 endmacro()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,6 +103,45 @@ macro(maliput_malidrive_build_tests)
   endforeach()
 endmacro()
 
+macro(maliput_malidrive_utility_tests)
+  # Build all the tests
+  foreach(GTEST_SOURCE_file ${ARGN})
+    string(REGEX REPLACE ".cc" "" BINARY_NAME ${GTEST_SOURCE_file})
+    set(BINARY_NAME ${TEST_TYPE}_${BINARY_NAME})
+
+    ament_add_gtest(${BINARY_NAME} ${GTEST_SOURCE_file} APPEND_LIBRARY_DIRS ${MALIPUT_MALIDRIVE_PLUGIN_LIBRARY_DIRS}
+      TIMEOUT 240)
+
+    target_include_directories(${BINARY_NAME}
+      PRIVATE
+        ${PROJECT_SOURCE_DIR}/src
+        ${PROJECT_SOURCE_DIR}/include
+        ${PYTHON_INCLUDE_DIRS}
+    )
+
+    # Kind of an ugly catch-all bucket
+    target_link_libraries(${BINARY_NAME}
+        utility
+    )
+
+    # To avoid a false positive when running ubsan the symbols must be exported
+    # See https://stackoverflow.com/questions/57361776/use-ubsan-with-dynamically-loaded-shared-libraries
+    set_target_properties(${BINARY_NAME}
+      PROPERTIES
+        ENABLE_EXPORTS ON
+    )
+
+    # Remove a warning in GTest.
+    target_compile_options(${BINARY_NAME} PRIVATE "-Wno-sign-compare")
+
+    target_compile_definitions(${BINARY_NAME}
+      PRIVATE
+        DEF_PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+    )
+
+  endforeach()
+endmacro()
+
 # This macro generates a test target per each map on the list.
 # Map file will be set using a CLI argument and it's the test responsibility
 # to parse it.

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(common)
 add_subdirectory(loader)
 add_subdirectory(plugin)
 add_subdirectory(road_curve)
+add_subdirectory(utility)
 add_subdirectory(xodr)
 
 ##############################################################################

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -78,7 +78,7 @@ class RoadGeometryTest : public ::testing::Test {
       kAssertContiguity);
   std::unique_ptr<road_curve::Function> reference_line_offset = MakeZeroCubicPolynomial(kP0, kP1, kLinearTolerance);
   std::unique_ptr<xodr::DBManager> manager =
-      xodr::LoadDataBaseFromFile(utility::FindResource("odr/SingleLane.xodr"), kParserConfiguration);
+      xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + "/SingleLane.xodr", kParserConfiguration);
 };
 
 // Tests getters and the constructor of an empty RoadGeometry.
@@ -145,7 +145,7 @@ class RoadGeometryFigure8Trafficlights : public ::testing::Test {
   void SetUp() override {
     road_geometry_configuration_.id = maliput::api::RoadGeometryId("figure8_trafficlights");
     road_geometry_configuration_.opendrive_file =
-        utility::FindResource("odr/figure8_trafficlights/figure8_trafficlights.xodr");
+        std::string(DEF_MALIDRIVE_RESOURCES) + "/figure8_trafficlights/figure8_trafficlights.xodr";
     road_network_ =
         ::malidrive::loader::Load<::malidrive::builder::RoadNetworkBuilder>(road_geometry_configuration_.ToStringMap());
   }

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -53,6 +53,9 @@ namespace malidrive {
 namespace tests {
 namespace {
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 std::unique_ptr<road_curve::Function> MakeZeroCubicPolynomial(double p0, double p1, double linear_tolerance) {
   return std::make_unique<road_curve::CubicPolynomial>(0., 0., 0., 0., p0, p1, linear_tolerance);
 }
@@ -77,8 +80,8 @@ class RoadGeometryTest : public ::testing::Test {
       MakeZeroCubicPolynomial(kP0, kP1, kLinearTolerance), MakeZeroCubicPolynomial(kP0, kP1, kLinearTolerance),
       kAssertContiguity);
   std::unique_ptr<road_curve::Function> reference_line_offset = MakeZeroCubicPolynomial(kP0, kP1, kLinearTolerance);
-  std::unique_ptr<xodr::DBManager> manager =
-      xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + "/SingleLane.xodr", kParserConfiguration);
+  std::unique_ptr<xodr::DBManager> manager = xodr::LoadDataBaseFromFile(
+      utility::FindResourceInPath("SingleLane.xodr", kMalidriveResourceFolder), kParserConfiguration);
 };
 
 // Tests getters and the constructor of an empty RoadGeometry.
@@ -145,7 +148,7 @@ class RoadGeometryFigure8Trafficlights : public ::testing::Test {
   void SetUp() override {
     road_geometry_configuration_.id = maliput::api::RoadGeometryId("figure8_trafficlights");
     road_geometry_configuration_.opendrive_file =
-        std::string(DEF_MALIDRIVE_RESOURCES) + "/figure8_trafficlights/figure8_trafficlights.xodr";
+        utility::FindResourceInPath("figure8_trafficlights/figure8_trafficlights.xodr", kMalidriveResourceFolder);
     road_network_ =
         ::malidrive::loader::Load<::malidrive::builder::RoadNetworkBuilder>(road_geometry_configuration_.ToStringMap());
   }

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -45,6 +45,9 @@ namespace builder {
 namespace test {
 namespace {
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 // TODO(maliput#341): Remove this operator once it is implemented in maliput.
 bool operator==(const maliput::api::LaneEnd& end_a, const maliput::api::LaneEnd& end_b) {
   return end_a.end == end_b.end && end_a.lane == end_b.lane;
@@ -246,7 +249,8 @@ class LanePropertiesTest : public ::testing::Test {
 
  protected:
   void SetUp() override {
-    manager_ = xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + "BikingLineLane.xodr", {std::nullopt});
+    manager_ = xodr::LoadDataBaseFromFile(utility::FindResourceInPath("BikingLineLane.xodr", kMalidriveResourceFolder),
+                                          {std::nullopt});
     road_header_ = &manager_->GetRoadHeaders().at(xodr::RoadHeader::Id(kRoadId));
   }
   std::unique_ptr<xodr::DBManager> manager_;

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -246,7 +246,7 @@ class LanePropertiesTest : public ::testing::Test {
 
  protected:
   void SetUp() override {
-    manager_ = xodr::LoadDataBaseFromFile(utility::FindResource("odr/BikingLineLane.xodr"), {std::nullopt});
+    manager_ = xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + "BikingLineLane.xodr", {std::nullopt});
     road_header_ = &manager_->GetRoadHeaders().at(xodr::RoadHeader::Id(kRoadId));
   }
   std::unique_ptr<xodr::DBManager> manager_;

--- a/test/regression/builder/phase_provider_builder_test.cc
+++ b/test/regression/builder/phase_provider_builder_test.cc
@@ -58,6 +58,9 @@ using maliput::api::rules::Phase;
 using maliput::api::rules::PhaseProvider;
 using maliput::api::rules::PhaseRing;
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 // Creates the stack of entities that are necessary to populate the ManualPhaseProvider through the PhaseProviderBuilder
 // functor.
 class PhaseProviderBuilderTest : public ::testing::Test {
@@ -75,11 +78,15 @@ class PhaseProviderBuilderTest : public ::testing::Test {
 
  protected:
   const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
-  const std::string rule_registry_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
-  const std::string road_rulebook_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
-  const std::string traffic_light_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
-  const std::string phase_ring_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string xodr_file_path{utility::FindResourceInPath(map_id + ".xodr", kMalidriveResourceFolder)};
+  const std::string rule_registry_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
+  const std::string road_rulebook_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
+  const std::string traffic_light_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
+  const std::string phase_ring_book_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
   const RoadGeometryConfiguration road_geometry_configuration_{RoadGeometryConfiguration::FromMap({
       {"opendrive_file", xodr_file_path},
       {"omit_nondrivable_lanes", "false"},

--- a/test/regression/builder/phase_provider_builder_test.cc
+++ b/test/regression/builder/phase_provider_builder_test.cc
@@ -74,12 +74,12 @@ class PhaseProviderBuilderTest : public ::testing::Test {
   }
 
  protected:
-  const std::string map_id{"odr/figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{utility::FindResource(map_id + ".xodr")};
-  const std::string rule_registry_path{utility::FindResource(map_id + "_new_rules.yaml")};
-  const std::string road_rulebook_path{utility::FindResource(map_id + "_new_rules.yaml")};
-  const std::string traffic_light_path{utility::FindResource(map_id + "_new_rules.yaml")};
-  const std::string phase_ring_book_path{utility::FindResource(map_id + "_new_rules.yaml")};
+  const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
+  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
+  const std::string rule_registry_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string road_rulebook_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string traffic_light_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string phase_ring_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
   const RoadGeometryConfiguration road_geometry_configuration_{RoadGeometryConfiguration::FromMap({
       {"opendrive_file", xodr_file_path},
       {"omit_nondrivable_lanes", "false"},

--- a/test/regression/builder/road_geometry_builder_test.cc
+++ b/test/regression/builder/road_geometry_builder_test.cc
@@ -57,6 +57,9 @@ using maliput::api::test::IsRBoundsClose;
 
 using malidrive::test::GetRoadGeometryConfigurationFor;
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 /*
   Loaded map has the following structure:
 
@@ -78,7 +81,8 @@ class BuilderTestSingleLane : public ::testing::Test {
     road_geometry_configuration_.tolerances.max_linear_tolerance = std::nullopt;
     road_geometry_configuration_.tolerances.angular_tolerance = kAngularTolerance;
     manager_ = xodr::LoadDataBaseFromFile(
-        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file, {kLinearTolerance});
+        utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder),
+        {kLinearTolerance});
   }
 
   RoadGeometryConfiguration road_geometry_configuration_{GetRoadGeometryConfigurationFor("SingleLane.xodr").value()};
@@ -373,7 +377,8 @@ class RoadGeometryBuilderBaseTest : public ::testing::TestWithParam<RoadGeometry
     road_geometry_configuration_.tolerances.max_linear_tolerance = std::nullopt;
     road_geometry_configuration_.tolerances.angular_tolerance = kAngularTolerance;
     manager_ = xodr::LoadDataBaseFromFile(
-        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file, {kLinearTolerance});
+        utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder),
+        {kLinearTolerance});
   }
 
   // Tests Junction, Segments and Lanes properties.
@@ -884,7 +889,8 @@ class BuilderBranchPointTest : public ::testing::TestWithParam<BuilderBranchPoin
     road_geometry_configuration_.tolerances.max_linear_tolerance = std::nullopt;
     road_geometry_configuration_.tolerances.angular_tolerance = kAngularTolerance;
     auto manager = xodr::LoadDataBaseFromFile(
-        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file, {kLinearTolerance});
+        utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder),
+        {kLinearTolerance});
     rg_ = builder::RoadGeometryBuilder(std::move(manager), road_geometry_configuration_)();
     expected_connections = GetParam().expected_connections;
   }
@@ -996,8 +1002,9 @@ class RoadGeometryBuilderSurfaceBoundariesTest : public ::testing::TestWithParam
     road_geometry_configuration_.tolerances.max_linear_tolerance = std::nullopt;
     road_geometry_configuration_.tolerances.angular_tolerance = kAngularTolerance;
     dut_ = builder::RoadGeometryBuilder(
-        xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file,
-                                   {kLinearTolerance}),
+        xodr::LoadDataBaseFromFile(
+            utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder),
+            {kLinearTolerance}),
         road_geometry_configuration_)();
   }
 
@@ -1108,8 +1115,9 @@ class RoadGeometryOmittingNonDrivableLanesTest
 
     // Load RoadGeometry.
     dut_ = builder::RoadGeometryBuilder(
-        xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file,
-                                   {road_geometry_configuration_.tolerances.linear_tolerance.value()}),
+        xodr::LoadDataBaseFromFile(
+            utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder),
+            {road_geometry_configuration_.tolerances.linear_tolerance.value()}),
         road_geometry_configuration_)();
 
     // Fill useful pointers;
@@ -1179,11 +1187,12 @@ TEST_F(RoadGeometryNegativeLaneWidthTest, Strict) {
   // Disables the tolerance range.
   rg_config.tolerances.max_linear_tolerance = std::nullopt;
 
-  EXPECT_THROW(builder::RoadGeometryBuilder(
-                   xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + rg_config.opendrive_file,
-                                              {rg_config.tolerances.linear_tolerance.value()}),
-                   rg_config)(),
-               maliput::common::assertion_error);
+  EXPECT_THROW(
+      builder::RoadGeometryBuilder(
+          xodr::LoadDataBaseFromFile(utility::FindResourceInPath(rg_config.opendrive_file, kMalidriveResourceFolder),
+                                     {rg_config.tolerances.linear_tolerance.value()}),
+          rg_config)(),
+      maliput::common::assertion_error);
 }
 
 // Allow having negative width descriptions.
@@ -1192,10 +1201,11 @@ TEST_F(RoadGeometryNegativeLaneWidthTest, AllowNegativeWidthDescriptions) {
   rg_config.standard_strictness_policy =
       builder::RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors;
 
-  ASSERT_NO_THROW(dut_ = builder::RoadGeometryBuilder(
-                      xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + rg_config.opendrive_file,
-                                                 {rg_config.tolerances.linear_tolerance.value()}),
-                      rg_config)());
+  ASSERT_NO_THROW(
+      dut_ = builder::RoadGeometryBuilder(
+          xodr::LoadDataBaseFromFile(utility::FindResourceInPath(rg_config.opendrive_file, kMalidriveResourceFolder),
+                                     {rg_config.tolerances.linear_tolerance.value()}),
+          rg_config)());
   ASSERT_NE(dut_, nullptr);
 
   // Let's make a `lane_bounds` query to a lane whose lane-width function has negative values.
@@ -1225,18 +1235,19 @@ TEST_P(RoadGeometryNonContiguousInNonDrivableLanesTest, CheckG1ContiguityEnforce
   // Gap in non drivable road/lane + strict.
   rg_config.standard_strictness_policy = builder::RoadGeometryConfiguration::StandardStrictnessPolicy::kStrict;
 
-  EXPECT_THROW(builder::RoadGeometryBuilder(
-                   xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + rg_config.opendrive_file,
-                                              {rg_config.tolerances.linear_tolerance.value()}),
-                   rg_config)(),
-               maliput::common::assertion_error);
+  EXPECT_THROW(
+      builder::RoadGeometryBuilder(
+          xodr::LoadDataBaseFromFile(utility::FindResourceInPath(rg_config.opendrive_file, kMalidriveResourceFolder),
+                                     {rg_config.tolerances.linear_tolerance.value()}),
+          rg_config)(),
+      maliput::common::assertion_error);
 
   // Gap in non drivable road/lane + allow semantic errors.
   rg_config.standard_strictness_policy =
       builder::RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors;
 
   EXPECT_NO_THROW(builder::RoadGeometryBuilder(
-      xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + rg_config.opendrive_file,
+      xodr::LoadDataBaseFromFile(utility::FindResourceInPath(rg_config.opendrive_file, kMalidriveResourceFolder),
                                  {rg_config.tolerances.linear_tolerance.value()}),
       rg_config)());
 }
@@ -1253,7 +1264,7 @@ INSTANTIATE_TEST_CASE_P(CheckG1ContiguityEnforcementGroup, RoadGeometryNonContig
 class ToleranceSelectionPolicyTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    rg_config.opendrive_file = std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile;
+    rg_config.opendrive_file = utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder);
     rg_config.omit_nondrivable_lanes = false;
     rg_config.standard_strictness_policy = RoadGeometryConfiguration::StandardStrictnessPolicy::kStrict;
     rg_config.tolerances.linear_tolerance = std::nullopt;

--- a/test/regression/builder/road_geometry_builder_test.cc
+++ b/test/regression/builder/road_geometry_builder_test.cc
@@ -77,8 +77,8 @@ class BuilderTestSingleLane : public ::testing::Test {
     road_geometry_configuration_.tolerances.linear_tolerance = kLinearTolerance;
     road_geometry_configuration_.tolerances.max_linear_tolerance = std::nullopt;
     road_geometry_configuration_.tolerances.angular_tolerance = kAngularTolerance;
-    manager_ = xodr::LoadDataBaseFromFile(utility::FindResource(road_geometry_configuration_.opendrive_file),
-                                          {kLinearTolerance});
+    manager_ = xodr::LoadDataBaseFromFile(
+        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file, {kLinearTolerance});
   }
 
   RoadGeometryConfiguration road_geometry_configuration_{GetRoadGeometryConfigurationFor("SingleLane.xodr").value()};
@@ -372,8 +372,8 @@ class RoadGeometryBuilderBaseTest : public ::testing::TestWithParam<RoadGeometry
     road_geometry_configuration_.tolerances.linear_tolerance = kLinearTolerance;
     road_geometry_configuration_.tolerances.max_linear_tolerance = std::nullopt;
     road_geometry_configuration_.tolerances.angular_tolerance = kAngularTolerance;
-    manager_ = xodr::LoadDataBaseFromFile(utility::FindResource(road_geometry_configuration_.opendrive_file),
-                                          {kLinearTolerance});
+    manager_ = xodr::LoadDataBaseFromFile(
+        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file, {kLinearTolerance});
   }
 
   // Tests Junction, Segments and Lanes properties.
@@ -883,8 +883,8 @@ class BuilderBranchPointTest : public ::testing::TestWithParam<BuilderBranchPoin
     road_geometry_configuration_.tolerances.linear_tolerance = kLinearTolerance;
     road_geometry_configuration_.tolerances.max_linear_tolerance = std::nullopt;
     road_geometry_configuration_.tolerances.angular_tolerance = kAngularTolerance;
-    auto manager = xodr::LoadDataBaseFromFile(utility::FindResource(road_geometry_configuration_.opendrive_file),
-                                              {kLinearTolerance});
+    auto manager = xodr::LoadDataBaseFromFile(
+        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file, {kLinearTolerance});
     rg_ = builder::RoadGeometryBuilder(std::move(manager), road_geometry_configuration_)();
     expected_connections = GetParam().expected_connections;
   }
@@ -996,7 +996,7 @@ class RoadGeometryBuilderSurfaceBoundariesTest : public ::testing::TestWithParam
     road_geometry_configuration_.tolerances.max_linear_tolerance = std::nullopt;
     road_geometry_configuration_.tolerances.angular_tolerance = kAngularTolerance;
     dut_ = builder::RoadGeometryBuilder(
-        xodr::LoadDataBaseFromFile(utility::FindResource(road_geometry_configuration_.opendrive_file),
+        xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file,
                                    {kLinearTolerance}),
         road_geometry_configuration_)();
   }
@@ -1108,7 +1108,7 @@ class RoadGeometryOmittingNonDrivableLanesTest
 
     // Load RoadGeometry.
     dut_ = builder::RoadGeometryBuilder(
-        xodr::LoadDataBaseFromFile(utility::FindResource(road_geometry_configuration_.opendrive_file),
+        xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file,
                                    {road_geometry_configuration_.tolerances.linear_tolerance.value()}),
         road_geometry_configuration_)();
 
@@ -1179,9 +1179,10 @@ TEST_F(RoadGeometryNegativeLaneWidthTest, Strict) {
   // Disables the tolerance range.
   rg_config.tolerances.max_linear_tolerance = std::nullopt;
 
-  EXPECT_THROW(builder::RoadGeometryBuilder(xodr::LoadDataBaseFromFile(utility::FindResource(rg_config.opendrive_file),
-                                                                       {rg_config.tolerances.linear_tolerance.value()}),
-                                            rg_config)(),
+  EXPECT_THROW(builder::RoadGeometryBuilder(
+                   xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + rg_config.opendrive_file,
+                                              {rg_config.tolerances.linear_tolerance.value()}),
+                   rg_config)(),
                maliput::common::assertion_error);
 }
 
@@ -1191,10 +1192,10 @@ TEST_F(RoadGeometryNegativeLaneWidthTest, AllowNegativeWidthDescriptions) {
   rg_config.standard_strictness_policy =
       builder::RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors;
 
-  ASSERT_NO_THROW(
-      dut_ = builder::RoadGeometryBuilder(xodr::LoadDataBaseFromFile(utility::FindResource(rg_config.opendrive_file),
-                                                                     {rg_config.tolerances.linear_tolerance.value()}),
-                                          rg_config)());
+  ASSERT_NO_THROW(dut_ = builder::RoadGeometryBuilder(
+                      xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + rg_config.opendrive_file,
+                                                 {rg_config.tolerances.linear_tolerance.value()}),
+                      rg_config)());
   ASSERT_NE(dut_, nullptr);
 
   // Let's make a `lane_bounds` query to a lane whose lane-width function has negative values.
@@ -1224,19 +1225,20 @@ TEST_P(RoadGeometryNonContiguousInNonDrivableLanesTest, CheckG1ContiguityEnforce
   // Gap in non drivable road/lane + strict.
   rg_config.standard_strictness_policy = builder::RoadGeometryConfiguration::StandardStrictnessPolicy::kStrict;
 
-  EXPECT_THROW(builder::RoadGeometryBuilder(xodr::LoadDataBaseFromFile(utility::FindResource(rg_config.opendrive_file),
-                                                                       {rg_config.tolerances.linear_tolerance.value()}),
-                                            rg_config)(),
+  EXPECT_THROW(builder::RoadGeometryBuilder(
+                   xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + rg_config.opendrive_file,
+                                              {rg_config.tolerances.linear_tolerance.value()}),
+                   rg_config)(),
                maliput::common::assertion_error);
 
   // Gap in non drivable road/lane + allow semantic errors.
   rg_config.standard_strictness_policy =
       builder::RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors;
 
-  EXPECT_NO_THROW(
-      builder::RoadGeometryBuilder(xodr::LoadDataBaseFromFile(utility::FindResource(rg_config.opendrive_file),
-                                                              {rg_config.tolerances.linear_tolerance.value()}),
-                                   rg_config)());
+  EXPECT_NO_THROW(builder::RoadGeometryBuilder(
+      xodr::LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + rg_config.opendrive_file,
+                                 {rg_config.tolerances.linear_tolerance.value()}),
+      rg_config)());
 }
 
 INSTANTIATE_TEST_CASE_P(CheckG1ContiguityEnforcementGroup, RoadGeometryNonContiguousInNonDrivableLanesTest,
@@ -1251,14 +1253,14 @@ INSTANTIATE_TEST_CASE_P(CheckG1ContiguityEnforcementGroup, RoadGeometryNonContig
 class ToleranceSelectionPolicyTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    rg_config.opendrive_file = utility::FindResource(kXodrFile);
+    rg_config.opendrive_file = std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile;
     rg_config.omit_nondrivable_lanes = false;
     rg_config.standard_strictness_policy = RoadGeometryConfiguration::StandardStrictnessPolicy::kStrict;
     rg_config.tolerances.linear_tolerance = std::nullopt;
     rg_config.tolerances.max_linear_tolerance = std::nullopt;
   }
 
-  const std::string kXodrFile{"odr/GapInElevationNonDrivableRoad.xodr"};
+  const std::string kXodrFile{"GapInElevationNonDrivableRoad.xodr"};
   builder::RoadGeometryConfiguration rg_config{};
 };
 

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -209,7 +209,7 @@ std::vector<RoadNetworkBuilderTestParameters> InstantiateBuilderParameters() {
       */
       // TODO(#510): Test was commented out to avoid blocking development.
       //             See issue for more information.
-      // {"TShapeRoad", "odr/TShapeRoad.xodr"},
+      // {"TShapeRoad", "TShapeRoad.xodr"},
 
       /*
         LineMultipleSections map has the following structure:
@@ -222,7 +222,7 @@ std::vector<RoadNetworkBuilderTestParameters> InstantiateBuilderParameters() {
       */
       // TODO(#510): Test was commented out to avoid blocking development.
       //             See issue for more information.
-      // {"LineMultipleSections", "odr/LineMultipleSections.xodr"},
+      // {"LineMultipleSections", "LineMultipleSections.xodr"},
 
       /*
         ParkingGarageRamp describes a Road in the form of a parking garage ramp.
@@ -282,7 +282,8 @@ TEST_P(RoadNetworkBuilderTest, RoadGeometryBuilding) {
   const auto rg_config_opt = GetRoadGeometryConfigurationFor(GetParam().path_to_xodr_file);
   ASSERT_NE(rg_config_opt, std::nullopt);
   RoadGeometryConfiguration road_geometry_configuration{rg_config_opt.value()};
-  road_geometry_configuration.opendrive_file = utility::FindResource(road_geometry_configuration.opendrive_file);
+  road_geometry_configuration.opendrive_file =
+      std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration.opendrive_file;
   const std::unique_ptr<maliput::api::RoadNetwork> dut =
       builder::RoadNetworkBuilder(road_geometry_configuration.ToStringMap())();
   ASSERT_NE(dynamic_cast<const malidrive::RoadGeometry*>(dut->road_geometry()), nullptr);
@@ -307,9 +308,9 @@ class BuilderTest : public ::testing::Test {
 class RuleRegistryBuildTest : public BuilderTest {
  protected:
   void SetUp() override {
-    const std::string kTShapeRoadYAMLPath{utility::FindResource("odr/TShapeRoad.yaml")};
+    const std::string kTShapeRoadYAMLPath{std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.yaml"};
     RoadGeometryConfiguration road_geometry_configuration{GetRoadGeometryConfigurationFor("TShapeRoad.xodr").value()};
-    road_geometry_configuration.opendrive_file = utility::FindResource("odr/TShapeRoad.xodr");
+    road_geometry_configuration.opendrive_file = std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.xodr";
     RoadNetworkConfiguration road_network_configuration{road_geometry_configuration, std::nullopt,
                                                         kTShapeRoadYAMLPath,         kTShapeRoadYAMLPath,
                                                         kTShapeRoadYAMLPath,         std::nullopt};
@@ -397,9 +398,9 @@ TEST_F(RuleRegistryBuildTest, RangeValueRuleTypesLoadTest) {
 }
 
 TEST_F(BuilderTest, CustomRoadNetworkEntitiesLoadersTest) {
-  const std::string kTShapeRoadYAMLPath{utility::FindResource("odr/TShapeRoad.yaml")};
+  const std::string kTShapeRoadYAMLPath{std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.yaml"};
   RoadGeometryConfiguration road_geometry_configuration{GetRoadGeometryConfigurationFor("TShapeRoad.xodr").value()};
-  road_geometry_configuration.opendrive_file = utility::FindResource("odr/TShapeRoad.xodr");
+  road_geometry_configuration.opendrive_file = std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.xodr";
   const RoadNetworkConfiguration road_network_configuration{road_geometry_configuration, std::nullopt,
                                                             kTShapeRoadYAMLPath,         kTShapeRoadYAMLPath,
                                                             kTShapeRoadYAMLPath,         kTShapeRoadYAMLPath};
@@ -448,9 +449,9 @@ TEST_F(BuilderTest, CustomRoadNetworkEntitiesLoadersTest) {
 // properties are parsed and added to the RoadNetwork variables are correctly
 // parsed.
 TEST_F(BuilderTest, StubProperties) {
-  const std::string kTShapeRoadYAMLPath{utility::FindResource("odr/TShapeRoad.yaml")};
+  const std::string kTShapeRoadYAMLPath{std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.yaml"};
   RoadGeometryConfiguration road_geometry_configuration{GetRoadGeometryConfigurationFor("TShapeRoad.xodr").value()};
-  road_geometry_configuration.opendrive_file = utility::FindResource("odr/TShapeRoad.xodr");
+  road_geometry_configuration.opendrive_file = std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.xodr";
   const RoadNetworkConfiguration road_network_configuration{road_geometry_configuration, std::nullopt,
                                                             kTShapeRoadYAMLPath,         kTShapeRoadYAMLPath,
                                                             kTShapeRoadYAMLPath,         std::nullopt};
@@ -493,7 +494,8 @@ class DirectionUsageTest : public ::testing::TestWithParam<DirectionUsageTruthTa
   static constexpr double kLinearTolerance{constants::kLinearTolerance};
 
   void SetUp() override {
-    road_geometry_configuration_.opendrive_file = utility::FindResource(road_geometry_configuration_.opendrive_file);
+    road_geometry_configuration_.opendrive_file =
+        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
     reference_values_ = GetParam().reference_values;
   }
 
@@ -759,7 +761,8 @@ class VehicleRulesTest : public ::testing::TestWithParam<VehicleRulesTruthTable>
   static constexpr double kLinearTolerance{constants::kLinearTolerance};
 
   void SetUp() override {
-    road_geometry_configuration_.opendrive_file = utility::FindResource(road_geometry_configuration_.opendrive_file);
+    road_geometry_configuration_.opendrive_file =
+        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
     reference_values_ = GetParam().reference_values;
   }
 
@@ -824,7 +827,8 @@ struct VehicleRulesStateProviderTruthTable {
 class VehicleRulesStateProviderTest : public ::testing::TestWithParam<VehicleRulesStateProviderTruthTable> {
  protected:
   void SetUp() override {
-    road_geometry_configuration_.opendrive_file = utility::FindResource(road_geometry_configuration_.opendrive_file);
+    road_geometry_configuration_.opendrive_file =
+        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
     reference_values_ = GetParam().reference_values;
   }
 
@@ -912,7 +916,8 @@ class SpeedLimitRuleBuilderTest : public ::testing::TestWithParam<SpeedLimitRule
   static constexpr double kSpeedTolerance{constants::kSpeedTolerance};
 
   void SetUp() override {
-    road_geometry_configuration_.opendrive_file = utility::FindResource(road_geometry_configuration_.opendrive_file);
+    road_geometry_configuration_.opendrive_file =
+        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
     reference_values_ = GetParam().reference_values;
   }
 
@@ -1151,7 +1156,8 @@ struct RangeValueRuleStateProviderTruthTable {
 class RangeValueRuleStateProviderTest : public ::testing::TestWithParam<RangeValueRuleStateProviderTruthTable> {
  protected:
   void SetUp() override {
-    road_geometry_configuration_.opendrive_file = utility::FindResource(road_geometry_configuration_.opendrive_file);
+    road_geometry_configuration_.opendrive_file =
+        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
     reference_values_ = GetParam().reference_values;
   }
 
@@ -1223,13 +1229,13 @@ class RoadNetworkBuilderPopulationTest : public ::testing::Test {
  protected:
   void SetUp() override {}
 
-  const std::string map_id{"odr/figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{utility::FindResource(map_id + ".xodr")};
-  const std::string rule_registry_path{utility::FindResource(map_id + "_new_rules.yaml")};
-  const std::string road_rulebook_path{utility::FindResource(map_id + "_new_rules.yaml")};
-  const std::string traffic_light_book_path{utility::FindResource(map_id + "_new_rules.yaml")};
-  const std::string phase_ring_book_path{utility::FindResource(map_id + "_new_rules.yaml")};
-  const std::string intersection_book_path{utility::FindResource(map_id + "_new_rules.yaml")};
+  const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
+  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
+  const std::string rule_registry_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string road_rulebook_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string traffic_light_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string phase_ring_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string intersection_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
   const RoadNetworkConfiguration road_network_configuration_{RoadNetworkConfiguration::FromMap({
       {params::kOpendriveFile, xodr_file_path},
       {params::kRuleRegistry, rule_registry_path},
@@ -1287,12 +1293,12 @@ class RoadNetworkBuilderPopulationOldRuleTest : public ::testing::Test {
  protected:
   void SetUp() override {}
 
-  const std::string map_id{"odr/figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{utility::FindResource(map_id + ".xodr")};
-  const std::string road_rulebook_path{utility::FindResource(map_id + ".yaml")};
-  const std::string traffic_light_book_path{utility::FindResource(map_id + ".yaml")};
-  const std::string phase_ring_book_path{utility::FindResource(map_id + ".yaml")};
-  const std::string intersection_book_path{utility::FindResource(map_id + ".yaml")};
+  const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
+  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
+  const std::string road_rulebook_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".yaml"};
+  const std::string traffic_light_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".yaml"};
+  const std::string phase_ring_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".yaml"};
+  const std::string intersection_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".yaml"};
   const RoadNetworkConfiguration road_network_configuration_{RoadNetworkConfiguration::FromMap({
       {params::kOpendriveFile, xodr_file_path},
       {params::kRoadRuleBook, road_rulebook_path},

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -85,6 +85,9 @@ using maliput::api::rules::SpeedLimitRule;
 
 using malidrive::test::GetRoadGeometryConfigurationFor;
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 // Functor to compare two maliput::api::rules::RangeValueRule::Ranges with
 // a certain tolerance for `min` and `max`.
 //
@@ -283,7 +286,7 @@ TEST_P(RoadNetworkBuilderTest, RoadGeometryBuilding) {
   ASSERT_NE(rg_config_opt, std::nullopt);
   RoadGeometryConfiguration road_geometry_configuration{rg_config_opt.value()};
   road_geometry_configuration.opendrive_file =
-      std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration.opendrive_file;
+      utility::FindResourceInPath(road_geometry_configuration.opendrive_file, kMalidriveResourceFolder);
   const std::unique_ptr<maliput::api::RoadNetwork> dut =
       builder::RoadNetworkBuilder(road_geometry_configuration.ToStringMap())();
   ASSERT_NE(dynamic_cast<const malidrive::RoadGeometry*>(dut->road_geometry()), nullptr);
@@ -308,9 +311,10 @@ class BuilderTest : public ::testing::Test {
 class RuleRegistryBuildTest : public BuilderTest {
  protected:
   void SetUp() override {
-    const std::string kTShapeRoadYAMLPath{std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.yaml"};
+    const std::string kTShapeRoadYAMLPath{utility::FindResourceInPath("TShapeRoad.yaml", kMalidriveResourceFolder)};
     RoadGeometryConfiguration road_geometry_configuration{GetRoadGeometryConfigurationFor("TShapeRoad.xodr").value()};
-    road_geometry_configuration.opendrive_file = std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.xodr";
+    road_geometry_configuration.opendrive_file =
+        utility::FindResourceInPath(road_geometry_configuration.opendrive_file, kMalidriveResourceFolder);
     RoadNetworkConfiguration road_network_configuration{road_geometry_configuration, std::nullopt,
                                                         kTShapeRoadYAMLPath,         kTShapeRoadYAMLPath,
                                                         kTShapeRoadYAMLPath,         std::nullopt};
@@ -398,9 +402,9 @@ TEST_F(RuleRegistryBuildTest, RangeValueRuleTypesLoadTest) {
 }
 
 TEST_F(BuilderTest, CustomRoadNetworkEntitiesLoadersTest) {
-  const std::string kTShapeRoadYAMLPath{std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.yaml"};
+  const std::string kTShapeRoadYAMLPath{utility::FindResourceInPath("TShapeRoad.yaml", kMalidriveResourceFolder)};
   RoadGeometryConfiguration road_geometry_configuration{GetRoadGeometryConfigurationFor("TShapeRoad.xodr").value()};
-  road_geometry_configuration.opendrive_file = std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.xodr";
+  road_geometry_configuration.opendrive_file = utility::FindResourceInPath("TShapeRoad.xodr", kMalidriveResourceFolder);
   const RoadNetworkConfiguration road_network_configuration{road_geometry_configuration, std::nullopt,
                                                             kTShapeRoadYAMLPath,         kTShapeRoadYAMLPath,
                                                             kTShapeRoadYAMLPath,         kTShapeRoadYAMLPath};
@@ -449,9 +453,9 @@ TEST_F(BuilderTest, CustomRoadNetworkEntitiesLoadersTest) {
 // properties are parsed and added to the RoadNetwork variables are correctly
 // parsed.
 TEST_F(BuilderTest, StubProperties) {
-  const std::string kTShapeRoadYAMLPath{std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.yaml"};
+  const std::string kTShapeRoadYAMLPath{utility::FindResourceInPath("TShapeRoad.yaml", kMalidriveResourceFolder)};
   RoadGeometryConfiguration road_geometry_configuration{GetRoadGeometryConfigurationFor("TShapeRoad.xodr").value()};
-  road_geometry_configuration.opendrive_file = std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.xodr";
+  road_geometry_configuration.opendrive_file = utility::FindResourceInPath("TShapeRoad.xodr", kMalidriveResourceFolder);
   const RoadNetworkConfiguration road_network_configuration{road_geometry_configuration, std::nullopt,
                                                             kTShapeRoadYAMLPath,         kTShapeRoadYAMLPath,
                                                             kTShapeRoadYAMLPath,         std::nullopt};
@@ -495,7 +499,7 @@ class DirectionUsageTest : public ::testing::TestWithParam<DirectionUsageTruthTa
 
   void SetUp() override {
     road_geometry_configuration_.opendrive_file =
-        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
+        utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder);
     reference_values_ = GetParam().reference_values;
   }
 
@@ -762,7 +766,7 @@ class VehicleRulesTest : public ::testing::TestWithParam<VehicleRulesTruthTable>
 
   void SetUp() override {
     road_geometry_configuration_.opendrive_file =
-        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
+        utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder);
     reference_values_ = GetParam().reference_values;
   }
 
@@ -828,7 +832,7 @@ class VehicleRulesStateProviderTest : public ::testing::TestWithParam<VehicleRul
  protected:
   void SetUp() override {
     road_geometry_configuration_.opendrive_file =
-        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
+        utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder);
     reference_values_ = GetParam().reference_values;
   }
 
@@ -917,7 +921,7 @@ class SpeedLimitRuleBuilderTest : public ::testing::TestWithParam<SpeedLimitRule
 
   void SetUp() override {
     road_geometry_configuration_.opendrive_file =
-        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
+        utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder);
     reference_values_ = GetParam().reference_values;
   }
 
@@ -1157,7 +1161,7 @@ class RangeValueRuleStateProviderTest : public ::testing::TestWithParam<RangeVal
  protected:
   void SetUp() override {
     road_geometry_configuration_.opendrive_file =
-        std::string(DEF_MALIDRIVE_RESOURCES) + road_geometry_configuration_.opendrive_file;
+        utility::FindResourceInPath(road_geometry_configuration_.opendrive_file, kMalidriveResourceFolder);
     reference_values_ = GetParam().reference_values;
   }
 
@@ -1230,12 +1234,17 @@ class RoadNetworkBuilderPopulationTest : public ::testing::Test {
   void SetUp() override {}
 
   const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
-  const std::string rule_registry_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
-  const std::string road_rulebook_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
-  const std::string traffic_light_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
-  const std::string phase_ring_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
-  const std::string intersection_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string xodr_file_path{utility::FindResourceInPath(map_id + ".xodr", kMalidriveResourceFolder)};
+  const std::string rule_registry_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
+  const std::string road_rulebook_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
+  const std::string traffic_light_book_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
+  const std::string phase_ring_book_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
+  const std::string intersection_book_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
   const RoadNetworkConfiguration road_network_configuration_{RoadNetworkConfiguration::FromMap({
       {params::kOpendriveFile, xodr_file_path},
       {params::kRuleRegistry, rule_registry_path},
@@ -1294,11 +1303,11 @@ class RoadNetworkBuilderPopulationOldRuleTest : public ::testing::Test {
   void SetUp() override {}
 
   const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
-  const std::string road_rulebook_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".yaml"};
-  const std::string traffic_light_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".yaml"};
-  const std::string phase_ring_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".yaml"};
-  const std::string intersection_book_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".yaml"};
+  const std::string xodr_file_path{utility::FindResourceInPath(map_id + ".xodr", kMalidriveResourceFolder)};
+  const std::string road_rulebook_path{utility::FindResourceInPath(map_id + ".yaml", kMalidriveResourceFolder)};
+  const std::string traffic_light_book_path{utility::FindResourceInPath(map_id + ".yaml", kMalidriveResourceFolder)};
+  const std::string phase_ring_book_path{utility::FindResourceInPath(map_id + ".yaml", kMalidriveResourceFolder)};
+  const std::string intersection_book_path{utility::FindResourceInPath(map_id + ".yaml", kMalidriveResourceFolder)};
   const RoadNetworkConfiguration road_network_configuration_{RoadNetworkConfiguration::FromMap({
       {params::kOpendriveFile, xodr_file_path},
       {params::kRoadRuleBook, road_rulebook_path},

--- a/test/regression/builder/road_rulebook_builder_test.cc
+++ b/test/regression/builder/road_rulebook_builder_test.cc
@@ -136,10 +136,10 @@ class RoadRulebookBuilderTest : public ::testing::Test {
   }
 
  protected:
-  const std::string map_id{"odr/figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{utility::FindResource(map_id + ".xodr")};
-  const std::string rule_registry_path{utility::FindResource(map_id + "_new_rules.yaml")};
-  const std::string road_rulebook_path{utility::FindResource(map_id + "_new_rules.yaml")};
+  const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
+  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
+  const std::string rule_registry_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string road_rulebook_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
   const RoadGeometryConfiguration road_geometry_configuration_{RoadGeometryConfiguration::FromMap({
       {"opendrive_file", xodr_file_path},
       {"omit_nondrivable_lanes", "false"},

--- a/test/regression/builder/road_rulebook_builder_test.cc
+++ b/test/regression/builder/road_rulebook_builder_test.cc
@@ -61,6 +61,9 @@ using maliput::api::rules::DiscreteValueRule;
 using maliput::api::rules::RangeValueRule;
 using maliput::api::rules::Rule;
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 // Verifies if `rule_a` and `rule_b` are equal based on a `tolerance`. The `tolerance` value applyies when the region
 // of the rule is being evaluated.
 //  `T` param: DiscreteValueRules or RangeValueRules.
@@ -137,9 +140,11 @@ class RoadRulebookBuilderTest : public ::testing::Test {
 
  protected:
   const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
-  const std::string rule_registry_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
-  const std::string road_rulebook_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string xodr_file_path{utility::FindResourceInPath(map_id + ".xodr", kMalidriveResourceFolder)};
+  const std::string rule_registry_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
+  const std::string road_rulebook_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
   const RoadGeometryConfiguration road_geometry_configuration_{RoadGeometryConfiguration::FromMap({
       {"opendrive_file", xodr_file_path},
       {"omit_nondrivable_lanes", "false"},

--- a/test/regression/builder/rule_registry_builder_test.cc
+++ b/test/regression/builder/rule_registry_builder_test.cc
@@ -48,6 +48,9 @@ namespace builder {
 namespace test {
 namespace {
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 // Obtains all the keys from `map`.
 template <typename T, typename Y>
 std::vector<T> GetAllKeysFromMap(std::map<T, Y> map) {
@@ -246,8 +249,9 @@ class RuleRegistryBuilderTest : public ::testing::Test {
 
  protected:
   const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
-  const std::string rule_registry_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
+  const std::string xodr_file_path{utility::FindResourceInPath(map_id + ".xodr", kMalidriveResourceFolder)};
+  const std::string rule_registry_path{
+      utility::FindResourceInPath(map_id + "_new_rules.yaml", kMalidriveResourceFolder)};
   const RoadGeometryConfiguration road_geometry_configuration_{RoadGeometryConfiguration::FromMap({
       {"opendrive_file", xodr_file_path},
   })};

--- a/test/regression/builder/rule_registry_builder_test.cc
+++ b/test/regression/builder/rule_registry_builder_test.cc
@@ -245,9 +245,9 @@ class RuleRegistryBuilderTest : public ::testing::Test {
   }
 
  protected:
-  const std::string map_id{"odr/figure8_trafficlights/figure8_trafficlights"};
-  const std::string xodr_file_path{utility::FindResource(map_id + ".xodr")};
-  const std::string rule_registry_path{utility::FindResource(map_id + "_new_rules.yaml")};
+  const std::string map_id{"figure8_trafficlights/figure8_trafficlights"};
+  const std::string xodr_file_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + ".xodr"};
+  const std::string rule_registry_path{std::string(DEF_MALIDRIVE_RESOURCES) + map_id + "_new_rules.yaml"};
   const RoadGeometryConfiguration road_geometry_configuration_{RoadGeometryConfiguration::FromMap({
       {"opendrive_file", xodr_file_path},
   })};

--- a/test/regression/loader/loader_test.cc
+++ b/test/regression/loader/loader_test.cc
@@ -50,7 +50,7 @@ class LoaderTestSingleLane : public ::testing::Test {
  protected:
   const std::map<std::string, std::string> road_geometry_configuration_{
       {builder::params::kRoadGeometryId, "test_id"},
-      {builder::params::kOpendriveFile, utility::FindResource("odr/SingleLane.xodr")},
+      {builder::params::kOpendriveFile, std::string(DEF_MALIDRIVE_RESOURCES) + "SingleLane.xodr"},
       {builder::params::kLinearTolerance, "1e-3"},
       {builder::params::kAngularTolerance, "1e-3"},
       {builder::params::kScaleLength, "1"},

--- a/test/regression/loader/loader_test.cc
+++ b/test/regression/loader/loader_test.cc
@@ -46,11 +46,14 @@ namespace loader {
 namespace test {
 namespace {
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 class LoaderTestSingleLane : public ::testing::Test {
  protected:
   const std::map<std::string, std::string> road_geometry_configuration_{
       {builder::params::kRoadGeometryId, "test_id"},
-      {builder::params::kOpendriveFile, std::string(DEF_MALIDRIVE_RESOURCES) + "SingleLane.xodr"},
+      {builder::params::kOpendriveFile, utility::FindResourceInPath("SingleLane.xodr", kMalidriveResourceFolder)},
       {builder::params::kLinearTolerance, "1e-3"},
       {builder::params::kAngularTolerance, "1e-3"},
       {builder::params::kScaleLength, "1"},

--- a/test/regression/plugin/road_network_plugin_test.cc
+++ b/test/regression/plugin/road_network_plugin_test.cc
@@ -27,6 +27,7 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include <cstdlib>
 #include <map>
 #include <memory>
 #include <string>
@@ -45,7 +46,8 @@ namespace malidrive {
 namespace {
 
 GTEST_TEST(RoadNetworkLoader, VerifyRoadNetworkPlugin) {
-  const std::string kXodrFilePath{utility::FindResource("odr/TShapeRoad.xodr")};
+  setenv("MALIPUT_PLUGIN_PATH", DEF_ROAD_NETWORK_PLUGIN, 1);
+  const std::string kXodrFilePath{std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.xodr"};
 
   // RoadNetworkLoader plugin id.
   const maliput::plugin::MaliputPlugin::Id kMaliputMalidrivePluginId{"maliput_malidrive"};

--- a/test/regression/plugin/road_network_plugin_test.cc
+++ b/test/regression/plugin/road_network_plugin_test.cc
@@ -27,7 +27,6 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include <cstdlib>
 #include <map>
 #include <memory>
 #include <string>
@@ -45,9 +44,12 @@
 namespace malidrive {
 namespace {
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 GTEST_TEST(RoadNetworkLoader, VerifyRoadNetworkPlugin) {
   setenv("MALIPUT_PLUGIN_PATH", DEF_ROAD_NETWORK_PLUGIN, 1);
-  const std::string kXodrFilePath{std::string(DEF_MALIDRIVE_RESOURCES) + "TShapeRoad.xodr"};
+  const std::string kXodrFilePath{utility::FindResourceInPath("TShapeRoad.xodr", kMalidriveResourceFolder)};
 
   // RoadNetworkLoader plugin id.
   const maliput::plugin::MaliputPlugin::Id kMaliputMalidrivePluginId{"maliput_malidrive"};

--- a/test/regression/utility/CMakeLists.txt
+++ b/test/regression/utility/CMakeLists.txt
@@ -1,0 +1,16 @@
+##############################################################################
+# utility
+##############################################################################
+
+# Test binary name prefix, used by malidrive_build_tests
+set(TEST_TYPE UNIT)
+
+##############################################################################
+# Tests
+##############################################################################
+
+set(UNIT_UTILITY_TEST_SOURCES
+  resources_test.cc
+)
+
+maliput_malidrive_utility_tests(${UNIT_UTILITY_TEST_SOURCES})

--- a/test/regression/utility/resources_test.cc
+++ b/test/regression/utility/resources_test.cc
@@ -1,0 +1,94 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "utility/resources.h"
+
+#include <cstdlib>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace utility {
+namespace test {
+namespace {
+
+static constexpr char kMalidriveProjectSourcePath[] = DEF_PROJECT_SOURCE_DIR;
+
+class FindResourceTest : public ::testing::Test {
+ public:
+  static constexpr char kMalidriveResourceEnv[] = "MALIPUT_MALIDRIVE_RESOURCE_ROOT";
+
+  void SetUp() override { setenv(kMalidriveResourceEnv, kMalidriveProjectSourcePath, 1); }
+};
+
+TEST_F(FindResourceTest, NotFound) {
+  const std::string kWrongFile{"WrongFile"};
+  EXPECT_THROW(FindResource(kWrongFile), std::runtime_error);
+}
+
+TEST_F(FindResourceTest, Found) {
+  const std::string kTShapeRoadXodrFile{"TShapeRoad.xodr"};
+  EXPECT_NO_THROW(FindResource(kTShapeRoadXodrFile));
+}
+
+class FindResourceInEnvPathTest : public FindResourceTest {
+ public:
+  void SetUp() override {
+    setenv(kMalidriveResourceEnv, (std::string(kMalidriveProjectSourcePath) + "/resources").c_str(), 1);
+  }
+};
+
+TEST_F(FindResourceInEnvPathTest, NotFound) {
+  const std::string kWrongFile{"WrongFile"};
+  EXPECT_THROW(FindResourceInEnvPath(kWrongFile, FindResourceTest::kMalidriveResourceEnv), std::runtime_error);
+}
+
+TEST_F(FindResourceInEnvPathTest, Found) {
+  const std::string kTShapeRoadXodrFile{"TShapeRoad.xodr"};
+  EXPECT_NO_THROW(FindResourceInEnvPath(kTShapeRoadXodrFile, FindResourceTest::kMalidriveResourceEnv));
+}
+
+class FindResourceInPathTest : public ::testing::Test {
+ public:
+  const std::string kMalidriveResourceFolder = std::string(kMalidriveProjectSourcePath) + "/resources";
+};
+
+TEST_F(FindResourceInPathTest, NotFound) {
+  const std::string kWrongFile{"WrongFile"};
+  EXPECT_THROW(FindResourceInPath(kWrongFile, kMalidriveResourceFolder), std::runtime_error);
+}
+
+TEST_F(FindResourceInPathTest, Found) {
+  const std::string kTShapeRoadXodrFile{"TShapeRoad.xodr"};
+  EXPECT_NO_THROW(FindResourceInPath(kTShapeRoadXodrFile, kMalidriveResourceFolder));
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace utility

--- a/test/regression/xodr/db_manager_test.cc
+++ b/test/regression/xodr/db_manager_test.cc
@@ -83,8 +83,8 @@ constexpr bool kDontAllowSemanticErrors{false};
 
 // Tests the loading of a XODR description from a file.
 GTEST_TEST(DBManager, LoadFromFile) {
-  const std::string kXodrFile = "odr/SingleLane.xodr";
-  EXPECT_NO_THROW(LoadDataBaseFromFile(utility::FindResource(kXodrFile), {kStrictParserSTolerance}));
+  const std::string kXodrFile = "SingleLane.xodr";
+  EXPECT_NO_THROW(LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {kStrictParserSTolerance}));
 }
 
 // Tests the loading of a XODR description from a string.
@@ -1269,11 +1269,11 @@ GTEST_TEST(DBManagerTest, GetJunctions) {
                                     {kConnection5.id, kConnection5}} /* connections */};
 
   const std::unordered_map<Junction::Id, Junction> kExpectedJunctions{{kExpectedJunction.id, kExpectedJunction}};
-  const std::string kXodrFile = "odr/TShapeRoad.xodr";
+  const std::string kXodrFile = "TShapeRoad.xodr";
   // If I decrease even more the tolerance, the TShapeRoad.xodr's geometries aren't contiguous in terms of the arc
   // length parameter.
   // TODO(#482): Decrease tolerance once the xodr file is fixed.
-  const std::unique_ptr<DBManager> dut = LoadDataBaseFromFile(utility::FindResource(kXodrFile), {1e-6});
+  const std::unique_ptr<DBManager> dut = LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {1e-6});
 
   const std::unordered_map<Junction::Id, Junction> junctions = dut->GetJunctions();
 
@@ -1296,7 +1296,7 @@ std::string LaneUserDataTravelDirTemplate(const std::string& travel_dir) {
 // However, this test's goal is showing the correct functioning by loading a long XODR description and selecting a
 // random Road and Junction and checking that the values are well parsed.
 GTEST_TEST(DBManagerTest, Highway) {
-  const std::string kXodrFile = "odr/Highway.xodr";
+  const std::string kXodrFile = "Highway.xodr";
   const int NumOfRoads{37};
   const int NumOfJunctions{6};
   // Road 52 of Highway description:
@@ -1580,7 +1580,7 @@ GTEST_TEST(DBManagerTest, Highway) {
   // @}
 
   const std::unique_ptr<DBManager> dut =
-      LoadDataBaseFromFile(utility::FindResource(kXodrFile), {kStrictParserSTolerance});
+      LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {kStrictParserSTolerance});
 
   const std::map<RoadHeader::Id, RoadHeader> road_headers = dut->GetRoadHeaders();
   EXPECT_EQ(NumOfRoads, static_cast<int>(road_headers.size()));
@@ -1728,8 +1728,9 @@ GTEST_TEST(DBManagerTest, LoadMapWith2Connections) {
 
 // Loads TShapeRoad.xodr and verifies the shortest and largest Geometry in the XODR.
 GTEST_TEST(DBManager, GetGeometriesLengthInformation) {
-  const std::string kXodrFile = "odr/TShapeRoad.xodr";
-  const auto db_manager = LoadDataBaseFromFile(utility::FindResource(kXodrFile), {constants::kLinearTolerance});
+  const std::string kXodrFile = "TShapeRoad.xodr";
+  const auto db_manager =
+      LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {constants::kLinearTolerance});
   const DBManager::XodrGeometryLengthData kExpectedShortest{RoadHeader::Id("6"), 3, 6.8474312421988870e-2};
   const DBManager::XodrGeometryLengthData kExpectedLargest{RoadHeader::Id("0"), 0, 46.};
   const auto shortest_geometry{db_manager->GetShortestGeometry()};
@@ -1745,8 +1746,9 @@ GTEST_TEST(DBManager, GetGeometriesLengthInformation) {
 // Loads Highway.xodr and verifies the shortest and largest LaneSection in the XODR.
 GTEST_TEST(DBManager, GetLaneSectionLengthInformation) {
   const double kTolerance{1e-14};
-  const std::string kXodrFile = "odr/Highway.xodr";
-  const auto db_manager = LoadDataBaseFromFile(utility::FindResource(kXodrFile), {constants::kLinearTolerance});
+  const std::string kXodrFile = "Highway.xodr";
+  const auto db_manager =
+      LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {constants::kLinearTolerance});
   const DBManager::XodrLaneSectionLengthData kExpectedShortest{RoadHeader::Id("4"), 0, 1.1649945427797022};
   const DBManager::XodrLaneSectionLengthData kExpectedLargest{RoadHeader::Id("11"), 0, 2.9161454554383585e+2};
   const auto shortest_lane_section{db_manager->GetShortestLaneSection()};
@@ -1762,8 +1764,9 @@ GTEST_TEST(DBManager, GetLaneSectionLengthInformation) {
 // Loads TShapeRoad.xodr and verifies the shortest and largest GAP between Geometries in the XODR.
 GTEST_TEST(DBManager, GetGeometriesGapInformation) {
   const double kTolerance{1e-14};
-  const std::string kXodrFile = "odr/TShapeRoad.xodr";
-  const auto db_manager = LoadDataBaseFromFile(utility::FindResource(kXodrFile), {constants::kLinearTolerance});
+  const std::string kXodrFile = "TShapeRoad.xodr";
+  const auto db_manager =
+      LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {constants::kLinearTolerance});
   const DBManager::XodrGapBetweenGeometries kExpectedShortest{RoadHeader::Id("6"), {2, 3}, 0.};
   const DBManager::XodrGapBetweenGeometries kExpectedLargest{RoadHeader::Id("6"), {1, 2}, 1.77636e-15};
   const auto shortest_geometry{db_manager->GetShortestGap()};

--- a/test/regression/xodr/db_manager_test.cc
+++ b/test/regression/xodr/db_manager_test.cc
@@ -44,6 +44,9 @@ namespace xodr {
 namespace test {
 namespace {
 
+// Resource folder path defined via compile definition.
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
 // Template of a XODR description that contains only the xodr header.
 constexpr const char* kXODRHeaderTemplate = R"R(
 <?xml version='1.0' standalone='yes'?>
@@ -84,7 +87,8 @@ constexpr bool kDontAllowSemanticErrors{false};
 // Tests the loading of a XODR description from a file.
 GTEST_TEST(DBManager, LoadFromFile) {
   const std::string kXodrFile = "SingleLane.xodr";
-  EXPECT_NO_THROW(LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {kStrictParserSTolerance}));
+  EXPECT_NO_THROW(LoadDataBaseFromFile(utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder),
+                                       {kStrictParserSTolerance}));
 }
 
 // Tests the loading of a XODR description from a string.
@@ -1273,7 +1277,8 @@ GTEST_TEST(DBManagerTest, GetJunctions) {
   // If I decrease even more the tolerance, the TShapeRoad.xodr's geometries aren't contiguous in terms of the arc
   // length parameter.
   // TODO(#482): Decrease tolerance once the xodr file is fixed.
-  const std::unique_ptr<DBManager> dut = LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {1e-6});
+  const std::unique_ptr<DBManager> dut =
+      LoadDataBaseFromFile(utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder), {1e-6});
 
   const std::unordered_map<Junction::Id, Junction> junctions = dut->GetJunctions();
 
@@ -1580,7 +1585,7 @@ GTEST_TEST(DBManagerTest, Highway) {
   // @}
 
   const std::unique_ptr<DBManager> dut =
-      LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {kStrictParserSTolerance});
+      LoadDataBaseFromFile(utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder), {kStrictParserSTolerance});
 
   const std::map<RoadHeader::Id, RoadHeader> road_headers = dut->GetRoadHeaders();
   EXPECT_EQ(NumOfRoads, static_cast<int>(road_headers.size()));
@@ -1729,8 +1734,8 @@ GTEST_TEST(DBManagerTest, LoadMapWith2Connections) {
 // Loads TShapeRoad.xodr and verifies the shortest and largest Geometry in the XODR.
 GTEST_TEST(DBManager, GetGeometriesLengthInformation) {
   const std::string kXodrFile = "TShapeRoad.xodr";
-  const auto db_manager =
-      LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {constants::kLinearTolerance});
+  const auto db_manager = LoadDataBaseFromFile(utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder),
+                                               {constants::kLinearTolerance});
   const DBManager::XodrGeometryLengthData kExpectedShortest{RoadHeader::Id("6"), 3, 6.8474312421988870e-2};
   const DBManager::XodrGeometryLengthData kExpectedLargest{RoadHeader::Id("0"), 0, 46.};
   const auto shortest_geometry{db_manager->GetShortestGeometry()};
@@ -1747,8 +1752,8 @@ GTEST_TEST(DBManager, GetGeometriesLengthInformation) {
 GTEST_TEST(DBManager, GetLaneSectionLengthInformation) {
   const double kTolerance{1e-14};
   const std::string kXodrFile = "Highway.xodr";
-  const auto db_manager =
-      LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {constants::kLinearTolerance});
+  const auto db_manager = LoadDataBaseFromFile(utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder),
+                                               {constants::kLinearTolerance});
   const DBManager::XodrLaneSectionLengthData kExpectedShortest{RoadHeader::Id("4"), 0, 1.1649945427797022};
   const DBManager::XodrLaneSectionLengthData kExpectedLargest{RoadHeader::Id("11"), 0, 2.9161454554383585e+2};
   const auto shortest_lane_section{db_manager->GetShortestLaneSection()};
@@ -1765,8 +1770,8 @@ GTEST_TEST(DBManager, GetLaneSectionLengthInformation) {
 GTEST_TEST(DBManager, GetGeometriesGapInformation) {
   const double kTolerance{1e-14};
   const std::string kXodrFile = "TShapeRoad.xodr";
-  const auto db_manager =
-      LoadDataBaseFromFile(std::string(DEF_MALIDRIVE_RESOURCES) + kXodrFile, {constants::kLinearTolerance});
+  const auto db_manager = LoadDataBaseFromFile(utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder),
+                                               {constants::kLinearTolerance});
   const DBManager::XodrGapBetweenGeometries kExpectedShortest{RoadHeader::Id("6"), {2, 3}, 0.};
   const DBManager::XodrGapBetweenGeometries kExpectedLargest{RoadHeader::Id("6"), {1, 2}, 1.77636e-15};
   const auto shortest_geometry{db_manager->GetShortestGap()};


### PR DESCRIPTION
Proposes a solution for https://github.com/maliput/maliput_malidrive/pull/218#issuecomment-1151657707

Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>