### PR TITLE
[infra] use the REAL bazel central registry

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,11 @@
 # use --enable_bzlmod on the command line.
 common --enable_bzlmod
 
-# TODO(daniel.stonier) Delete once 'yaml-cpp' has made it into the official BCR
-common --registry=https://raw.githubusercontent.com/stonier/bazel-central-registry/maliput_releases/
+# A local fork of the registry:
+# common --registry=file://%workspace%/../bazel-central-registry
+
+# Central Registry
+build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/
 
 ########################################
 # Bazel Configuration

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: stonier
+  email: d.stonier@gmail.com

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/maliput/maliput_malidrive",
+    "maintainers": [
+      {
+        "name": "Daniel Stonier",
+        "email": "d.stonier@gmail.com",
+        "github": "stonier"
+      }
+    ],
+    "repository": [
+      "github:maliput/maliput_malidrive"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+  }

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,16 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["ubuntu2004"]  # "debian10", "macos", "windows"
+  tasks:
+    verify_targets:
+      name: Verify Build Targets
+      platform: ${{ platform }}
+      build_targets:
+        - '@maliput_malidrive//:maliput_malidrive'
+    # TODO(stonier): no tests yet...
+    # run_tests:
+    #   name: "Run test module"
+    #   platform: ${{ platform }}
+    #   test_targets:
+    #     - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "",
+    "strip_prefix": "{REPO}-{VERSION}",
+    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: gcc
+name: Build
 
 on:
   pull_request:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,4 +1,4 @@
-name: containers
+name: Containers
 
 permissions: write-all
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+# Cuts a github release with a stable release archive [1] from a *.*.* tag.
+#
+# [1] See https://blog.bazel.build/2023/02/15/github-archive-checksum.html
+# for why source code assets are not stable).
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set Variables
+        shell: bash
+        run: echo "ARCHIVE_NAME=${{ github.event.repository.name }}-${GITHUB_REF_NAME}" >> $GITHUB_ENV
+      - name: Variables
+        run: |
+          echo "Repository Name: ${{ github.event.repository.name }}"
+          echo "GITHUB_REF: ${GITHUB_REF}"
+          echo "GITUB_REF_NAME: ${GITHUB_REF_NAME}"
+          echo "ARCHIVE_NAME: ${{ env.ARCHIVE_NAME }}"
+      - name: Create Release Asset
+        shell: bash
+        run: git archive $GITHUB_REF --prefix=${{ env.ARCHIVE_NAME }}/ -o "${{ env.ARCHIVE_NAME }}.tar.gz"
+      - name: Cut a Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          prerelease: false
+          files: ${{ env.ARCHIVE_NAME }}.tar.gz

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,4 +1,4 @@
-name: clang
+name: Sanitizers
 
 on:
   pull_request:

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -1,4 +1,4 @@
-name: scan_build
+name: Scan Build
 
 on:
   pull_request:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.1.1")
+bazel_dep(name = "maliput", version = "1.2.0")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)


### PR DESCRIPTION
# 🎉 New feature

Migrate to the BCR (for both fetching dependencies and publishing of this package)

## Summary

* Points bazel at the REAL BCR, not our fork
* CI automation for cutting releases and PR'ing the BCR
* Updates the dependency on maliput to that found on the BCR
* (other) Name consistency for CI workflows

