### PR TITLE
[applications] xodr_to_obj

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -234,6 +234,24 @@ cc_binary(
 )
 
 cc_binary(
+    name = "xodr_to_obj",
+    srcs = ["src/applications/xodr_to_obj.cc"],
+    copts = COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":log_level_flag",
+        ":builder",
+        ":common",
+        ":loader",
+        ":xodr",
+        "@gflags//:gflags",
+        "@maliput//:common",
+        "@maliput//:utility",
+        "@tinyxml2//:tinyxml2"
+    ],
+)
+
+cc_binary(
     name = "xodr_validate",
     srcs = ["src/applications/xodr_validate.cc"],
     copts = COPTS,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,4 +16,3 @@ bazel_dep(name = "maliput", version = "1.2.0")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)
-

--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -67,3 +67,25 @@ install(
   DESTINATION
     ${CMAKE_INSTALL_BINDIR}/${PROJECT_NAME}/applications
 )
+
+add_executable(xodr_to_obj xodr_to_obj.cc)
+target_link_libraries(
+  xodr_to_obj
+  PRIVATE
+    gflags
+    maliput::common
+    maliput::utility
+    maliput_malidrive::builder
+    maliput_malidrive::common
+    maliput_malidrive::loader
+    maliput_malidrive::xodr
+    tinyxml2
+  INTERFACE
+    log_level_flag
+)
+install(
+  TARGETS
+     xodr_to_obj
+  DESTINATION
+    ${CMAKE_INSTALL_BINDIR}/${PROJECT_NAME}/applications
+)

--- a/src/applications/xodr_extract.cc
+++ b/src/applications/xodr_extract.cc
@@ -118,7 +118,7 @@ int Main(int argc, char** argv) {
   output_xodr_doc.SaveFile(FLAGS_output_file_path.c_str());
   maliput::log()->info("XODR file created: ", FLAGS_output_file_path);
 
-  return 1;
+  return 0;
 }
 
 }  // namespace

--- a/src/applications/xodr_query.cc
+++ b/src/applications/xodr_query.cc
@@ -383,7 +383,7 @@ int Main(int argc, char** argv) {
     query.GetGeometries(RoadHeaderIdFromCli(&(argv[3])));
   }
 
-  return 1;
+  return 0;
 }
 
 }  // namespace

--- a/src/applications/xodr_to_obj.cc
+++ b/src/applications/xodr_to_obj.cc
@@ -40,7 +40,6 @@
 #include <maliput/utility/generate_obj.h>
 
 #include "applications/log_level_flag.h"
-
 #include "maliput_malidrive/builder/road_network_builder.h"
 #include "maliput_malidrive/loader/loader.h"
 
@@ -53,7 +52,9 @@ namespace {
 std::string GetUsageMessage() {
   std::stringstream ss;
   ss << "CLI for XODR to OBJ conversion:" << std::endl << std::endl;
-  ss << "  xodr_to_obj --xodr_file=<path> --out-dir=<path> --tolerance=<float> [--allow-schema-errors] [--allow-semantic-errors]" << std::endl;
+  ss << "  xodr_to_obj --xodr_file=<path> --out-dir=<path> --tolerance=<float> [--allow-schema-errors] "
+        "[--allow-semantic-errors]"
+     << std::endl;
   return ss.str();
 }
 
@@ -82,9 +83,7 @@ int Main(int argc, char** argv) {
   // Load the road network
   std::map<std::string, std::string> road_network_configuration;
   road_network_configuration.emplace("opendrive_file", FLAGS_xodr_file);
-  auto road_network = malidrive::loader::Load<malidrive::builder::RoadNetworkBuilder>(
-    road_network_configuration
-  );
+  auto road_network = malidrive::loader::Load<malidrive::builder::RoadNetworkBuilder>(road_network_configuration);
 
   std::string name = FLAGS_xodr_file;
   name.erase(name.begin(), name.begin() + name.rfind("/") + 1);
@@ -92,12 +91,7 @@ int Main(int argc, char** argv) {
 
   maliput::utility::ObjFeatures features;
   features.min_grid_resolution = 5.0;
-  maliput::utility::GenerateObjFile(
-    road_network->road_geometry(),
-    FLAGS_out_dir,
-    name,
-    features
-  );
+  maliput::utility::GenerateObjFile(road_network->road_geometry(), FLAGS_out_dir, name, features);
   return 0;
 }
 

--- a/src/applications/xodr_to_obj.cc
+++ b/src/applications/xodr_to_obj.cc
@@ -1,7 +1,6 @@
 // BSD 3-Clause License
 //
-// Copyright (c) 2022, Woven Planet. All rights reserved.
-// Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
+// Copyright (c) 2023, Woven Planet. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -28,7 +27,7 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Validates a XODR map.
+// Generates an OBJ from an XODR map.
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -36,10 +35,14 @@
 #include <string>
 
 #include <gflags/gflags.h>
+#include <maliput/common/filesystem.h>
 #include <maliput/common/logger.h>
+#include <maliput/utility/generate_obj.h>
 
 #include "applications/log_level_flag.h"
-#include "maliput_malidrive/xodr/db_manager.h"
+
+#include "maliput_malidrive/builder/road_network_builder.h"
+#include "maliput_malidrive/loader/loader.h"
 
 namespace malidrive {
 namespace applications {
@@ -49,13 +52,14 @@ namespace {
 // @return A string with the usage message.
 std::string GetUsageMessage() {
   std::stringstream ss;
-  ss << "CLI for XODR validation:" << std::endl << std::endl;
-  ss << "  xodr_validate --xodr_file=<xodr_file_path>" << std::endl;
+  ss << "CLI for XODR to OBJ conversion:" << std::endl << std::endl;
+  ss << "  xodr_to_obj --xodr_file=<path> --out-dir=<path> --tolerance=<float> [--allow-schema-errors] [--allow-semantic-errors]" << std::endl;
   return ss.str();
 }
 
 // @{ CLI Arguments
 DEFINE_string(xodr_file, "", "XODR input file defining a Malidrive road geometry");
+DEFINE_string(out_dir, ".", "Directory to save the OBJ to");
 DEFINE_double(tolerance, 1e-3, "Tolerance to validate continuity in piecewise defined geometries.");
 DEFINE_bool(allow_schema_errors, false, "If true, the XODR parser will attempt to work around XODR schema violations.");
 DEFINE_bool(allow_semantic_errors, false,
@@ -75,15 +79,25 @@ int Main(int argc, char** argv) {
   maliput::log()->info("Parser: Allow schema errors: ", (FLAGS_allow_schema_errors ? "enabled" : "disabled"));
   maliput::log()->info("Parser: Allow semantic errors: ", (FLAGS_allow_semantic_errors ? "enabled" : "disabled"));
 
-  // Tries to load the XODR map and logs the result.
-  try {
-    auto db_manager = malidrive::xodr::LoadDataBaseFromFile(
-        FLAGS_xodr_file, {FLAGS_tolerance, FLAGS_allow_schema_errors, FLAGS_allow_semantic_errors});
-    std::cout << "Successfully loaded the map." << std::endl;
-  } catch (const std::exception& e) {
-    std::cerr << e.what() << std::endl;
-    std::cerr << "The map could not be loaded." << std::endl;
-  }
+  // Load the road network
+  std::map<std::string, std::string> road_network_configuration;
+  road_network_configuration.emplace("opendrive_file", FLAGS_xodr_file);
+  auto road_network = malidrive::loader::Load<malidrive::builder::RoadNetworkBuilder>(
+    road_network_configuration
+  );
+
+  std::string name = FLAGS_xodr_file;
+  name.erase(name.begin(), name.begin() + name.rfind("/") + 1);
+  name.erase(name.begin() + name.rfind("."), name.end());
+
+  maliput::utility::ObjFeatures features;
+  features.min_grid_resolution = 5.0;
+  maliput::utility::GenerateObjFile(
+    road_network->road_geometry(),
+    FLAGS_out_dir,
+    name,
+    features
+  );
   return 0;
 }
 


### PR DESCRIPTION
# 🎉 New feature

Adds a command line utility for dumping .obj/.mtl files from an xodr.

Also:
* Bugfixes the return values of all applications to 0 on success
* Adds an xodr that is currently unsupported (spiral geometries) <- I was trying to get a .obj of this road network

## Summary

Not fancy, but has the basics for getting a .obj file.

## Test it

```
bazel run //:xodr_to_obj -- --xodr-file=${PWD}/resources/Town07.xodr --out-dir=${PWD}
```

