### PR TITLE
Extends coverage of the SpiralGroundCurve and fixes some bugs

### DIFF
--- a/src/maliput_malidrive/road_curve/spiral_ground_curve.h
+++ b/src/maliput_malidrive/road_curve/spiral_ground_curve.h
@@ -59,9 +59,6 @@ namespace road_curve {
 /// <a href="https://github.com/pageldev/libOpenDRIVE/blob/master/LICENSE">Apache License 2.0</a>
 /// <a
 /// href="https://github.com/pageldev/libOpenDRIVE/blob/9a0437f8a18d445d5c43fe2a4c9401d8a4b770f0/src/Geometries/Spiral.cpp">Spiral.cpp</a>
-///
-/// This implementation does not admit different signs in the start and end curvatures.
-// TODO(#265): Evaluate start and end curvature being of different sign.
 class SpiralGroundCurve : public GroundCurve {
  public:
   MALIDRIVE_NO_COPY_NO_MOVE_NO_ASSIGN(SpiralGroundCurve);
@@ -77,11 +74,11 @@ class SpiralGroundCurve : public GroundCurve {
   /// @param curvature0 Quantity which indicates the reciprocal of the
   ///        turning radius of the arc at @p p0. A positive @p curvature0 makes a
   ///        counterclockwise turn. It must be different from @p curvature1 by at least
-  ///        GroundCurve::kEpsilon. It must be of the same sign as @p curvature1.
+  ///        GroundCurve::kEpsilon.
   /// @param curvature1 Quantity which indicates the reciprocal of the
   ///        turning radius of the arc at @p p1. A positive @p curvature1 makes a
   ///        counterclockwise turn. It must be different from @p curvature1 by at least
-  ///        GroundCurve::kEpsilon. It must be of the same sign as @p curvature0.
+  ///        GroundCurve::kEpsilon.
   /// @param arc_length The spiral's length. It must be greate-r or equal to
   ///        GroundCurve::kEpsilon.
   /// @param p0 The value of the @f$ p @f$ parameter at the beginning of the
@@ -92,9 +89,7 @@ class SpiralGroundCurve : public GroundCurve {
   /// @throws maliput::common::assertion_error When @p linear_tolerance is
   ///         non-positive.
   /// @throws maliput::common::assertion_error When @p curvature0 is
-  ///         different from @p curvature1 by less than  GroundCurve::kEpsilon.
-  /// @throws maliput::common::assertion_error When @p curvature0 and @p curvature1
-  ///         have a different sign.
+  ///         different from @p curvature1 by less than GroundCurve::kEpsilon.
   /// @throws maliput::common::assertion_error When @p arc_length is smaller
   ///         than GroundCurve::kEpsilon.
   /// @throws maliput::common::assertion_error When @p p0 is negative.
@@ -150,7 +145,7 @@ class SpiralGroundCurve : public GroundCurve {
   // Heading of the normalized spiral at `p0_`.
   const double spiral_heading0_{};
   // Start position of the spiral in the normalized spiral frame.
-  const maliput::math::Vector2 spiral_xy0_{};
+  maliput::math::Vector2 spiral_xy0_{};
 };
 
 }  // namespace road_curve


### PR DESCRIPTION
# 🎉 New feature

Part of #265 
Goes on top of #271 

## Summary
Fixes some bugs, extends coverage, but still is tested against normalized curvatures. It is not functional yet a proper ground curve but provides a good testing base and leaves that to a future PR.
The issue with normalization is that the general math resources considers the length from the curvature = 0 to a certain curvature and not a particular inter non-zero curvature extensions which makes it trickier to get it right. A future PR will address exactly that.

## Test it

Via unit testing.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
