### PR TITLE
Updates ros-tooling version to avoid error with dependency.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       image: ubuntu:20.04
     steps:
     - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/setup-ros@v0.6
     - uses: ros-tooling/action-ros-ci@v0.2
       id: action_ros_ci_step
       with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -36,7 +36,7 @@ jobs:
       LDFLAGS: -fuse-ld=lld-8
     steps:
     # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
-    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/setup-ros@v0.6
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - uses: actions/checkout@v3

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -23,7 +23,7 @@ jobs:
       LDFLAGS: -fuse-ld=lld-8
     steps:
     # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
-    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/setup-ros@v0.6
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - uses: actions/checkout@v3


### PR DESCRIPTION
# 🦟 Bug fix

Pairs with https://github.com/maliput/maliput_infrastructure/pull/317

## Summary

Updates setup-ros to use v0.6 to avoid erros with empy.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
