### PR TITLE
Adds periodic wheel generation.(once a week)

### DIFF
--- a/.github/workflows/wheel_generation.yml
+++ b/.github/workflows/wheel_generation.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    - cron:  '0 9 * * *' # 9:00am UTC, 1:00am PST.
 
 env:
   PACKAGE_NAME: maliput_malidrive

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![gcc](https://github.com/maliput/maliput_malidrive/actions/workflows/build.yml/badge.svg)](https://github.com/maliput/maliput_malidrive/actions/workflows/build.yml)
+[![gcc](https://github.com/maliput/maliput_malidrive/actions/workflows/build.yml/badge.svg)](https://github.com/maliput/maliput_malidrive/actions/workflows/build.yml) [![Wheel Generation](https://github.com/maliput/maliput_malidrive/actions/workflows/wheel_generation.yml/badge.svg?branch=main)](https://github.com/maliput/maliput_malidrive/actions/workflows/wheel_generation.yml)
 
 # maliput_malidrive
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
 - Sets wheel generation workflow to run once a week.
 - Adds badge status in the README file.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

