### PR TITLE
Bazel module

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,31 @@
+########################################
+# Bzlmod Configuration
+########################################
+
+# Uncomment to build with bzlmod (i.e. use MODULE.bazel) or
+# use --enable_bzlmod on the command line.
+common --enable_bzlmod
+
+# TODO(daniel.stonier) Delete once 'yaml-cpp' has made it into the official BCR
+build --registry=https://raw.githubusercontent.com/stonier/bazel-central-registry/maliput_releases/
+
+########################################
+# Bazel Configuration
+########################################
+
+# https://bazel.build/docs/user-manual#verbose-failures
+build --verbose_failures
+
+########################################
+# C++ Configuration
+########################################
+
+build --cxxopt="-std=c++17"
+build --cxxopt="-Werror"
+
+# Silence compiler warnings for external dependencies.
+#  - https://github.com/bazelbuild/bazel/commit/08936aecb96f2937c61bdedfebcf1c5a41a0786d
+build --features=external_include_paths
+# In case that the above feature leaks some warnings, silence all warnings from the 'external' folder.
+# If in the future there are warnings leaked from other 3rd libs, add more 'per_file_copt' to include their paths.
+build --per_file_copt=external.*\.(cc|cpp|h|hpp|c)@-w

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -30,7 +30,7 @@ Locally:
 * Open a terminal in the container and run
 
 ```
-(docker) zen@bazel-zen:/workspaces/maliput$ bazel build //...
+(docker) zen@bazel-zen:/workspaces/maliput_malidrive$ bazel build //...
 ```
 
 CodeSpaces:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: gcc
 
 on:
-  push:
   pull_request:
     branches:
       - main
@@ -11,9 +10,27 @@ env:
   PACKAGE_NAME: maliput_malidrive
   ROS_DISTRO: foxy
 
+
+# Cancel previously running PR jobs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
-  compile_and_test:
-    name: Compile and test
+  bazel:
+    name: Compile and Test (Bazel)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}-bazel-ci:latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      shell: bash
+      run: |
+        bazel build //...
+
+  cmake:
+    name: Compile and Test (CMake)
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Python caches
 __pycache__
+
+# Bazel
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,150 @@
+###############################################################################
+# Libraries
+###############################################################################
+
+# TODO(daniel.stonier): revise these, get in sync with cmake/DefaultCFlags.cmake.
+# Be aware though that many do not work across platforms, e.g. there is no
+# cross-platform mechanism for setting std=c++17 in bazel
+
+COPTS = [
+    "-std=c++17",
+    "-Wno-builtin-macro-redefined",
+    "-Wno-missing-field-initializers",
+    "-Wno-unused-const-variable",
+
+    # Others from cmake/DefaultCFlags.cmake
+    # "-fdata-sections",
+    # "-fdiagnostics-color=always"
+    # "-ffunction-sections"
+    # "-fopenmp"
+    # "-fPIC"
+    # "-fstack-protector"
+    # "-fno-omit-frame-pointer"
+    # "-no-canonical-prefixes"
+    # "-Wall"
+    # "-Wregister"
+    # "-Wstrict-overflow"
+
+    # Some flags that were used in the TRI build
+    # "-Wno-unused-parameter",
+    # "-Wno-missing-braces",
+    # "-Wno-pessimizing-move",
+    # "-Wno-self-assign",
+    # "-Wno-deprecated-declarations",
+    # "-Wno-unused-private-field",
+    # "-Wno-maybe-uninitialized",
+    # "-Wno-deprecated-register",
+]
+
+cc_library(
+    name = "utility",
+    srcs = glob(["src/utility/**/*.cc"]),
+    hdrs = glob(["src/utility/**/*.h"]),
+    copts = COPTS,
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "maliput_malidrive_public_headers",
+    hdrs = glob(["include/maliput_malidrive/**/*.h"]),
+    copts = COPTS,
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@maliput//:api",
+        "@maliput//:base",
+        "@maliput//:common",
+        "@maliput//:plugin",
+        "@maliput//:geometry_base",
+    ],
+)
+
+# TODO(stonier): decompose this across dirs in src/maliput_malidrive
+cc_library(
+    name = "maliput_malidrive",
+    srcs = glob(["src/maliput_malidrive/**/*.cc"]),
+    hdrs = glob(["src/maliput_malidrive/**/*.h"]),
+    copts = COPTS,
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":maliput_malidrive_public_headers",
+        ":utility",
+        "@maliput//:api",
+        "@maliput//:base",
+        "@maliput//:geometry_base",
+        "@maliput//:utility",
+        "@maliput//:drake",
+        "@tinyxml2//:tinyxml2"
+    ],
+)
+
+cc_library(
+    name = "plugin",
+    srcs = glob(["src/plugin/**/*.cc"]),
+    copts = COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":maliput_malidrive",
+        "@maliput//:api",
+        "@maliput//:base",
+        "@maliput//:common",
+    ],
+)
+
+###############################################################################
+# Binaries
+###############################################################################
+
+cc_library(
+    name = "log_level_flag",
+    hdrs = glob(["src/applications/log_level_flag.h"]),
+    copts = COPTS,
+    strip_include_prefix = "src",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@gflags//:gflags",
+    ],
+)
+
+cc_binary(
+    name = "xodr_extract",
+    srcs = ["src/applications/xodr_extract.cc"],
+    copts = COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":log_level_flag",
+        ":maliput_malidrive",
+        "@gflags//:gflags",
+        "@maliput//:common",
+        "@tinyxml2//:tinyxml2"
+    ],
+)
+
+
+cc_binary(
+    name = "xodr_query",
+    srcs = ["src/applications/xodr_query.cc"],
+    copts = COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":log_level_flag",
+        ":maliput_malidrive",
+        "@gflags//:gflags",
+        "@maliput//:common",
+    ],
+)
+
+cc_binary(
+    name = "xodr_validate",
+    srcs = ["src/applications/xodr_validate.cc"],
+    copts = COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":log_level_flag",
+        ":maliput_malidrive",
+        "@gflags//:gflags",
+        "@maliput//:common",
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,18 @@
+"""
+Welcome to Maliput Malidrive!
+"""
+
+module(
+    name = "maliput_malidrive",
+    compatibility_level = 1,
+    version = "0.1.4",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.8")
+
+bazel_dep(name = "gflags", version = "2.2.2")
+bazel_dep(name = "maliput", version = "1.1.1")
+bazel_dep(name = "tinyxml2", version = "9.0.0")
+
+# bazel_dep(name = "fmt", version = "10.1.0", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,1 @@
+workspace(name = "maliput_malidrive")

--- a/resources/BUILD.bazel
+++ b/resources/BUILD.bazel
@@ -1,0 +1,51 @@
+###############################################################################
+# Resources
+###############################################################################
+
+# TODO(stonier): Consider making individual targets available. This would be
+# especially useful when the road network is more than just the .xodr file
+
+filegroup(
+    name = "all",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name="carla",
+    srcs = glob(["Town*.xodr"]),
+    visibility = ["//visibility:public"]
+)
+
+# !!! KEEP SYNC'D WITH test/CMakeLists.txt !!!
+filegroup(
+    name = "golden",
+    srcs = [
+        "ArcLane.xodr",
+        "Highway.xodr",
+        "LShapeRoad.xodr",
+        "LShapeRoadVariableLanes.xodr",
+        "LineMultipleSections.xodr",
+        "LineVariableWidth.xodr",
+        "LineVariableOffset.xodr",
+        "ParkingGarageRamp.xodr",
+        "RRFigure8.xodr",
+        "RRLongRoad.xodr",
+        "SingleLane.xodr",
+        "SingleRoadComplexDescription.xodr",
+        "SingleRoadComplexDescription2.xodr",
+        "SingleRoadHighCoefficients.xodr",
+        "SingleRoadNanValues.xodr",
+        "SingleRoadNegativeWidth.xodr",
+        "SingleRoadTinyGeometry.xodr",
+        "SingleRoadTwoGeometries.xodr",
+        "SShapeRoad.xodr",
+        "SShapeSuperelevatedRoad.xodr",
+        "StraightForward.xodr",
+        "TShapeRoad.xodr",
+        "Figure8.xodr",
+    ] + glob(["Town*.xodr"]),
+    visibility = ["//visibility:private"],
+    testonly = True
+)
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -145,6 +145,9 @@ endmacro()
 # This macro generates a test target per each map on the list.
 # Map file will be set using a CLI argument and it's the test responsibility
 # to parse it.
+#
+# !!! KEEP SYNC'D WITH resources/BUILD.bazel !!!
+#
 macro(malidrive_build_integration_based_tests)
   set(XODR_FILE_PREFIX ${PROJECT_SOURCE_DIR}/resources/)
   set(XODR_FILE_PATHS


### PR DESCRIPTION
# 🎉 New feature

Bazel module. 

## Summary

* [x] Uses the temporary BCR fork from https://github.com/stonier/bazel-central-registry [1]
* [x] `MODULE.bazel` - package and dependency information
* [x] `BUILD.bazel` - library and application targets
* [x] `resources/BUILD.bazel` - filegroup targets for maps
* [x] `build.yml` - a bazel build task

[1] It will take some time to get `yaml-cpp`, `tinyxml` and `maliput` into the BCR itself.

No tests yet, also no idea how to get the plugin framework working with bazel. These will come in followup PR's.

## Test it

With #235, load the devcontainer and `bazel build //...`

See also the CI result: https://github.com/maliput/maliput_malidrive/actions/runs/6239555329/job/16937711920?pr=236

## Checklist
- [x] Signed all commits for DCO
