### PR TITLE
Matches with changes in Maliput: Lane::ToLanePosition.

### DIFF
--- a/src/maliput_malidrive/base/lane.cc
+++ b/src/maliput_malidrive/base/lane.cc
@@ -189,11 +189,23 @@ Vector3 Lane::BackendFrameToLaneFrame(const Vector3& xyz) const {
 
 void Lane::DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
                                    maliput::math::Vector3* nearest_backend_pos, double* distance) const {
+  InertialToLaneSegmentPositionBackend(true, backend_pos, lane_position, nearest_backend_pos, distance);
+}
+
+void Lane::DoToSegmentPositionBackend(const maliput::math::Vector3& backend_pos,
+                                      maliput::api::LanePosition* lane_position,
+                                      maliput::math::Vector3* nearest_backend_pos, double* distance) const {
+  InertialToLaneSegmentPositionBackend(false, backend_pos, lane_position, nearest_backend_pos, distance);
+}
+
+void Lane::InertialToLaneSegmentPositionBackend(bool use_lane_boundaries, const maliput::math::Vector3& backend_pos,
+                                                maliput::api::LanePosition* lane_position,
+                                                maliput::math::Vector3* nearest_backend_pos, double* distance) const {
   const maliput::math::Vector3 unconstrained_prh{BackendFrameToLaneFrame(backend_pos)};
   MALIDRIVE_IS_IN_RANGE(unconstrained_prh[0], p0_, p1_);
   const double s = s_from_p_(unconstrained_prh[0]);
-  const maliput::api::RBounds segment_boundaries = segment_bounds(s);
-  const double r = maliput::math::saturate(unconstrained_prh[1], segment_boundaries.min(), segment_boundaries.max());
+  const maliput::api::RBounds r_bounds = use_lane_boundaries ? lane_bounds(s) : segment_bounds(s);
+  const double r = maliput::math::saturate(unconstrained_prh[1], r_bounds.min(), r_bounds.max());
   const maliput::api::HBounds elevation_boundaries = elevation_bounds(s, r);
   const double h =
       maliput::math::saturate(unconstrained_prh[2], elevation_boundaries.min(), elevation_boundaries.max());

--- a/src/maliput_malidrive/base/lane.cc
+++ b/src/maliput_malidrive/base/lane.cc
@@ -39,6 +39,15 @@
 #include "maliput_malidrive/road_curve/open_range_validator.h"
 
 namespace malidrive {
+namespace {
+
+// Values used for the InertialToLaneSegmentPositionBackend method.
+// @{
+static constexpr bool kUseLaneBoundaries = true;
+static constexpr bool kUseSegmentBoundaries = !kUseLaneBoundaries;
+// @}
+
+}  // namespace
 
 using maliput::math::Vector3;
 
@@ -189,13 +198,14 @@ Vector3 Lane::BackendFrameToLaneFrame(const Vector3& xyz) const {
 
 void Lane::DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
                                    maliput::math::Vector3* nearest_backend_pos, double* distance) const {
-  InertialToLaneSegmentPositionBackend(true, backend_pos, lane_position, nearest_backend_pos, distance);
+  InertialToLaneSegmentPositionBackend(kUseLaneBoundaries, backend_pos, lane_position, nearest_backend_pos, distance);
 }
 
 void Lane::DoToSegmentPositionBackend(const maliput::math::Vector3& backend_pos,
                                       maliput::api::LanePosition* lane_position,
                                       maliput::math::Vector3* nearest_backend_pos, double* distance) const {
-  InertialToLaneSegmentPositionBackend(false, backend_pos, lane_position, nearest_backend_pos, distance);
+  InertialToLaneSegmentPositionBackend(kUseSegmentBoundaries, backend_pos, lane_position, nearest_backend_pos,
+                                       distance);
 }
 
 void Lane::InertialToLaneSegmentPositionBackend(bool use_lane_boundaries, const maliput::math::Vector3& backend_pos,

--- a/src/maliput_malidrive/base/lane.h
+++ b/src/maliput_malidrive/base/lane.h
@@ -133,11 +133,17 @@ class Lane : public maliput::geometry_base::Lane {
   maliput::math::Vector3 DoToBackendPosition(const maliput::api::LanePosition& lane_pos) const override;
   void DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
                                maliput::math::Vector3* nearest_backend_pos, double* distance) const override;
+  void DoToSegmentPositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
+                                  maliput::math::Vector3* nearest_backend_pos, double* distance) const override;
   // @}
   maliput::api::Rotation DoGetOrientation(const maliput::api::LanePosition& lane_pos) const override;
   maliput::api::LanePosition DoEvalMotionDerivatives(const maliput::api::LanePosition& position,
                                                      const maliput::api::IsoLaneVelocity& velocity) const override;
   //@}
+
+  void InertialToLaneSegmentPositionBackend(bool use_lane_boundaries, const maliput::math::Vector3& backend_pos,
+                                            maliput::api::LanePosition* lane_position,
+                                            maliput::math::Vector3* nearest_backend_pos, double* distance) const;
 
   // @returns The r-coordinate in LANE Frame from `(p, r)` in the `road_curve`
   //          Frame.


### PR DESCRIPTION
Related to https://github.com/maliput/maliput/issues/496

### Summary

Matches with https://github.com/maliput/maliput/pull/521

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/b218a7671b9bb6b6be2c22ac19f85793/raw/8c1e3852f99a5ea730b12be37ac6c6205cf67a2a/maliput_malidrive.repos