### PR TITLE
uAdds bazel version information to presubmit.yml file.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,15 +1,18 @@
 bcr_test_module:
   module_path: "."
   matrix:
+    bazel: [6.x]
     platform: ["ubuntu2004"]  # "debian10", "macos", "windows"
   tasks:
     verify_targets:
       name: Verify Build Targets
+      bazel: ${{ bazel }}
       platform: ${{ platform }}
       build_targets:
         - '@maliput_malidrive//:maliput_malidrive'
     run_tests:
       name: "Run test module"
+      bazel: ${{ bazel }}
       platform: ${{ platform }}
       test_targets:
         - "//..."


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/maliput/maliput-rs/pull/10#issuecomment-1932037818
Related to https://github.com/bazelbuild/bazel-central-registry/pull/1423

## Summary
Adds bazel version to presubmit.yml file. This is required by the bazel registry CI

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
