### PR TITLE
Adds vcstool and pip to bazel-zen docker image.

### DIFF
--- a/.devcontainer/bazel-zen/Dockerfile
+++ b/.devcontainer/bazel-zen/Dockerfile
@@ -44,7 +44,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     # python
     python3-dev \
+    python3-pip \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+################################################################################
+# Install vcstool
+################################################################################
+RUN pip install vcstool
 
 ################################################################################
 # Bazelisk


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Edits the docker image for bazel usage to include pip and vcstool. That will allow https://github.com/maliput/maliput_malidrive/pull/253 to pull a docker image that contains vcs and avoid installing it each time.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
