### PR TITLE
Adds -O2 flag to bazel build.

### DIFF
--- a/bazel/variables.bzl
+++ b/bazel/variables.bzl
@@ -11,6 +11,7 @@ COPTS = [
     "-Wno-builtin-macro-redefined",
     "-Wno-missing-field-initializers",
     "-Wno-unused-const-variable",
+    "-O2",
 
     # Others from cmake/DefaultCFlags.cmake
     # "-fdata-sections",


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Adds -O2 flag to bazel build to reduce execution time of tests.
See https://github.com/maliput/maliput_malidrive/pull/252#issuecomment-1818816657 for an example of the failures we face.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
