### PR TITLE
Adds missing gflags dependency to package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
 find_package(fmt 6.1.2 EXACT REQUIRED)
+find_package(gflags REQUIRED)
 
 find_package(maliput REQUIRED)
 find_package(maliput_drake REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <doc_depend>ament_cmake_doxygen</doc_depend>
 
   <depend>fmt</depend>
+  <depend>libgflags-dev</depend>
   <depend>maliput</depend>
   <depend>maliput_drake</depend>
   <depend>tinyxml2</depend>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
- This dependency was missing, causing CI to fail.
- Recently the dependency was removed from maliput package: https://github.com/maliput/maliput/pull/559 
  - Maybe malidrive was getting the implict dependency from there and that's why it was working.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
