### PR TITLE
Adds spiral geometry parsing capabilities

### DIFF
--- a/src/maliput_malidrive/xodr/geometry.cc
+++ b/src/maliput_malidrive/xodr/geometry.cc
@@ -34,12 +34,12 @@ namespace xodr {
 namespace {
 
 // Map for Type to string conversion.
-const std::map<Geometry::Type, std::string> type_to_str_map{{Geometry::Type::kLine, "line"},
-                                                            {Geometry::Type::kArc, "arc"}};
+const std::map<Geometry::Type, std::string> type_to_str_map{
+    {Geometry::Type::kLine, "line"}, {Geometry::Type::kArc, "arc"}, {Geometry::Type::kSpiral, "spiral"}};
 
 // Map for string to Type conversion.
-const std::map<std::string, Geometry::Type> str_to_type_map{{"line", Geometry::Type::kLine},
-                                                            {"arc", Geometry::Type::kArc}};
+const std::map<std::string, Geometry::Type> str_to_type_map{
+    {"line", Geometry::Type::kLine}, {"arc", Geometry::Type::kArc}, {"spiral", Geometry::Type::kSpiral}};
 
 }  // namespace
 
@@ -66,6 +66,10 @@ std::ostream& operator<<(std::ostream& os, const Geometry& geometry) {
       os << " - curvature: " << std::get<xodr::Geometry::Arc>(geometry.description).curvature;
       break;
     case Geometry::Type::kLine:
+      break;
+    case Geometry::Type::kSpiral:
+      os << " - curvature at [start, end]: [" << std::get<xodr::Geometry::Spiral>(geometry.description).curv_start;
+      os << ", " << std::get<xodr::Geometry::Spiral>(geometry.description).curv_end << "]";
       break;
     default:
       MALIPUT_THROW_MESSAGE("Unknown Geometry::Type");

--- a/src/maliput_malidrive/xodr/geometry.h
+++ b/src/maliput_malidrive/xodr/geometry.h
@@ -55,6 +55,9 @@ namespace xodr {
 ///               <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="100.0">
 ///                   <arc curvature="0.025"/>
 ///               </geometry>
+///               <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="100.0">
+///                   <spiral curvStart="0.025" curvEnd="0.05"/>
+///               </geometry>
 ///           </planView>
 ///       ...
 ///   </OpenDRIVE>
@@ -72,6 +75,7 @@ struct Geometry {
   enum class Type {
     kLine = 0,
     kArc,
+    kSpiral,
   };
 
   /// Line geometry description.
@@ -89,6 +93,21 @@ struct Geometry {
 
     /// Equality operator.
     bool operator==(const Arc& other) const { return curvature == other.curvature; }
+  };
+
+  /// Spiral geometry description.
+  struct Spiral {
+    /// Holds the tag name in the XODR Geometry description.
+    static constexpr const char* kCurvStart = "curvStart";
+    static constexpr const char* kCurvEnd = "curvEnd";
+
+    /// Spiral's start curvature.
+    double curv_start{};
+    /// Spiral's end curvature.
+    double curv_end{};
+
+    /// Equality operator.
+    bool operator==(const Spiral& other) const { return curv_start == other.curv_start && curv_end == other.curv_end; }
   };
 
   /// Matches string with a Type.
@@ -119,7 +138,7 @@ struct Geometry {
   /// Type of geometric element.
   Type type{Type::kLine};
   /// Description of the geometric type.
-  std::variant<Line, Arc> description;
+  std::variant<Line, Arc, Spiral> description;
 };
 
 /// Streams a string representation of @p geometry into @p os.

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -385,6 +385,20 @@ Geometry::Arc NodeParser::As() const {
   return Geometry::Arc{ValidateDouble(curvature, kDontAllowNan)};
 }
 
+// Specialization to parse `Spiral`'s node.
+template <>
+Geometry::Spiral NodeParser::As() const {
+  if (NumberOfAttributes() != 2) {
+    MALIDRIVE_THROW_MESSAGE(std::string("Bad Spiral description. Spiral demands only two arguments: 'curvStart' and "
+                                        "'curvEnd'. ") +
+                            ConvertXMLNodeToText(element_));
+  }
+  const AttributeParser attribute_parser(element_, parser_configuration_);
+  const auto curv_start = attribute_parser.As<double>(Geometry::Spiral::kCurvStart);
+  const auto curv_end = attribute_parser.As<double>(Geometry::Spiral::kCurvEnd);
+  return Geometry::Spiral{ValidateDouble(curv_start, kDontAllowNan), ValidateDouble(curv_end, kDontAllowNan)};
+}
+
 // Specialization to parse `LaneWidth`'s node.
 template <>
 LaneWidth NodeParser::As() const {
@@ -688,6 +702,9 @@ Geometry NodeParser::As() const {
       break;
     case Geometry::Type::kArc:
       geometry.description = geometry_type.As<Geometry::Arc>();
+      break;
+    case Geometry::Type::kSpiral:
+      geometry.description = geometry_type.As<Geometry::Spiral>();
       break;
     default:
       MALIDRIVE_THROW_MESSAGE(std::string("The Geometry type '") + Geometry::type_to_str(geometry.type) +

--- a/test/regression/xodr/geometry_test.cc
+++ b/test/regression/xodr/geometry_test.cc
@@ -124,9 +124,9 @@ GTEST_TEST(Geometry, ArcGeometrySerialization) {
 GTEST_TEST(Geometry, SpiralGeometrySerialization) {
   const Geometry kGeometrySpiral{
       1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},     0.77 /* orientation */,
-      100. /* length */, Geometry::Type::kSpiral /* Type */, {Geometry::Spiral{1.95, 0.5}} /* description */};
+      100. /* length */, Geometry::Type::kSpiral /* Type */, {Geometry::Spiral{-1.95, -0.5}} /* description */};
   const std::string kExpectedStrGeometrySpiral(
-      "Geometry type: spiral - curvature at [start, end]: [1.95, 0.5] | s: 1.23 | {x, y} : {523.2, 83.27} | hdg: "
+      "Geometry type: spiral - curvature at [start, end]: [-1.95, -0.5] | s: 1.23 | {x, y} : {523.2, 83.27} | hdg: "
       "0.77\n");
   std::stringstream ss;
   ss << kGeometrySpiral;

--- a/test/regression/xodr/geometry_test.cc
+++ b/test/regression/xodr/geometry_test.cc
@@ -39,16 +39,21 @@ namespace xodr {
 namespace test {
 namespace {
 
+static constexpr char kLineTypeStr[]{"line"};
+static constexpr char kArcTypeStr[]{"arc"};
+static constexpr char kSpiralTypeStr[]{"spiral"};
+
 GTEST_TEST(Geometry, TypeToStrMethod) {
-  const std::string kExpectedStr{"line"};
-  EXPECT_EQ(kExpectedStr, Geometry::type_to_str(Geometry::Type::kLine));
+  EXPECT_EQ(kLineTypeStr, Geometry::type_to_str(Geometry::Type::kLine));
+  EXPECT_EQ(kArcTypeStr, Geometry::type_to_str(Geometry::Type::kArc));
+  EXPECT_EQ(kSpiralTypeStr, Geometry::type_to_str(Geometry::Type::kSpiral));
 }
 
 GTEST_TEST(Geometry, StrToTypeMethod) {
-  const Geometry::Type kExpectedType{Geometry::Type::kLine};
-  const std::string kTypeStr{"line"};
   const std::string kWrongTypeStr{"WrongType"};
-  EXPECT_EQ(kExpectedType, Geometry::str_to_type(kTypeStr));
+  EXPECT_EQ(Geometry::Type::kLine, Geometry::str_to_type(kLineTypeStr));
+  EXPECT_EQ(Geometry::Type::kArc, Geometry::str_to_type(kArcTypeStr));
+  EXPECT_EQ(Geometry::Type::kSpiral, Geometry::str_to_type(kSpiralTypeStr));
   EXPECT_THROW(Geometry::str_to_type(kWrongTypeStr), maliput::common::assertion_error);
 }
 
@@ -83,24 +88,49 @@ GTEST_TEST(Geometry, EqualityOperator) {
   EXPECT_NE(geometry, geometry_arc);
   geometry.description = Geometry::Arc{0.5};
   EXPECT_EQ(geometry, geometry_arc);
+
+  Geometry geometry_spiral = kGeometry;
+  geometry_spiral.type = Geometry::Type::kSpiral;
+  geometry_spiral.description = Geometry::Spiral{0.5, 0.25};
+  EXPECT_NE(kGeometry, geometry_spiral);
+  geometry.type = Geometry::Type::kSpiral;
+  geometry.description = Geometry::Spiral{0.25, 0.5};
+  EXPECT_NE(geometry, geometry_spiral);
+  geometry.description = Geometry::Spiral{0.5, 0.25};
+  EXPECT_EQ(geometry, geometry_spiral);
 }
 
-GTEST_TEST(Geometry, Serialization) {
+GTEST_TEST(Geometry, LineGeometrySerialization) {
   const Geometry kGeometryLine{
       1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},   0.77 /* orientation */,
       100. /* length */, Geometry::Type::kLine /* Type */, {Geometry::Line{}} /* description */};
   const std::string kExpectedStrGeometryLine("Geometry type: line | s: 1.23 | {x, y} : {523.2, 83.27} | hdg: 0.77\n");
-  const Geometry kGeometryARc{
+  std::stringstream ss;
+  ss << kGeometryLine;
+  EXPECT_EQ(kExpectedStrGeometryLine, ss.str());
+}
+
+GTEST_TEST(Geometry, ArcGeometrySerialization) {
+  const Geometry kGeometryArc{
       1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},  0.77 /* orientation */,
       100. /* length */, Geometry::Type::kArc /* Type */, {Geometry::Arc{1.95}} /* description */};
   const std::string kExpectedStrGeometryArc(
       "Geometry type: arc - curvature: 1.95 | s: 1.23 | {x, y} : {523.2, 83.27} | hdg: 0.77\n");
   std::stringstream ss;
-  ss << kGeometryLine;
-  EXPECT_EQ(kExpectedStrGeometryLine, ss.str());
-  ss.str("");
-  ss << kGeometryARc;
+  ss << kGeometryArc;
   EXPECT_EQ(kExpectedStrGeometryArc, ss.str());
+}
+
+GTEST_TEST(Geometry, SpiralGeometrySerialization) {
+  const Geometry kGeometrySpiral{
+      1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},     0.77 /* orientation */,
+      100. /* length */, Geometry::Type::kSpiral /* Type */, {Geometry::Spiral{1.95, 0.5}} /* description */};
+  const std::string kExpectedStrGeometrySpiral(
+      "Geometry type: spiral - curvature at [start, end]: [1.95, 0.5] | s: 1.23 | {x, y} : {523.2, 83.27} | hdg: "
+      "0.77\n");
+  std::stringstream ss;
+  ss << kGeometrySpiral;
+  EXPECT_EQ(kExpectedStrGeometrySpiral, ss.str());
 }
 
 }  // namespace

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -454,7 +454,7 @@ TEST_F(ParsingTests, NodeParserArcGeometry) {
 TEST_F(ParsingTests, NodeParserSpiralGeometry) {
   const Geometry kExpectedGeometry{
       1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},     0.77 /* orientation */,
-      100. /* length */, Geometry::Type::kSpiral /* Type */, Geometry::Spiral{0.5, 0.25} /* description */};
+      100. /* length */, Geometry::Type::kSpiral /* Type */, Geometry::Spiral{0.5, -0.25} /* description */};
   const std::string geometry_description =
       Geometry::type_to_str(kExpectedGeometry.type) + " " + Geometry::Spiral::kCurvStart + "='" +
       std::to_string(std::get<Geometry::Spiral>(kExpectedGeometry.description).curv_start) + "' " +

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -450,6 +450,27 @@ TEST_F(ParsingTests, NodeParserArcGeometry) {
   EXPECT_EQ(kExpectedGeometry, geometry);
 }
 
+// Tests `Geometry` parsing.
+TEST_F(ParsingTests, NodeParserSpiralGeometry) {
+  const Geometry kExpectedGeometry{
+      1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},     0.77 /* orientation */,
+      100. /* length */, Geometry::Type::kSpiral /* Type */, Geometry::Spiral{0.5, 0.25} /* description */};
+  const std::string geometry_description =
+      Geometry::type_to_str(kExpectedGeometry.type) + " " + Geometry::Spiral::kCurvStart + "='" +
+      std::to_string(std::get<Geometry::Spiral>(kExpectedGeometry.description).curv_start) + "' " +
+      Geometry::Spiral::kCurvEnd + "='" +
+      std::to_string(std::get<Geometry::Spiral>(kExpectedGeometry.description).curv_end) + "'";
+  const std::string xml_description =
+      GetGeometry(kExpectedGeometry.s_0, kExpectedGeometry.start_point.x(), kExpectedGeometry.start_point.y(),
+                  kExpectedGeometry.orientation, kExpectedGeometry.length, geometry_description);
+
+  const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Geometry::kGeometryTag),
+                       {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
+  EXPECT_EQ(Geometry::kGeometryTag, dut.GetName());
+  const Geometry geometry = dut.As<Geometry>();
+  EXPECT_EQ(kExpectedGeometry, geometry);
+}
+
 // Get a XML description that contains a XODR PlanView.
 // @param s_0 The s_0 value of first geometry.
 // @param x_0 The x_0 value of first geometry.


### PR DESCRIPTION
# 🎉 New feature

Related to #260 

## Summary

From OpenDRIVE Format Specification 1.5: 
```
This record describes a spiral as part of the road’s reference line. For this type of spiral, the curvature
change between start and end of the element is linear.

In order to provide consistency between spiral evaluations of various implementations, users are
highly recommended to use identical algorithms, or, at least, algorithms with reasonable accuracy
within the applicable range (i.e. curvature, length of spiral etc.).

The theory of clothoids is described (for example) at
http://en.wikipedia.org/wiki/Euler_spiral
A library for computing clothoids can be downloaded at
http://www.opendrive.org/downloads/spiral.zip
```


![image](https://github.com/maliput/maliput_malidrive/assets/53065142/d8b17177-9a65-4ce0-9146-b770c15524e6)


## Test it!

After building and sourcing.

```
xodr_query src/maliput_malidrive/resources/SpiralRoad.xodr GetGeometries 1
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
