### PR TITLE
Removes fmt dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ include(GNUInstallDirs)
 message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
-find_package(fmt 6.1.2 EXACT REQUIRED)
 find_package(gflags REQUIRED)
 
 find_package(maliput REQUIRED)
@@ -176,7 +175,6 @@ ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.d
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.sh.in")
 
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(fmt)
 ament_export_dependencies(maliput)
 ament_export_dependencies(maliput_drake)
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,5 +14,4 @@ bazel_dep(name = "gflags", version = "2.2.2")
 bazel_dep(name = "maliput", version = "1.1.1")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
-# bazel_dep(name = "fmt", version = "10.1.0", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <doc_depend>ament_cmake_doxygen</doc_depend>
 
-  <depend>fmt</depend>
   <depend>libgflags-dev</depend>
   <depend>maliput</depend>
   <depend>maliput_drake</depend>

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -30,8 +30,8 @@
 #include "maliput_malidrive/xodr/parser.h"
 
 #include <algorithm>
+#include <sstream>
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <maliput/common/assertion_error.h>
 
@@ -81,12 +81,23 @@ class ParsingTests : public ::testing::Test {
 };
 
 // Basic XML node templatized.
-constexpr const char* kBasicXMLNode = R"R(
-<root>
-  <{} {}='{}' {}='{}' >
-  </{}>
-</root>
-)R";
+// @param node_name: The name of the node.
+// @param attribute_name_1: The name of the first attribute.
+// @param attribute_value_1: The value of the first attribute.
+// @param attribute_name_2: The name of the second attribute.
+// @param attribute_value_2: The value of the second attribute.
+// @returns A string that contains a XML node with two attributes.
+std::string GetBasicXMLNode(const std::string& node_name, const std::string& attribute_name_1,
+                            const std::string& attribute_value_1, const std::string& attribute_name_2,
+                            const std::string& attribute_value_2) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<" << node_name << " " << attribute_name_1 << "='" << attribute_value_1 << "' " << attribute_name_2 << "='"
+     << attribute_value_2 << "' >";
+  ss << "</" << node_name << ">";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `NumberOfAttributes` method.
 TEST_F(ParsingTests, NumberOfAttributes) {
@@ -96,7 +107,7 @@ TEST_F(ParsingTests, NumberOfAttributes) {
   const int kNumberOfAttributes = 2;
   const double kExpectedValues[2]{1.57, 35.6};
   const std::string xml_description =
-      fmt::format(kBasicXMLNode, kNode, kValue1, kExpectedValues[0], kValue2, kExpectedValues[1], kNode);
+      GetBasicXMLNode(kNode, kValue1, std::to_string(kExpectedValues[0]), kValue2, std::to_string(kExpectedValues[1]));
   const ParserBase dut(LoadXMLAndGetNodeByName(xml_description, kNode),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_EQ(kNumberOfAttributes, dut.NumberOfAttributes());
@@ -109,7 +120,7 @@ TEST_F(ParsingTests, AttributeParserDouble) {
   constexpr const char* kValue2 = "value2";
   const double kExpectedValues[2]{1.57, 35.6};
   std::string xml_description =
-      fmt::format(kBasicXMLNode, kNode, kValue1, kExpectedValues[0], kValue2, kExpectedValues[1], kNode);
+      GetBasicXMLNode(kNode, kValue1, std::to_string(kExpectedValues[0]), kValue2, std::to_string(kExpectedValues[1]));
 
   const AttributeParser dut(LoadXMLAndGetNodeByName(xml_description, kNode),
                             {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -128,7 +139,7 @@ TEST_F(ParsingTests, AttributeParserDouble) {
 
   const double kNanValue{NAN};
 
-  xml_description = fmt::format(kBasicXMLNode, kNode, kValue1, kNanValue, kValue2, kNanValue, kNode);
+  xml_description = GetBasicXMLNode(kNode, kValue1, std::to_string(kNanValue), kValue2, std::to_string(kNanValue));
   const AttributeParser dut2(LoadXMLAndGetNodeByName(xml_description, kNode),
                              {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut2.As<double>(kValue1), maliput::common::assertion_error);
@@ -141,8 +152,7 @@ TEST_F(ParsingTests, AttributeParserString) {
   constexpr const char* kValue1 = "value1";
   constexpr const char* kValue2 = "value2";
   const std::string kExpectedValues[2]{"string_1", "string_2"};
-  const std::string xml_description =
-      fmt::format(kBasicXMLNode, kNode, kValue1, kExpectedValues[0], kValue2, kExpectedValues[1], kNode);
+  const std::string xml_description = GetBasicXMLNode(kNode, kValue1, kExpectedValues[0], kValue2, kExpectedValues[1]);
 
   const AttributeParser dut(LoadXMLAndGetNodeByName(xml_description, kNode),
                             {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -160,13 +170,34 @@ TEST_F(ParsingTests, AttributeParserString) {
   EXPECT_FALSE(missing_value.has_value());
 }
 
-// Basic XML node templatized.
-constexpr const char* kBasicXMLNode5Attributes = R"R(
-<root>
-  <{} {}='{}' {}='{}' {}='{}' {}='{}' {}='{}' >
-  </{}>
-</root>
-)R";
+// Basic XML node templatized for 5 attributes.
+// @param node_name: The name of the node.
+// @param attribute_name_1: The name of the first attribute.
+// @param attribute_value_1: The value of the first attribute.
+// @param attribute_name_2: The name of the second attribute.
+// @param attribute_value_2: The value of the second attribute.
+// @param attribute_name_3: The name of the third attribute.
+// @param attribute_value_3: The value of the third attribute.
+// @param attribute_name_4: The name of the fourth attribute.
+// @param attribute_value_4: The value of the fourth attribute.
+// @param attribute_name_5: The name of the fifth attribute.
+// @param attribute_value_5: The value of the fifth attribute.
+// @returns A string that contains a XML node with five attributes.
+std::string GetBasicXMLNode5Attributes(const std::string& node_name, const std::string& attribute_name_1,
+                                       const std::string& attribute_value_1, const std::string& attribute_name_2,
+                                       const std::string& attribute_value_2, const std::string& attribute_name_3,
+                                       const std::string& attribute_value_3, const std::string& attribute_name_4,
+                                       const std::string& attribute_value_4, const std::string& attribute_name_5,
+                                       const std::string& attribute_value_5) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<" << node_name << " " << attribute_name_1 << "='" << attribute_value_1 << "' " << attribute_name_2 << "='"
+     << attribute_value_2 << "' " << attribute_name_3 << "='" << attribute_value_3 << "' " << attribute_name_4 << "='"
+     << attribute_value_4 << "' " << attribute_name_5 << "='" << attribute_value_5 << "' >";
+  ss << "</" << node_name << ">";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `bool` parsing.
 TEST_F(ParsingTests, AttributeParserBool) {
@@ -175,8 +206,8 @@ TEST_F(ParsingTests, AttributeParserBool) {
   const std::string kStringValues[5]{"true", "false", "1", "0", "wrong_value"};
   const bool kExpectedValues[4]{true, false, true, false};
   const std::string xml_description =
-      fmt::format(kBasicXMLNode5Attributes, kNode, kValue[0], kStringValues[0], kValue[1], kStringValues[1], kValue[2],
-                  kStringValues[2], kValue[3], kStringValues[3], kValue[4], kStringValues[4], kNode);
+      GetBasicXMLNode5Attributes(kNode, kValue[0], kStringValues[0], kValue[1], kStringValues[1], kValue[2],
+                                 kStringValues[2], kValue[3], kStringValues[3], kValue[4], kStringValues[4]);
 
   const AttributeParser dut(LoadXMLAndGetNodeByName(xml_description, kNode),
                             {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -199,8 +230,7 @@ TEST_F(ParsingTests, AttributeParserHandTrafficRule) {
   constexpr const char* kValue1 = "rule1";
   constexpr const char* kValue2 = "rule2";
   const std::string kExpectedValues[2]{"LHT", "NotValid"};
-  const std::string xml_description =
-      fmt::format(kBasicXMLNode, kNode, kValue1, kExpectedValues[0], kValue2, kExpectedValues[1], kNode);
+  const std::string xml_description = GetBasicXMLNode(kNode, kValue1, kExpectedValues[0], kValue2, kExpectedValues[1]);
 
   const AttributeParser dut(LoadXMLAndGetNodeByName(xml_description, kNode),
                             {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -218,14 +248,30 @@ TEST_F(ParsingTests, AttributeParserHandTrafficRule) {
   EXPECT_FALSE(missing_value.has_value());
 }
 
-// Template of a XML description that contains a XODR header.
-constexpr const char* kHeaderTemplate = R"R(
-<root>
-  <header revMajor='{}' revMinor='{}' name='{}' version='{}' date='{}'
-    north='{}' south='{}' east='{}' west='{}' vendor='{}' >
-  </header>
-</root>
-)R";
+// Get a XML description of a XODR header.
+// @param rev_major: The major revision number.
+// @param rev_minor: The minor revision number.
+// @param name: The name of the header.
+// @param version: The version of the header.
+// @param date: The date of the header.
+// @param north: The north value of the header.
+// @param south: The south value of the header.
+// @param east: The east value of the header.
+// @param west: The west value of the header.
+// @param vendor: The vendor of the header.
+// @returns A string that contains a XML description of a XODR header.
+std::string GetXODRHeader(double rev_major, double rev_minor, const std::string& name, double version,
+                          const std::string& date, double north, double south, double east, double west,
+                          const std::string& vendor) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<header revMajor='" << rev_major << "' revMinor='" << rev_minor << "' name='" << name << "' version='"
+     << version << "' date='" << date << "' north='" << north << "' south='" << south << "' east='" << east
+     << "' west='" << west << "' vendor='" << vendor << "' >";
+  ss << "</header>";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `Header` parsing.
 TEST_F(ParsingTests, NodeParserHeader) {
@@ -240,10 +286,10 @@ TEST_F(ParsingTests, NodeParserHeader) {
                                4.4 /* west */,
                                "TestVendor" /* vendor */};
   const std::string xml_description =
-      fmt::format(kHeaderTemplate, kExpectedHeader.rev_major, kExpectedHeader.rev_minor, kExpectedHeader.name.value(),
-                  kExpectedHeader.version.value(), kExpectedHeader.date.value(), kExpectedHeader.north.value(),
-                  kExpectedHeader.south.value(), kExpectedHeader.east.value(), kExpectedHeader.west.value(),
-                  kExpectedHeader.vendor.value());
+      GetXODRHeader(kExpectedHeader.rev_major, kExpectedHeader.rev_minor, kExpectedHeader.name.value(),
+                    kExpectedHeader.version.value(), kExpectedHeader.date.value(), kExpectedHeader.north.value(),
+                    kExpectedHeader.south.value(), kExpectedHeader.east.value(), kExpectedHeader.west.value(),
+                    kExpectedHeader.vendor.value());
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Header::kHeaderTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -251,16 +297,28 @@ TEST_F(ParsingTests, NodeParserHeader) {
   EXPECT_EQ(kExpectedHeader, dut.As<Header>());
 }
 
-// Template of a XML description that contains a XODR RoadLink.
-constexpr const char* kRoadLinkTemplate = R"R(
-<root>
-  <link>
-      <predecessor elementType="{}" elementId="{}" contactPoint="{}"/>
-      <successor elementType="{}" elementId="{}" contactPoint="{}"/>
-  </link>
-</root>
-)R";
-
+// Get a XML description of a XODR RoadLink.
+// @param pred_element_type: The predecessor element type.
+// @param pred_element_id: The predecessor element id.
+// @param pred_contact_point: The predecessor contact point.
+// @param succ_element_type: The successor element type.
+// @param succ_element_id: The successor element id.
+// @param succ_contact_point: The successor contact point.
+// @returns A string that contains a XML description of a XODR RoadLink.
+std::string GetRoadLink(const std::string& pred_element_type, const std::string& pred_element_id,
+                        const std::string& pred_contact_point, const std::string& succ_element_type,
+                        const std::string& succ_element_id, const std::string& succ_contact_point) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<link>";
+  ss << "<predecessor elementType='" << pred_element_type << "' elementId='" << pred_element_id << "' contactPoint='"
+     << pred_contact_point << "' />";
+  ss << "<successor elementType='" << succ_element_type << "' elementId='" << succ_element_id << "' contactPoint='"
+     << succ_contact_point << "' />";
+  ss << "</link>";
+  ss << "</root>";
+  return ss.str();
+}
 // Tests `RoadLink` parsing.
 TEST_F(ParsingTests, NodeParserRoadLink) {
   const RoadLink::LinkAttributes kPredecessor{RoadLink::ElementType::kRoad /* elementType */,
@@ -271,7 +329,7 @@ TEST_F(ParsingTests, NodeParserRoadLink) {
                                             RoadLink::ContactPoint::kStart /* contactPoint*/};
   const RoadLink kExpectedRoadLink{kPredecessor, kSuccessor};
   const std::string xml_description =
-      fmt::format(kRoadLinkTemplate, RoadLink::element_type_to_str(kExpectedRoadLink.predecessor->element_type),
+      GetRoadLink(RoadLink::element_type_to_str(kExpectedRoadLink.predecessor->element_type),
                   kExpectedRoadLink.predecessor->element_id.string(),
                   RoadLink::contact_point_to_str(*kExpectedRoadLink.predecessor->contact_point),
                   RoadLink::element_type_to_str(kExpectedRoadLink.successor->element_type),
@@ -285,19 +343,23 @@ TEST_F(ParsingTests, NodeParserRoadLink) {
   EXPECT_EQ(kExpectedRoadLink, road_link);
 }
 
-// Template of a XML description that contains a XODR RoadType::Speed.
-constexpr const char* kRoadSpeedTemplate = R"R(
-<root>
-  <speed max='{}' unit='{}'/>
-</root>
-)R";
+// Get a XML description of a XODR RoadSpeed
+// @param max The max speed.
+// @param unit The unit of the speed.
+// @returns A string that contains a XML description of a XODR RoadSpeed.
+std::string GetRoadSpeed(double max, const std::string& unit) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<speed max='" << max << "' unit='" << unit << "' />";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `RoadType::Speed` parsing.
 TEST_F(ParsingTests, NodeParserRoadSpeed) {
   const RoadType::Speed kExpectedSpeed{45. /* max */, Unit::kMph /* unit */};
 
-  const std::string xml_description =
-      fmt::format(kRoadSpeedTemplate, kExpectedSpeed.max.value(), unit_to_str(kExpectedSpeed.unit));
+  const std::string xml_description = GetRoadSpeed(kExpectedSpeed.max.value(), unit_to_str(kExpectedSpeed.unit));
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, RoadType::Speed::kSpeedTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -306,23 +368,27 @@ TEST_F(ParsingTests, NodeParserRoadSpeed) {
   EXPECT_EQ(kExpectedSpeed, speed);
 }
 
-// Template of a XML description that contains a XODR RoadType.
-constexpr const char* kRoadTypeTemplate = R"R(
-<root>
-  <type s='{}' type='{}' country='{}'>
-    <speed max='45.' unit='mph'/>
-  </type>
-</root>
-)R";
-
+// Get a XML description that contains a XODR RoadType.
+// @param s The s value.
+// @param type The type value.
+// @param country The country value.
+// @returns A string that contains a XML description of a XODR RoadType.
+std::string GetRoadType(double s, const std::string& type, const std::string& country) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<type s='" << s << "' type='" << type << "' country='" << country << "'>";
+  ss << "<speed max='45.' unit='mph'/>";
+  ss << "</type>";
+  ss << "</root>";
+  return ss.str();
+}
 // Tests `RoadType` parsing.
 TEST_F(ParsingTests, NodeParserRoadType) {
   const RoadType::Speed kSpeed{45. /* max */, Unit::kMph /* unit */};
   const RoadType kExpectedRoadType{1.2 /* s0 */, RoadType::Type::kPedestrian /* type */, "+54" /* country */,
                                    kSpeed /* speed */};
-  const std::string xml_description =
-      fmt::format(kRoadTypeTemplate, kExpectedRoadType.s_0, RoadType::type_to_str(kExpectedRoadType.type),
-                  kExpectedRoadType.country.value());
+  const std::string xml_description = GetRoadType(kExpectedRoadType.s_0, RoadType::type_to_str(kExpectedRoadType.type),
+                                                  kExpectedRoadType.country.value());
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, RoadType::kRoadTypeTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -331,22 +397,31 @@ TEST_F(ParsingTests, NodeParserRoadType) {
   EXPECT_EQ(kExpectedRoadType, road_type);
 }
 
-// Template of a XML description that contains a XODR Geometry.
-constexpr const char* kGeometryTemplate = R"R(
-<root>
-  <geometry s='{}' x='{}' y='{}' hdg='{}' length='{}'>
-      <{}/>
-  </geometry>
-</root>
-)R";
+// Get a XML description that contains a XODR Geometry.
+// @param s_0 The s_0 value.
+// @param x The x value.
+// @param y The y value.
+// @param orientation The orientation value.
+// @param length The length value.
+// @param type The type value.
+std::string GetGeometry(double s_0, double x, double y, double orientation, double length, const std::string& type) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<geometry s='" << s_0 << "' x='" << x << "' y='" << y << "' hdg='" << orientation << "' length='" << length
+     << "'>";
+  ss << "<" << type << "/>";
+  ss << "</geometry>";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `Geometry` parsing.
 TEST_F(ParsingTests, NodeParserLineGeometry) {
   const Geometry kExpectedGeometry{
       1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},   0.77 /* orientation */,
       100. /* length */, Geometry::Type::kLine /* Type */, {Geometry::Line{}} /* description */};
-  const std::string xml_description = fmt::format(
-      kGeometryTemplate, kExpectedGeometry.s_0, kExpectedGeometry.start_point.x(), kExpectedGeometry.start_point.y(),
+  const std::string xml_description = GetGeometry(
+      kExpectedGeometry.s_0, kExpectedGeometry.start_point.x(), kExpectedGeometry.start_point.y(),
       kExpectedGeometry.orientation, kExpectedGeometry.length, Geometry::type_to_str(kExpectedGeometry.type));
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Geometry::kGeometryTag),
@@ -362,11 +437,11 @@ TEST_F(ParsingTests, NodeParserArcGeometry) {
       1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},  0.77 /* orientation */,
       100. /* length */, Geometry::Type::kArc /* Type */, Geometry::Arc{0.5} /* description */};
   const std::string geometry_description =
-      fmt::format("{} {}='{}'", Geometry::type_to_str(kExpectedGeometry.type), Geometry::Arc::kCurvature,
-                  std::get<Geometry::Arc>(kExpectedGeometry.description).curvature);
-  const std::string xml_description = fmt::format(
-      kGeometryTemplate, kExpectedGeometry.s_0, kExpectedGeometry.start_point.x(), kExpectedGeometry.start_point.y(),
-      kExpectedGeometry.orientation, kExpectedGeometry.length, geometry_description);
+      Geometry::type_to_str(kExpectedGeometry.type) + " " + Geometry::Arc::kCurvature + "='" +
+      std::to_string(std::get<Geometry::Arc>(kExpectedGeometry.description).curvature) + "'";
+  const std::string xml_description =
+      GetGeometry(kExpectedGeometry.s_0, kExpectedGeometry.start_point.x(), kExpectedGeometry.start_point.y(),
+                  kExpectedGeometry.orientation, kExpectedGeometry.length, geometry_description);
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Geometry::kGeometryTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -375,19 +450,41 @@ TEST_F(ParsingTests, NodeParserArcGeometry) {
   EXPECT_EQ(kExpectedGeometry, geometry);
 }
 
-// Template of a XML description that contains a XODR PlanView.
-constexpr const char* kPlainViewTemplate = R"R(
-<root>
-  <planView>
-    <geometry s='{}' x='{}' y='{}' hdg='{}' length='{}'>
-        <{}/>
-    </geometry>
-    <geometry s='{}' x='{}' y='{}' hdg='{}' length='{}'>
-        <{} {}='{}'/>
-    </geometry>
-  </planView>
-</root>
-)R";
+// Get a XML description that contains a XODR PlanView.
+// @param s_0 The s_0 value of first geometry.
+// @param x_0 The x_0 value of first geometry.
+// @param y_0 The y_0 value of first geometry.
+// @param orientation_0 The orientation value value of first geometry.
+// @param length_0 The length value of first geometry.
+// @param type_0 The type value of first geometry.
+// @param s_1 The s_1 value of second geometry.
+// @param x_1 The x_1 value of second geometry.
+// @param y_1 The y_1 value of second geometry.
+// @param orientation_1 The orientation value of second geometry.
+// @param length_1 The length value of second geometry.
+// @param type_1 The type value of second geometry.
+// @param arc_description The arc description.
+// @param curvature The curvature value.
+// @returns A string that contains a XML description of a XODR PlanView.
+std::string GetPlainView(double s_0, double x_0, double y_0, double orientation_0, double length_0,
+                         const std::string& type_0, double s_1, double x_1, double y_1, double orientation_1,
+                         double length_1, const std::string& type_1, const std::string& arc_description,
+                         double curvature) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<planView>";
+  ss << "<geometry s='" << s_0 << "' x='" << x_0 << "' y='" << y_0 << "' hdg='" << orientation_0 << "' length='"
+     << length_0 << "'>";
+  ss << "<" << type_0 << "/>";
+  ss << "</geometry>";
+  ss << "<geometry s='" << s_1 << "' x='" << x_1 << "' y='" << y_1 << "' hdg='" << orientation_1 << "' length='"
+     << length_1 << "'>";
+  ss << "<" << type_1 << " " << arc_description << "='" << curvature << "'/>";
+  ss << "</geometry>";
+  ss << "</planView>";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `PlanView` parsing.
 TEST_F(ParsingTests, NodeParserPlanView) {
@@ -403,8 +500,8 @@ TEST_F(ParsingTests, NodeParserPlanView) {
                                                                   200. /* length */,
                                                                   Geometry::Type::kArc /* Type */,
                                                                   Geometry::Arc{0.5} /* description */}}};
-  const std::string xml_description = fmt::format(
-      kPlainViewTemplate, kExpectedPlanView.geometries[0].s_0, kExpectedPlanView.geometries[0].start_point.x(),
+  const std::string xml_description = GetPlainView(
+      kExpectedPlanView.geometries[0].s_0, kExpectedPlanView.geometries[0].start_point.x(),
       kExpectedPlanView.geometries[0].start_point.y(), kExpectedPlanView.geometries[0].orientation,
       kExpectedPlanView.geometries[0].length, Geometry::type_to_str(kExpectedPlanView.geometries[0].type),
       kExpectedPlanView.geometries[1].s_0, kExpectedPlanView.geometries[1].start_point.x(),
@@ -433,8 +530,8 @@ TEST_F(ParsingTests, NodeParserPlanViewNonContiguous) {
                                                                   200. /* length */,
                                                                   Geometry::Type::kArc /* Type */,
                                                                   Geometry::Arc{0.5} /* description */}}};
-  const std::string xml_description = fmt::format(
-      kPlainViewTemplate, kExpectedPlanView.geometries[0].s_0, kExpectedPlanView.geometries[0].start_point.x(),
+  const std::string xml_description = GetPlainView(
+      kExpectedPlanView.geometries[0].s_0, kExpectedPlanView.geometries[0].start_point.x(),
       kExpectedPlanView.geometries[0].start_point.y(), kExpectedPlanView.geometries[0].orientation,
       kExpectedPlanView.geometries[0].length, Geometry::type_to_str(kExpectedPlanView.geometries[0].type),
       kExpectedPlanView.geometries[1].s_0, kExpectedPlanView.geometries[1].start_point.x(),
@@ -447,20 +544,28 @@ TEST_F(ParsingTests, NodeParserPlanViewNonContiguous) {
   EXPECT_THROW(dut.As<PlanView>(), maliput::common::assertion_error);
 }
 
-// Template of a XML description that contains a XODR elevation.
-constexpr const char* kElevationTemplate = R"R(
-<root>
-  <elevation s='{}' a='{}' b='{}' c='{}' d='{}'/>
-</root>
-)R";
+// Get a XML description that contains a XODR elevation.
+// @param s The s value.
+// @param a The a value.
+// @param b The b value.
+// @param c The c value.
+// @param d The d value.
+// @returns A string that contains a XML description of a XODR elevation.
+std::string GetElevation(double s, double a, double b, double c, double d) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<elevation s='" << s << "' a='" << a << "' b='" << b << "' c='" << c << "' d='" << d << "' />";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `Elevation` parsing.
 TEST_F(ParsingTests, NodeParserElevation) {
   const ElevationProfile::Elevation kExpectedElevation{1.1 /* s0 */, 2.2 /* a */, 3.3 /* b */, 4.4 /* c */,
                                                        5.5 /* d */};
 
-  const std::string xml_description = fmt::format(kElevationTemplate, kExpectedElevation.s_0, kExpectedElevation.a,
-                                                  kExpectedElevation.b, kExpectedElevation.c, kExpectedElevation.d);
+  const std::string xml_description = GetElevation(kExpectedElevation.s_0, kExpectedElevation.a, kExpectedElevation.b,
+                                                   kExpectedElevation.c, kExpectedElevation.d);
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, ElevationProfile::Elevation::kElevationTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -491,21 +596,27 @@ TEST_F(ParsingTests, NodeParserElevationProfile) {
   const ElevationProfile::Elevation kElevation5{21.21, 22.22, 23.23, 24.24, 25.25};
   const ElevationProfile kExpectedElevationProfile{{kElevation1, kElevation2, kElevation3, kElevation4, kElevation5}};
 
-  const std::string xml_description = fmt::format(kElevationProfileTemplate);
-
-  const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, ElevationProfile::kElevationProfileTag),
+  const NodeParser dut(LoadXMLAndGetNodeByName(kElevationProfileTemplate, ElevationProfile::kElevationProfileTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_EQ(ElevationProfile::kElevationProfileTag, dut.GetName());
   const ElevationProfile elevation_profile = dut.As<ElevationProfile>();
   EXPECT_EQ(kExpectedElevationProfile, elevation_profile);
 }
 
-// Template of a XML description that contains a XODR superelevation.
-constexpr const char* kSuperelevationTemplate = R"R(
-<root>
-  <superelevation s='{}' a='{}' b='{}' c='{}' d='{}'/>
-</root>
-)R";
+// Get a XML description that contains a XODR superelevation.
+// @param s The s value.
+// @param a The a value.
+// @param b The b value.
+// @param c The c value.
+// @param d The d value.
+// @returns A string that contains a XML description of a XODR superelevation.
+std::string GetSuperelevation(double s, double a, double b, double c, double d) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<superelevation s='" << s << "' a='" << a << "' b='" << b << "' c='" << c << "' d='" << d << "' />";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `Superelevation` parsing.
 TEST_F(ParsingTests, NodeParserSuperelevation) {
@@ -513,8 +624,8 @@ TEST_F(ParsingTests, NodeParserSuperelevation) {
                                                                5.5 /* d */};
 
   const std::string xml_description =
-      fmt::format(kSuperelevationTemplate, kExpectedSuperelevation.s_0, kExpectedSuperelevation.a,
-                  kExpectedSuperelevation.b, kExpectedSuperelevation.c, kExpectedSuperelevation.d);
+      GetSuperelevation(kExpectedSuperelevation.s_0, kExpectedSuperelevation.a, kExpectedSuperelevation.b,
+                        kExpectedSuperelevation.c, kExpectedSuperelevation.d);
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, LateralProfile::Superelevation::kSuperelevationTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -546,28 +657,34 @@ TEST_F(ParsingTests, NodeParserLateralProfile) {
   const LateralProfile kExpectedLateralProfile{
       {kSuperelevation1, kSuperelevation2, kSuperelevation3, kSuperelevation4, kSuperelevation5}};
 
-  const std::string xml_description = fmt::format(kLateralProfileTemplate);
-
-  const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, LateralProfile::kLateralProfileTag),
+  const NodeParser dut(LoadXMLAndGetNodeByName(kLateralProfileTemplate, LateralProfile::kLateralProfileTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_EQ(LateralProfile::kLateralProfileTag, dut.GetName());
   const LateralProfile lateral_profile = dut.As<LateralProfile>();
   EXPECT_EQ(kExpectedLateralProfile, lateral_profile);
 }
 
-// Template of a XML description that contains a XODR width node.
-constexpr const char* kWidthTemplate = R"R(
-<root>
-  <width sOffset='{}' a='{}' b='{}' c='{}' d='{}'/>
-</root>
-)R";
+// Get a XML description that contains a XODR width node.
+// @param s_offset The s_offset value.
+// @param a The a value.
+// @param b The b value.
+// @param c The c value.
+// @param d The d value.
+// @returns A string that contains a XML description of a XODR width node.
+std::string GetWidth(double s_offset, double a, double b, double c, double d) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<width sOffset='" << s_offset << "' a='" << a << "' b='" << b << "' c='" << c << "' d='" << d << "' />";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `LaneWidth` parsing.
 TEST_F(ParsingTests, NodeParserLaneWidth) {
   const LaneWidth kExpectedLaneWidth{1.1 /* sOffset */, 2.2 /* a */, 3.3 /* b */, 4.4 /* c */, 5.5 /* d */};
 
-  const std::string xml_description = fmt::format(kWidthTemplate, kExpectedLaneWidth.s_0, kExpectedLaneWidth.a,
-                                                  kExpectedLaneWidth.b, kExpectedLaneWidth.c, kExpectedLaneWidth.d);
+  const std::string xml_description = GetWidth(kExpectedLaneWidth.s_0, kExpectedLaneWidth.a, kExpectedLaneWidth.b,
+                                               kExpectedLaneWidth.c, kExpectedLaneWidth.d);
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, LaneWidth::kLaneWidthTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -576,19 +693,25 @@ TEST_F(ParsingTests, NodeParserLaneWidth) {
   EXPECT_EQ(kExpectedLaneWidth, lane_width);
 }
 
-// Template of a XML description that contains a XODR Lane::Speed.
-constexpr const char* kLaneSpeedTemplate = R"R(
-<root>
-  <speed sOffset='{}' max='{}' unit='{}'/>
-</root>
-)R";
+// Get a XML description that contains a XODR Lane::Speed.
+// @param s_offset The s_offset value.
+// @param max The max value.
+// @param unit The unit value.
+// @returns A string that contains a XML description of a XODR Lane::Speed.
+std::string GetLaneSpeed(double s_offset, double max, const std::string& unit) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<speed sOffset='" << s_offset << "' max='" << max << "' unit='" << unit << "' />";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `Lane::Speed` parsing.
 TEST_F(ParsingTests, NodeParserLaneSpeed) {
   const Lane::Speed kExpectedSpeed{0.1 /* sOffset */, 45. /* max */, Unit::kMph /* unit */};
 
   const std::string xml_description =
-      fmt::format(kLaneSpeedTemplate, kExpectedSpeed.s_offset, kExpectedSpeed.max, unit_to_str(kExpectedSpeed.unit));
+      GetLaneSpeed(kExpectedSpeed.s_offset, kExpectedSpeed.max, unit_to_str(kExpectedSpeed.unit));
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Lane::Speed::kSpeedTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -597,19 +720,28 @@ TEST_F(ParsingTests, NodeParserLaneSpeed) {
   EXPECT_EQ(kExpectedSpeed, speed);
 }
 
-// Template of a XML description that contains a XODR lane offset node.
-constexpr const char* kLaneOffsetTemplate = R"R(
-<root>
-  <laneOffset s='{}' a='{}' b='{}' c='{}' d='{}'/>
-</root>
-)R";
+// Get a XML description that contains a XODR lane offset node.
+// @param s The s value.
+// @param a The a value.
+// @param b The b value.
+// @param c The c value.
+// @param d The d value.
+// @returns A string that contains a XML description of a XODR lane offset node.
+std::string GetLaneOffset(double s, double a, double b, double c, double d) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<laneOffset s='" << s << "' a='" << a << "' b='" << b << "' c='" << c << "' d='" << d << "' />";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `LaneOffset` parsing.
 TEST_F(ParsingTests, NodeParserLaneOffset) {
   const LaneOffset kExpectedLaneOffset{1.1 /* s */, 2.2 /* a */, 3.3 /* b */, 4.4 /* c */, 5.5 /* d */};
 
-  const std::string xml_description = fmt::format(kLaneOffsetTemplate, kExpectedLaneOffset.s_0, kExpectedLaneOffset.a,
-                                                  kExpectedLaneOffset.b, kExpectedLaneOffset.c, kExpectedLaneOffset.d);
+  const std::string xml_description =
+      GetLaneOffset(kExpectedLaneOffset.s_0, kExpectedLaneOffset.a, kExpectedLaneOffset.b, kExpectedLaneOffset.c,
+                    kExpectedLaneOffset.d);
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, LaneOffset::kLaneOffsetTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -618,22 +750,27 @@ TEST_F(ParsingTests, NodeParserLaneOffset) {
   EXPECT_EQ(kExpectedLaneOffset, lane_offset);
 }
 
-// Template of a XML description that contains a XODR LaneLink.
-constexpr const char* kLaneLinkTemplate = R"R(
-<root>
-  <link>
-      <predecessor id='{}'/>
-      <successor id='{}'/>
-  </link>
-</root>
-)R";
+// Get a XML description that contains a XODR LaneLink.
+// @param pred_element_id The predecessor element id.
+// @param succ_element_id The successor element id.
+// @returns A string that contains a XML description of a XODR LaneLink.
+std::string GetLaneLink(const std::string& pred_element_id, const std::string& succ_element_id) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<link>";
+  ss << "<predecessor id='" << pred_element_id << "'/>";
+  ss << "<successor id='" << succ_element_id << "'/>";
+  ss << "</link>";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `LaneLink` parsing.
 TEST_F(ParsingTests, NodeParserLaneLink) {
   const LaneLink::LinkAttributes kPredecessor{LaneLink::LinkAttributes::Id("50") /* elementId*/};
   const LaneLink::LinkAttributes kSuccessor{LaneLink::LinkAttributes::Id("80") /* elementId*/};
   const LaneLink kExpectedLaneLink{kPredecessor, kSuccessor};
-  const std::string xml_description = fmt::format(kLaneLinkTemplate, kPredecessor.id.string(), kSuccessor.id.string());
+  const std::string xml_description = GetLaneLink(kPredecessor.id.string(), kSuccessor.id.string());
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, LaneLink::kLaneLinkTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -642,21 +779,27 @@ TEST_F(ParsingTests, NodeParserLaneLink) {
   EXPECT_EQ(kExpectedLaneLink, road_link);
 }
 
-// Template of a XML description that contains a XODR Lane node.
-constexpr const char* kLaneTemplate = R"R(
-<root>
-  <lane id='{}' type='{}' level='{}' >
-    <link>
-      <predecessor id='50'/>
-      <successor id='80'/>
-    </link>
-    <width sOffset='1.1' a='2.2' b='3.3' c='4.4' d='5.5'/>
-    <width sOffset='6.6' a='7.7' b='8.8' c='9.9' d='10.1'/>
-    <speed sOffset='0.1' max='45.' unit='mph'/>
-    <speed sOffset='0.5' max='3.'/>
-  </lane>
-</root>
-)R";
+// Get a XML description that contains a XODR Lane node.
+// @param id The id value.
+// @param type The type value.
+// @param level The level value.
+// @returns A string that contains a XML description of a XODR Lane node.
+std::string GetLane(const std::string& id, const std::string& type, const std::string& level) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<lane id='" << id << "' type='" << type << "' level='" << level << "' >";
+  ss << "<link>";
+  ss << "<predecessor id='50'/>";
+  ss << "<successor id='80'/>";
+  ss << "</link>";
+  ss << "<width sOffset='1.1' a='2.2' b='3.3' c='4.4' d='5.5'/>";
+  ss << "<width sOffset='6.6' a='7.7' b='8.8' c='9.9' d='10.1'/>";
+  ss << "<speed sOffset='0.1' max='45.' unit='mph'/>";
+  ss << "<speed sOffset='0.5' max='3.'/>";
+  ss << "</lane>";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `Lane` parsing.
 TEST_F(ParsingTests, NodeParserLane) {
@@ -673,9 +816,8 @@ TEST_F(ParsingTests, NodeParserLane) {
       lane_link /* lane_link */,    kWidthDescription /* widths */,  kSpeed /*speed*/
   };
 
-  const std::string xml_description =
-      fmt::format(kLaneTemplate, kExpectedLane.id.string(), Lane::type_to_str(kExpectedLane.type),
-                  kExpectedLane.level.value() ? "true" : "false");
+  const std::string xml_description = GetLane(kExpectedLane.id.string(), Lane::type_to_str(kExpectedLane.type),
+                                              kExpectedLane.level.value() ? "true" : "false");
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Lane::kLaneTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -684,10 +826,14 @@ TEST_F(ParsingTests, NodeParserLane) {
   EXPECT_EQ(kExpectedLane, lane);
 }
 
-// Template of a XML description that contains a XODR LaneSection node.
-constexpr const char* kLaneSectionTemplate = R"R(
-<root>
-  <laneSection s='{}'>
+// Get a XML description that contains a XODR LaneSection node.
+// @param s The s value.
+// @returns A string that contains a XML description of a XODR LaneSection node.
+std::string GetLaneSection(double s) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<laneSection s='" << s << "'>";
+  ss << R"R(
       <left>
           <lane id='1' type='driving' level= '0'>
               <width sOffset='0.' a='1.' b='2.' c='3.' d='4.'/>
@@ -705,6 +851,8 @@ constexpr const char* kLaneSectionTemplate = R"R(
   </laneSection>
 </root>
 )R";
+  return ss.str();
+}
 
 // Tests `LaneSection` parsing.
 TEST_F(ParsingTests, NodeParserLaneSection) {
@@ -717,7 +865,7 @@ TEST_F(ParsingTests, NodeParserLaneSection) {
                                          center_lane /* center_lane */,
                                          {right_lane} /* right_lanes */};
 
-  const std::string xml_description = fmt::format(kLaneSectionTemplate, kExpectedLaneSection.s_0);
+  const std::string xml_description = GetLaneSection(kExpectedLaneSection.s_0);
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, LaneSection::kLaneSectionTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -816,11 +964,20 @@ TEST_F(ParsingTests, NodeParserLanes) {
   EXPECT_EQ(kExpectedLanes, lanes);
 }
 
-// Template of a XML description that contains a XODR RoadHeader.
-constexpr const char* kRoadHeaderTemplate = R"R(
-<root>
-  <road name='{}' length='{}' id='{}' junction='{}' rule='{}'>"
-     <link>
+// Get a XML description that contains a XODR RoadHeader.
+// @param name The name value.
+// @param length The length value.
+// @param id The id value.
+// @param junction The junction value.
+// @param rule The rule value.
+// @returns A string that contains a XML description of a XODR RoadHeader.
+std::string GetRoadHeader(const std::string& name, double length, const std::string& id, const std::string& junction,
+                          const std::string& rule) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<road name='" << name << "' length='" << length << "' id='" << id << "' junction='" << junction << "' rule='"
+     << rule << "'>";
+  ss << R"R(<link>
          <predecessor elementType="road" elementId="80" contactPoint="end"/>
          <successor elementType="road" elementId="10" contactPoint="start"/>
      </link>
@@ -913,6 +1070,8 @@ constexpr const char* kRoadHeaderTemplate = R"R(
   </road>"
 </root>
 )R";
+  return ss.str();
+}
 
 // Tests `RoadHeader` parsing.
 TEST_F(ParsingTests, NodeParserRoadHeader) {
@@ -992,10 +1151,9 @@ TEST_F(ParsingTests, NodeParserRoadHeader) {
       {kRoadType1, kRoadType2} /* road_types */,
       {kArbitraryPlanView, kElevationProfile, kLateralProfile} /* reference_geometry */,
       kLanes /* lanes */};
-  const std::string xml_description =
-      fmt::format(kRoadHeaderTemplate, kExpectedRoadHeader.name.value(), kExpectedRoadHeader.length,
-                  kExpectedRoadHeader.id.string(), kExpectedRoadHeader.junction,
-                  RoadHeader::hand_traffic_rule_to_str(kExpectedRoadHeader.rule.value()));
+  const std::string xml_description = GetRoadHeader(
+      kExpectedRoadHeader.name.value(), kExpectedRoadHeader.length, kExpectedRoadHeader.id.string(),
+      kExpectedRoadHeader.junction, RoadHeader::hand_traffic_rule_to_str(kExpectedRoadHeader.rule.value()));
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, RoadHeader::kRoadHeaderTag),
                        {kStrictParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -1003,15 +1161,33 @@ TEST_F(ParsingTests, NodeParserRoadHeader) {
   EXPECT_EQ(kExpectedRoadHeader, dut.As<RoadHeader>());
 }
 
-// Template of a XML description that contains a XODR Connection.
-constexpr const char* kConnectionTemplate = R"R(
-<root>
-  <connection id="{}" incomingRoad="{}" connectingRoad="{}" contactPoint="{}" connectionMaster="{}" type="{}">
-      <laneLink from="{}" to="{}"/>
-      <laneLink from="{}" to="{}"/>
-  </connection>
-</root>
-)R";
+// Get a XML description that contains a XODR Connection.
+// @param id The id value.
+// @param incoming_road The incoming_road value.
+// @param connecting_road The connecting_road value.
+// @param contact_point The contact_point value.
+// @param connection_master The connection_master value.
+// @param type The type value.
+// @param from_1 From value of first lane link.
+// @param to_1 To value of first lane link.
+// @param from_2 From value of second lane link.
+// @param to_2 To value of second lane link.
+// @returns A string that contains a XML description of a XODR Connection.
+std::string GetConnection(const std::string& id, const std::string& incoming_road, const std::string& connecting_road,
+                          const std::string& contact_point, const std::string& connection_master,
+                          const std::string& type, const std::string& from_1, const std::string& to_1,
+                          const std::string& from_2, const std::string& to_2) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<connection id='" << id << "' incomingRoad='" << incoming_road << "' connectingRoad='" << connecting_road
+     << "' contactPoint='" << contact_point << "' connectionMaster='" << connection_master << "' type='" << type
+     << "'>";
+  ss << "<laneLink from='" << from_1 << "' to='" << to_1 << "'/>";
+  ss << "<laneLink from='" << from_2 << "' to='" << to_2 << "'/>";
+  ss << "</connection>";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `Connection` parsing.
 TEST_F(ParsingTests, NodeParserConnection) {
@@ -1025,9 +1201,9 @@ TEST_F(ParsingTests, NodeParserConnection) {
       {{Connection::LaneLink::Id("1"), Connection::LaneLink::Id("1")},
        {Connection::LaneLink::Id("-1"), Connection::LaneLink::Id("-1")}} /* lane_links */};
 
-  const std::string xml_description = fmt::format(
-      kConnectionTemplate, kExpectedConnection.id.string(), kExpectedConnection.incoming_road,
-      kExpectedConnection.connecting_road, Connection::contact_point_to_str(kExpectedConnection.contact_point),
+  const std::string xml_description = GetConnection(
+      kExpectedConnection.id.string(), kExpectedConnection.incoming_road, kExpectedConnection.connecting_road,
+      Connection::contact_point_to_str(kExpectedConnection.contact_point),
       kExpectedConnection.connection_master->string(), Connection::type_to_str(kExpectedConnection.type.value()),
       kExpectedConnection.lane_links[0].from.string(), kExpectedConnection.lane_links[0].to.string(),
       kExpectedConnection.lane_links[1].from.string(), kExpectedConnection.lane_links[1].to.string());
@@ -1039,10 +1215,17 @@ TEST_F(ParsingTests, NodeParserConnection) {
   EXPECT_EQ(kExpectedConnection, connection);
 }
 
-// Template of a XML description that contains a XODR Junction.
-constexpr const char* kJunctionTemplate = R"R(
-<root>
-  <junction id="{}" name="{}" type="{}">
+// Get a XML description that contains a XODR Junction.
+// @param junction_id The junction_id value.
+// @param junction_name The junction_name value.
+// @param junction_type The junction_type value.
+// @returns A string that contains a XML description of a XODR Junction.
+std::string GetJunction(const std::string& junction_id, const std::string& junction_name,
+                        const std::string& junction_type) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<junction id='" << junction_id << "' name='" << junction_name << "' type='" << junction_type << "'>";
+  ss << R"R(
     <connection id="10" incomingRoad="1" connectingRoad="2" contactPoint="start" connectionMaster="50" type="default">
         <laneLink from="1" to="1"/>
         <laneLink from="-1" to="-1"/>
@@ -1054,6 +1237,8 @@ constexpr const char* kJunctionTemplate = R"R(
   </junction>
 </root>
 )R";
+  return ss.str();
+}
 
 // Tests `Junction` parsing.
 TEST_F(ParsingTests, NodeParserJunction) {
@@ -1080,9 +1265,8 @@ TEST_F(ParsingTests, NodeParserJunction) {
       Junction::Type::kDefault /* type */,
       {{kConnectionA.id, kConnectionA}, {kConnectionB.id, kConnectionB}} /* connections */};
 
-  const std::string xml_description =
-      fmt::format(kJunctionTemplate, kExpectedJunction.id.string(), kExpectedJunction.name.value(),
-                  Junction::type_to_str(kExpectedJunction.type.value()));
+  const std::string xml_description = GetJunction(kExpectedJunction.id.string(), kExpectedJunction.name.value(),
+                                                  Junction::type_to_str(kExpectedJunction.type.value()));
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Junction::kJunctionTag),
                        {kStrictParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
@@ -1101,8 +1285,6 @@ constexpr const char* kJunctionTemplateNoConnections = R"R(
 
 // Tests `Junction` parsing with no connections.
 TEST_F(ParsingTests, NodeParserJunctionNoConnections) {
-  const std::string xml_description = fmt::format(kJunctionTemplateNoConnections);
-
   bool allow_schema_errors{true};
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(kJunctionTemplateNoConnections, Junction::kJunctionTag),
                                   {kStrictParserSTolerance, allow_schema_errors, kDontAllowSemanticErrors});
@@ -1128,30 +1310,33 @@ GTEST_TEST(XMLToText, ConvertXMLNodeToText) {
   EXPECT_EQ(kArbitraryXMLDescription, str_xml);
 }
 
-// Template of a XML description that contains function description that matches with ElevationProfile or Lateralprofile
+// Get a XML description that contains function description that matches with ElevationProfile or LateralProfile
 // descriptions.
 // - 1st and 2nd descriptions are equal
 // - 3rd and 4th descriptions are equal
 // - 5th description start at the same S value as 4th description.
-constexpr const char* kElevationSuperelevationTemplate = R"R(
-<root>
-  <{0}>
-    <{1} s="0.0" a="1.0" b="2.0" c="3.0" d="4.0"/>
-    <{1} s="0.0" a="1.0" b="2.0" c="3.0" d="4.0"/>
-    <{1} s="5.0" a="2.0" b="0.0" c="0.0" d="0.0"/>
-    <{1} s="5.0" a="2.0" b="0.0" c="0.0" d="0.0"/>
-    <{1} s="5.0" a="2.1" b="0.0" c="0.0" d="0.0"/>
-  </{0}>
-</root>
-)R";
+// @param profile The profile tag.
+// @param description The description tag.
+std::string GetElevationSuperelevation(const std::string& profile, const std::string& description) {
+  std::stringstream ss;
+  ss << "<root>";
+  ss << "<" << profile << ">";
+  ss << "<" << description << " s='0.' a='1.' b='2.' c='3.' d='4.'/>";
+  ss << "<" << description << " s='0.' a='1.' b='2.' c='3.' d='4.'/>";
+  ss << "<" << description << " s='5.' a='2.' b='0.' c='0.' d='0.'/>";
+  ss << "<" << description << " s='5.' a='2.' b='0.' c='0.' d='0.'/>";
+  ss << "<" << description << " s='5.' a='2.1' b='0.' c='0.' d='0.'/>";
+  ss << "</" << profile << ">";
+  ss << "</root>";
+  return ss.str();
+}
 
 // Tests `ElevationProfile` and `LateralProfile` parsing when having repeated descriptions.
 // @{
 class ElevationRepeatedDescriptionsParsingTests : public ParsingTests {
  protected:
   const std::string xml_description =
-      fmt::format(kElevationSuperelevationTemplate, ElevationProfile::kElevationProfileTag,
-                  ElevationProfile::Elevation::kElevationTag);
+      GetElevationSuperelevation(ElevationProfile::kElevationProfileTag, ElevationProfile::Elevation::kElevationTag);
 };
 
 TEST_F(ElevationRepeatedDescriptionsParsingTests, NotAllowingSchemaErrors) {
@@ -1173,8 +1358,8 @@ TEST_F(ElevationRepeatedDescriptionsParsingTests, AllowingSchemaErrors) {
 
 class SuperelevationRepeatedDescriptionsParsingTests : public ParsingTests {
  protected:
-  const std::string xml_description = fmt::format(kElevationSuperelevationTemplate, LateralProfile::kLateralProfileTag,
-                                                  LateralProfile::Superelevation::kSuperelevationTag);
+  const std::string xml_description = GetElevationSuperelevation(LateralProfile::kLateralProfileTag,
+                                                                 LateralProfile::Superelevation::kSuperelevationTag);
 };
 
 TEST_F(SuperelevationRepeatedDescriptionsParsingTests, NotAllowingSchemaErrors) {
@@ -1287,36 +1472,51 @@ class FunctionsWithNanValuesTests : public ParsingTests {
  protected:
   static constexpr double kSameStartS{3.0};
   static constexpr double kDifferentStartS{1.0};
-  // Template of a XML description that contains function description that matches with ElevationProfile or
+  // Get a XML description that contains function description that matches with ElevationProfile or
   // Lateralprofile descriptions.
   // - 1st function has nan values
   //   - It is loadable only when `s=3.0`(same as the next function) and schema errors are allowed.
-  static constexpr const char* kNanElevationSuperelevationTemplate = R"R(
-  <root>
-    <{0}>
-      <{1} s="{2}" a="nan" b="nan" c="nan" d="nan"/>
-      <{1} s="3.0" a="2.0" b="0.0" c="0.0" d="0.0"/>
-      <{1} s="5.0" a="2.1" b="0.0" c="0.0" d="0.0"/>
-    </{0}>
-  </root>
-  )R";
-  // Template of a XML description that contains a XODR Lane node with width descriptions filled with nan values.
+  // @param profile The profile tag.
+  // @param description The description tag.
+  // @param s The s value of the first function description.
+  // @returns A string that contains a XML description of a XODR ElevationProfile or LateralProfile.
+  static std::string GetNanElevationSuperelevation(const std::string& profile, const std::string& description,
+                                                   double s) {
+    std::stringstream ss;
+    ss << "<root>";
+    ss << "<" << profile << ">";
+    ss << "<" << description << " s='" << s << "' a='nan' b='nan' c='nan' d='nan'/>";
+    ss << "<" << description << " s='3.0' a='2.0' b='0.0' c='0.0' d='0.0'/>";
+    ss << "<" << description << " s='5.0' a='2.1' b='0.0' c='0.0' d='0.0'/>";
+    ss << "</" << profile << ">";
+    ss << "</root>";
+    return ss.str();
+  }
+  // Get a XML description that contains a XODR Lane node with width descriptions filled with nan values.
   // - 1st function has nan values
   //   - It is loadable only when `s=3.0`(same as the next function) and schema errors are allowed.
-  static constexpr const char* kNanLaneWidthTemplate = R"R(
-  <root>
-    <lane id='1' type='driving' >
-      <width sOffset="{0}" a="nan" b="nan" c="nan" d="nan"/>
-      <width sOffset="3.0" a="2.0" b="0.0" c="0.0" d="0.0"/>
-      <width sOffset="5.0" a="2.1" b="0.0" c="0.0" d="0.0"/>
-    </lane>
-  </root>
-  )R";
-  // Template of a XML description that contains a XODR Lanes node with laneOffset descriptions filled with nan values.
-  static constexpr const char* kLanesNodeWithNanLaneOffsetTemplate = R"R(
-  <root>
-    <lanes>
-      <laneOffset s="{0}" a="nan" b="nan" c="nan" d="nan"/>
+  // @param s The s value of the first function description.
+  // @returns A string that contains a XML description of a XODR Lane with the above description.
+  static std::string GetNanLaneWidth(double s) {
+    std::stringstream ss;
+    ss << "<root>";
+    ss << "<lane id='1' type='driving' >";
+    ss << "<width sOffset='" << s << "' a='nan' b='nan' c='nan' d='nan'/>";
+    ss << "<width sOffset='3.0' a='2.0' b='0.0' c='0.0' d='0.0'/>";
+    ss << "<width sOffset='5.0' a='2.1' b='0.0' c='0.0' d='0.0'/>";
+    ss << "</lane>";
+    ss << "</root>";
+    return ss.str();
+  }
+  // Get a XML description that contains a XODR Lanes node with laneOffset descriptions filled with nan values.
+  // @param s The s value of the first offset description.
+  // @returns A string that contains a XML description of a XODR Lanes with the above description.
+  static std::string GetLanesNodeWithNanLaneOffset(double s) {
+    std::stringstream ss;
+    ss << "<root>";
+    ss << "<lanes>";
+    ss << "<laneOffset s='" << s << "' a='nan' b='nan' c='nan' d='nan'/>";
+    ss << R"R(
       <laneOffset s="3.0" a="2.0" b="0.0" c="0.0" d="0.0"/>
       <laneOffset s="5.0" a="2.1" b="0.0" c="0.0" d="0.0"/>
       <laneSection s='0.'>
@@ -1333,6 +1533,8 @@ class FunctionsWithNanValuesTests : public ParsingTests {
     </lanes>
   </root>
   )R";
+    return ss.str();
+  }
 };
 
 // Tests `ElevationProfile` and `LateralProfile` parsing when having nan values.
@@ -1340,9 +1542,8 @@ class FunctionsWithNanValuesTests : public ParsingTests {
 class ElevationNanDescriptionsParsingTests : public FunctionsWithNanValuesTests {};
 
 TEST_F(ElevationNanDescriptionsParsingTests, NotAllowingSchemaErrors) {
-  const std::string xml_description =
-      fmt::format(kNanElevationSuperelevationTemplate, ElevationProfile::kElevationProfileTag,
-                  ElevationProfile::Elevation::kElevationTag, kSameStartS);
+  const std::string xml_description = GetNanElevationSuperelevation(
+      ElevationProfile::kElevationProfileTag, ElevationProfile::Elevation::kElevationTag, kSameStartS);
   const NodeParser dut_strict(LoadXMLAndGetNodeByName(xml_description, ElevationProfile::kElevationProfileTag),
                               {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut_strict.As<ElevationProfile>(), maliput::common::assertion_error);
@@ -1352,18 +1553,16 @@ TEST_F(ElevationNanDescriptionsParsingTests, NotAllowingSchemaErrors) {
 // However it throws because NaN values are allowed in the function iff
 // the next function description starts at the same `s` value so as to discard the one with NaN values.
 TEST_F(ElevationNanDescriptionsParsingTests, AllowingSchemaErrorsDifferentStartPoint) {
-  const std::string xml_description =
-      fmt::format(kNanElevationSuperelevationTemplate, ElevationProfile::kElevationProfileTag,
-                  ElevationProfile::Elevation::kElevationTag, kDifferentStartS);
+  const std::string xml_description = GetNanElevationSuperelevation(
+      ElevationProfile::kElevationProfileTag, ElevationProfile::Elevation::kElevationTag, kDifferentStartS);
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(xml_description, ElevationProfile::kElevationProfileTag),
                                   {kNullParserSTolerance, kAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut_permissive.As<ElevationProfile>(), maliput::common::assertion_error);
 }
 
 TEST_F(ElevationNanDescriptionsParsingTests, AllowingSchemaErrorsSameStartPoint) {
-  const std::string xml_description =
-      fmt::format(kNanElevationSuperelevationTemplate, ElevationProfile::kElevationProfileTag,
-                  ElevationProfile::Elevation::kElevationTag, kSameStartS);
+  const std::string xml_description = GetNanElevationSuperelevation(
+      ElevationProfile::kElevationProfileTag, ElevationProfile::Elevation::kElevationTag, kSameStartS);
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(xml_description, ElevationProfile::kElevationProfileTag),
                                   {kNullParserSTolerance, kAllowSchemaErrors, kDontAllowSemanticErrors});
   ElevationProfile elevation_profile;
@@ -1377,9 +1576,8 @@ TEST_F(ElevationNanDescriptionsParsingTests, AllowingSchemaErrorsSameStartPoint)
 class SuperelevationNanDescriptionsParsingTests : public FunctionsWithNanValuesTests {};
 
 TEST_F(SuperelevationNanDescriptionsParsingTests, NotAllowingSchemaErrors) {
-  const std::string xml_description =
-      fmt::format(kNanElevationSuperelevationTemplate, LateralProfile::kLateralProfileTag,
-                  LateralProfile::Superelevation::kSuperelevationTag, kSameStartS);
+  const std::string xml_description = GetNanElevationSuperelevation(
+      LateralProfile::kLateralProfileTag, LateralProfile::Superelevation::kSuperelevationTag, kSameStartS);
   const NodeParser dut_strict(LoadXMLAndGetNodeByName(xml_description, LateralProfile::kLateralProfileTag),
                               {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut_strict.As<LateralProfile>(), maliput::common::assertion_error);
@@ -1389,18 +1587,16 @@ TEST_F(SuperelevationNanDescriptionsParsingTests, NotAllowingSchemaErrors) {
 // However it throws because NaN values are allowed in the function iff
 // the next function description starts at the same `s` value so as to discard the one with NaN values.
 TEST_F(SuperelevationNanDescriptionsParsingTests, AllowingSchemaErrorsDifferentStartPoint) {
-  const std::string xml_description =
-      fmt::format(kNanElevationSuperelevationTemplate, LateralProfile::kLateralProfileTag,
-                  LateralProfile::Superelevation::kSuperelevationTag, kDifferentStartS);
+  const std::string xml_description = GetNanElevationSuperelevation(
+      LateralProfile::kLateralProfileTag, LateralProfile::Superelevation::kSuperelevationTag, kDifferentStartS);
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(xml_description, LateralProfile::kLateralProfileTag),
                                   {kNullParserSTolerance, kAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut_permissive.As<LateralProfile>(), maliput::common::assertion_error);
 }
 
 TEST_F(SuperelevationNanDescriptionsParsingTests, AllowingSchemaErrorsSameStartPoint) {
-  const std::string xml_description =
-      fmt::format(kNanElevationSuperelevationTemplate, LateralProfile::kLateralProfileTag,
-                  LateralProfile::Superelevation::kSuperelevationTag, kSameStartS);
+  const std::string xml_description = GetNanElevationSuperelevation(
+      LateralProfile::kLateralProfileTag, LateralProfile::Superelevation::kSuperelevationTag, kSameStartS);
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(xml_description, LateralProfile::kLateralProfileTag),
                                   {kNullParserSTolerance, kAllowSchemaErrors, kDontAllowSemanticErrors});
   LateralProfile lateral_profile;
@@ -1416,7 +1612,7 @@ TEST_F(SuperelevationNanDescriptionsParsingTests, AllowingSchemaErrorsSameStartP
 class LaneWithNanWidthDescriptionsParsingTests : public FunctionsWithNanValuesTests {};
 
 TEST_F(LaneWithNanWidthDescriptionsParsingTests, NotAllowingSchemaErrors) {
-  const std::string xml_description = fmt::format(kNanLaneWidthTemplate, kSameStartS);
+  const std::string xml_description = GetNanLaneWidth(kSameStartS);
   const NodeParser dut_strict(LoadXMLAndGetNodeByName(xml_description, Lane::kLaneTag),
                               {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut_strict.As<Lane>(), maliput::common::assertion_error);
@@ -1426,14 +1622,14 @@ TEST_F(LaneWithNanWidthDescriptionsParsingTests, NotAllowingSchemaErrors) {
 // However it throws because NaN values are allowed in the function iff
 // the next function description starts at the same `s` value so as to discard the one with NaN values.
 TEST_F(LaneWithNanWidthDescriptionsParsingTests, AllowingSchemaErrorsDifferentStartPoint) {
-  const std::string xml_description = fmt::format(kNanLaneWidthTemplate, kDifferentStartS);
+  const std::string xml_description = GetNanLaneWidth(kDifferentStartS);
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(xml_description, Lane::kLaneTag),
                                   {kNullParserSTolerance, kAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut_permissive.As<Lane>(), maliput::common::assertion_error);
 }
 
 TEST_F(LaneWithNanWidthDescriptionsParsingTests, AllowingSchemaErrorsSameStartPoint) {
-  const std::string xml_description = fmt::format(kNanLaneWidthTemplate, kSameStartS);
+  const std::string xml_description = GetNanLaneWidth(kSameStartS);
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(xml_description, Lane::kLaneTag),
                                   {kNullParserSTolerance, kAllowSchemaErrors, kDontAllowSemanticErrors});
   Lane lane;
@@ -1456,7 +1652,7 @@ TEST_F(LaneWithNanWidthDescriptionsParsingTests, AllowingSchemaErrorsSameStartPo
 class LanesWithNanLaneOffsetParsingTests : public FunctionsWithNanValuesTests {};
 
 TEST_F(LanesWithNanLaneOffsetParsingTests, NotAllowingSchemaErrors) {
-  const std::string xml_description = fmt::format(kLanesNodeWithNanLaneOffsetTemplate, kSameStartS);
+  const std::string xml_description = GetLanesNodeWithNanLaneOffset(kSameStartS);
   const NodeParser dut_strict(LoadXMLAndGetNodeByName(xml_description, Lanes::kLanesTag),
                               {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut_strict.As<Lanes>(), maliput::common::assertion_error);
@@ -1466,14 +1662,14 @@ TEST_F(LanesWithNanLaneOffsetParsingTests, NotAllowingSchemaErrors) {
 // However it throws because NaN values are allowed in the function iff
 // the next function description starts at the same `s` value so as to discard the one with NaN values.
 TEST_F(LanesWithNanLaneOffsetParsingTests, AllowingSchemaErrorsDifferentStartPoint) {
-  const std::string xml_description = fmt::format(kLanesNodeWithNanLaneOffsetTemplate, kDifferentStartS);
+  const std::string xml_description = GetLanesNodeWithNanLaneOffset(kDifferentStartS);
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(xml_description, Lanes::kLanesTag),
                                   {kNullParserSTolerance, kAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_THROW(dut_permissive.As<Lanes>(), maliput::common::assertion_error);
 }
 
 TEST_F(LanesWithNanLaneOffsetParsingTests, AllowingSchemaErrorsSameStartPoint) {
-  const std::string xml_description = fmt::format(kLanesNodeWithNanLaneOffsetTemplate, kSameStartS);
+  const std::string xml_description = GetLanesNodeWithNanLaneOffset(kSameStartS);
   const NodeParser dut_permissive(LoadXMLAndGetNodeByName(xml_description, Lanes::kLanesTag),
                                   {kNullParserSTolerance, kAllowSchemaErrors, kDontAllowSemanticErrors});
   Lanes lanes;


### PR DESCRIPTION
# 🎉 New feature

Closes #234 

## Summary
 - Tests where fmt was used was replaced by custom code.
 - fmt dependency was removed from maliput_malidrive.
 
## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

