### PR TITLE
Uses default ManualPhaseProvider implementation.

### DIFF
--- a/src/maliput_malidrive/builder/phase_provider_builder.cc
+++ b/src/maliput_malidrive/builder/phase_provider_builder.cc
@@ -42,29 +42,7 @@ using maliput::api::rules::Phase;
 using maliput::api::rules::PhaseRing;
 
 std::unique_ptr<maliput::ManualPhaseProvider> PhaseProviderBuilder::operator()() const {
-  auto manual_phase_provider = std::make_unique<maliput::ManualPhaseProvider>();
-  for (const auto& phase_ring_id : phase_ring_book_->GetPhaseRings()) {
-    const std::optional<PhaseRing> phase_ring = phase_ring_book_->GetPhaseRing(phase_ring_id);
-    MALIPUT_THROW_UNLESS(phase_ring != std::nullopt);
-    std::optional<Phase::Id> next_phase_id = std::nullopt;
-    std::optional<double> duration_until = std::nullopt;
-
-    const std::unordered_map<Phase::Id, Phase>& phases = phase_ring->phases();
-    if (phases.empty()) continue;
-    // As `phases` is an unordered map, the initial phase is randomly selected even though always the "begin" value of
-    // the collection is selected.
-    const Phase::Id initial_phase = phases.begin()->first;
-    const std::vector<PhaseRing::NextPhase> next_phases = phase_ring->next_phases().at(initial_phase);
-    if (!next_phases.empty()) {
-      // Arbitrarily selects the first next phase.
-      const PhaseRing::NextPhase& n = next_phases.front();
-      next_phase_id = n.id;
-      duration_until = n.duration_until;
-    }
-    manual_phase_provider->AddPhaseRing(phase_ring_id, initial_phase, next_phase_id, duration_until);
-  }
-
-  return manual_phase_provider;
+  return maliput::ManualPhaseProvider::GetDefaultPopulatedManualPhaseProvider(phase_ring_book_);
 }
 
 }  // namespace builder


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/maliput/maliput/pull/530

## Summary
Remove custom implementation as default populated ManualPhaseProvider is provided at https://github.com/maliput/maliput/pull/530

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/b218a7671b9bb6b6be2c22ac19f85793/raw/a6e2832ee69e953cdf9cf5391a0a000dc569653e/maliput_malidrive.repos