### PR TITLE
Enables spiral geometries parsing.

### DIFF
--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -385,6 +385,20 @@ Geometry::Arc NodeParser::As() const {
   return Geometry::Arc{ValidateDouble(curvature, kDontAllowNan)};
 }
 
+// Specialization to parse `Spiral`'s node.
+template <>
+Geometry::Spiral NodeParser::As() const {
+  if (NumberOfAttributes() != 2) {
+    MALIDRIVE_THROW_MESSAGE(std::string("Bad Spiral description. Spiral demands only two arguments: 'curvStart' and "
+                                        "'curvEnd'. ") +
+                            ConvertXMLNodeToText(element_));
+  }
+  const AttributeParser attribute_parser(element_, parser_configuration_);
+  const auto curv_start = attribute_parser.As<double>(Geometry::Spiral::kCurvStart);
+  const auto curv_end = attribute_parser.As<double>(Geometry::Spiral::kCurvEnd);
+  return Geometry::Spiral{ValidateDouble(curv_start, kDontAllowNan), ValidateDouble(curv_end, kDontAllowNan)};
+}
+
 // Specialization to parse `LaneWidth`'s node.
 template <>
 LaneWidth NodeParser::As() const {
@@ -688,6 +702,9 @@ Geometry NodeParser::As() const {
       break;
     case Geometry::Type::kArc:
       geometry.description = geometry_type.As<Geometry::Arc>();
+      break;
+    case Geometry::Type::kSpiral:
+      geometry.description = geometry_type.As<Geometry::Spiral>();
       break;
     default:
       MALIDRIVE_THROW_MESSAGE(std::string("The Geometry type '") + Geometry::type_to_str(geometry.type) +

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -450,6 +450,27 @@ TEST_F(ParsingTests, NodeParserArcGeometry) {
   EXPECT_EQ(kExpectedGeometry, geometry);
 }
 
+// Tests `Geometry` parsing.
+TEST_F(ParsingTests, NodeParserSpiralGeometry) {
+  const Geometry kExpectedGeometry{
+      1.23 /* s_0 */,    {523.2 /* x */, 83.27 /* y */},     0.77 /* orientation */,
+      100. /* length */, Geometry::Type::kSpiral /* Type */, Geometry::Spiral{0.5, 0.25} /* description */};
+  const std::string geometry_description =
+      Geometry::type_to_str(kExpectedGeometry.type) + " " + Geometry::Spiral::kCurvStart + "='" +
+      std::to_string(std::get<Geometry::Spiral>(kExpectedGeometry.description).curv_start) + "' " +
+      Geometry::Spiral::kCurvEnd + "='" +
+      std::to_string(std::get<Geometry::Spiral>(kExpectedGeometry.description).curv_end) + "'";
+  const std::string xml_description =
+      GetGeometry(kExpectedGeometry.s_0, kExpectedGeometry.start_point.x(), kExpectedGeometry.start_point.y(),
+                  kExpectedGeometry.orientation, kExpectedGeometry.length, geometry_description);
+
+  const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Geometry::kGeometryTag),
+                       {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
+  EXPECT_EQ(Geometry::kGeometryTag, dut.GetName());
+  const Geometry geometry = dut.As<Geometry>();
+  EXPECT_EQ(kExpectedGeometry, geometry);
+}
+
 // Get a XML description that contains a XODR PlanView.
 // @param s_0 The s_0 value of first geometry.
 // @param x_0 The x_0 value of first geometry.


### PR DESCRIPTION
# 🎉 New feature

Goes on top of https://github.com/maliput/maliput_malidrive/pull/261
Related to #260 

## Summary
 - Parses Spiral Geometries

## Test it!

After building and sourcing.

```
xodr_query src/maliput_malidrive/resources/SpiralRoad.xodr GetGeometries 1
```


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
