### PR TITLE
Adds try_vcs_checkout to wheel_generation workflow.

### DIFF
--- a/.github/workflows/wheel_generation.yml
+++ b/.github/workflows/wheel_generation.yml
@@ -17,6 +17,7 @@ env:
   PYTHON_VERSION: cp38-cp38
   CMAKE_COMMAND_ENV: /opt/_internal/cpython-3.8.18/bin/cmake
   RETENTION_DAYS: 7
+  VCS_PATH: /opt/_internal/cpython-3.8.18/bin/
 
   # Cancel previously running PR jobs
 concurrency:
@@ -40,11 +41,11 @@ jobs:
     - name: vcs import
       shell: bash
       working-directory: ${{ env.COLCON_WS }}
-      run: vcs import src < src/${PACKAGE_NAME}/.github/dependencies.repos
+      run: PATH=$PATH:${{ env.VCS_PATH }} vcs import src < src/${PACKAGE_NAME}/.github/dependencies.repos
     - name: check if dependencies have a matching branch
       shell: bash
       working-directory: ${{ env.COLCON_WS }}/src
-      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+      run: PATH=$PATH:${{ env.VCS_PATH }} ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
     - name: colcon graph
       run: /opt/python/${PYTHON_VERSION}/bin/colcon graph
       shell: bash

--- a/.github/workflows/wheel_generation.yml
+++ b/.github/workflows/wheel_generation.yml
@@ -37,10 +37,14 @@ jobs:
       with:
         path: ${{ env.COLCON_WS }}/src/${{ env.PACKAGE_NAME }}
     # clone public dependencies
-    - name: git clone maliput
+    - name: vcs import
+      shell: bash
+      working-directory: ${{ env.COLCON_WS }}
+      run: vcs import src < src/${PACKAGE_NAME}/.github/dependencies.repos
+    - name: check if dependencies have a matching branch
       shell: bash
       working-directory: ${{ env.COLCON_WS }}/src
-      run: git clone https://github.com/maliput/maliput
+      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
     - name: colcon graph
       run: /opt/python/${PYTHON_VERSION}/bin/colcon graph
       shell: bash


### PR DESCRIPTION
# 🦟 Bug fix

Follow up to https://github.com/maliput/maliput_infrastructure/pull/316

## Summary
The wheel generation workflow was not switching branches based on the naming scheme. Doing it here so it gets fixed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

