### PR TITLE
SpiralGroundCurve with tests.

### DIFF
--- a/src/maliput_malidrive/road_curve/CMakeLists.txt
+++ b/src/maliput_malidrive/road_curve/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(road_curve
   piecewise_ground_curve.cc
   road_curve.cc
   road_curve_offset.cc
+  spiral_ground_curve.cc
 )
 add_library(maliput_malidrive::road_curve ALIAS road_curve)
 set_target_properties(road_curve

--- a/src/maliput_malidrive/road_curve/spiral_ground_curve.cc
+++ b/src/maliput_malidrive/road_curve/spiral_ground_curve.cc
@@ -1,0 +1,200 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven Planet. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/road_curve/spiral_ground_curve.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <maliput/math/fresnel.h>
+
+namespace malidrive {
+namespace road_curve {
+namespace {
+
+// Rotates @p v by @p angle.
+// @param v Input 2D vector to rotate.
+// @param angle Input angle to rotate.
+// @return The rotated vector.
+inline maliput::math::Vector2 RotateVector(const maliput::math::Vector2& v, double angle) {
+  const double ca = std::cos(angle);
+  const double sa = std::sin(angle);
+  return maliput::math::Vector2{ca * v.x() - sa * v.y(), sa * v.x() + ca * v.y()};
+}
+
+// Conditionally shifts the y-component of @p v when @p cond is true.
+// @param v Input vector.
+// @param cond Conditional flag.
+// @return When @p cond is true, returns `[v.x(), -v.y()]`, otherwise @p v.
+inline maliput::math::Vector2 ConditionalShiftYComponent(const maliput::math::Vector2& v, bool cond) {
+  return cond ? maliput::math::Vector2{v.x(), -v.y()} : v;
+}
+
+// Finds the best p parameter for @p curve that maps a point in the 2D INERTIAL-Frame that minimizes
+// the distance to @p point.
+// @details The function implements a binary search within a range trying to minimize the distance against
+// @p point. The range is split into equal @p partitions. The search can be early terminated if any of the
+// extents of the range at each iteration is within @p tolerance.
+// @param curve The SpiralGoundCurve to use.
+// @param point The point in the 2D INERTIAL-Frame to find a p parameter value for.
+// @param p0 The p parameter start range value. It must be non-negative.
+// @param p1 The p parameter end range value. It must be greater than @p p0 by GroundCurve::kEpsilon.
+// @param partitions The number of partitions of the range [@p p0; @p p1]. It must be greater or equal to 2.
+// @param tolerance The tolereance to early stop the search. It must be non-negative.
+// @return The p parameter value that minimizes the distance against @p point.
+double FindBestPParameter(const SpiralGroundCurve& curve, const maliput::math::Vector2& point, double p0, double p1,
+                          size_t partitions, double tolerance) {
+  MALIPUT_THROW_UNLESS(p0 >= 0.);
+  MALIPUT_THROW_UNLESS(p1 - p0 >= GroundCurve::kEpsilon);
+  MALIPUT_THROW_UNLESS(partitions >= 2u);
+  MALIPUT_THROW_UNLESS(tolerance >= 0.);
+
+  const size_t kIterations{2u * static_cast<size_t>(std::ceil(std::log(partitions))) + 1u};
+  // Initialize the list of p values.
+  std::vector<double> p_values(partitions);
+  const double step = (p1 - p0) / static_cast<double>(partitions - 1u);
+  for (size_t i = 0u; i < partitions - 1u; ++i) {
+    p_values[i] = p0 + static_cast<double>(i) * step;
+  }
+  p_values[partitions - 1u] = p1;
+
+  // Find the p-value that minimizes the distance to the target point using a binary search
+  // across the list of p values.
+  size_t start_i{0u};
+  size_t end_i{partitions - 1u};
+  double start_distance{std::numeric_limits<double>::max()};
+  double end_distance{std::numeric_limits<double>::max()};
+  for (size_t iter = 0u; iter < kIterations; ++iter) {
+    const maliput::math::Vector2 start_point = curve.G(p_values[start_i]);
+    const maliput::math::Vector2 end_point = curve.G(p_values[end_i]);
+    start_distance = (start_point - point).norm();
+    end_distance = (end_point - point).norm();
+    // Early termination conditions.
+    if (start_distance <= tolerance || end_distance <= tolerance) {
+      break;
+    }
+    if ((end_i - start_i) <= 1u) {
+      break;
+    }
+    // Index adjustment for the next iteration.
+    if (start_distance <= end_distance) {
+      end_i = std::ceil((end_i + start_i) / 2u);
+    } else {
+      start_i = std::floor((end_i + start_i) / 2u);
+    }
+  }
+  return start_distance <= end_distance ? p_values[start_i] : p_values[end_i];
+}
+
+}  // namespace
+
+SpiralGroundCurve::SpiralGroundCurve(double linear_tolerance, const maliput::math::Vector2& xy0, double heading0,
+                                     double curvature0, double curvature1, double arc_length, double p0, double p1)
+    : linear_tolerance_(linear_tolerance),
+      xy0_(xy0),
+      heading0_(heading0),
+      curvature0_(curvature0),
+      curvature1_(curvature1),
+      arc_length_(arc_length),
+      k_dot_((curvature1 - curvature0) / arc_length),
+      norm_(std::sqrt(M_PI / std::abs(k_dot_))),
+      t0_(curvature0 / (k_dot_ * norm_)),
+      xy0_spiral_(ConditionalShiftYComponent(maliput::math::ComputeFresnelCosineAndSine(t0_) * norm_, k_dot_ < 0.)),
+      heading0_spiral_(maliput::math::FresnelSpiralHeading(t0_, k_dot_)),
+      p0_(p0),
+      p1_(p1),
+      validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_,
+                                                                               GroundCurve::kEpsilon)) {
+  MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0);
+  MALIDRIVE_THROW_UNLESS(arc_length_ >= GroundCurve::kEpsilon);
+  MALIDRIVE_THROW_UNLESS(p0_ >= 0.);
+  MALIDRIVE_THROW_UNLESS(p1_ - p0_ >= GroundCurve::kEpsilon);
+  MALIDRIVE_THROW_UNLESS(std::abs(curvature1_ - curvature0_) >= GroundCurve::kEpsilon);
+}
+
+maliput::math::Vector2 SpiralGroundCurve::DoG(double p) const {
+  p = validate_p_(p);
+  const double t = TFromP(p);
+  const maliput::math::Vector2 xy =
+      ConditionalShiftYComponent(maliput::math::ComputeFresnelCosineAndSine(t) * norm_, k_dot_ < 0.) - xy0_spiral_;
+  const double heading = Heading(p);
+  return RotateVector(xy, heading) + xy0_;
+}
+
+maliput::math::Vector2 SpiralGroundCurve::DoGDot(double p) const {
+  const double heading = Heading(p);
+  return maliput::math::Vector2{std::cos(heading), std::sin(heading)};
+}
+
+double SpiralGroundCurve::DoGInverse(const maliput::math::Vector2& point) const {
+  static constexpr size_t kMaxIterations{10u};
+  static constexpr size_t kPartitionSize{1000u};
+
+  // Initializes the error and the extents of the range to search.
+  double start_p = p0_;
+  double end_p = p1_;
+  double best_p = p0_;
+  // Iterates in the search to get a better precision of the p value.
+  for (size_t i = 0; i < kMaxIterations; ++i) {
+    // Obtains the best p parameter value for the given range.
+    best_p = FindBestPParameter(*this, point, start_p, end_p, kPartitionSize, linear_tolerance_);
+    // Computes the error, i.e. distance to the point to match. When the error
+    // is less or equal to linear_tolerance, there is no need to continue iterating.
+    if ((G(best_p) - point).norm() <= linear_tolerance_) {
+      return best_p;
+    }
+    // Creates a new extent whose range is step. Note that FindBestPParameter
+    // returns the minimum out of the two possible values in the range.
+    const double step = (end_p - start_p) / static_cast<double>(kPartitionSize);
+    start_p = std::max(p0_, best_p - step);
+    end_p = std::min(p1_, best_p + step);
+    // When the range has been constrained beyond the GroundCurve::kEpsilon, we should
+    // return to avoid further numerical error even if the parameter is not good enough.
+    if ((end_p - start_p) < GroundCurve::kEpsilon) {
+      return best_p;
+    }
+  }
+
+  return best_p;
+}
+
+double SpiralGroundCurve::DoHeading(double p) const {
+  p = validate_p_(p);
+  const double t = TFromP(p);
+  const double heading_fresnel = maliput::math::FresnelSpiralHeading(t, k_dot_);
+  return heading_fresnel - heading0_spiral_ + heading0_;
+}
+
+double SpiralGroundCurve::DoHeadingDot(double p) const {
+  p = validate_p_(p);
+  const double t = TFromP(p);
+  return maliput::math::FresnelSpiralHeadingDot(t, k_dot_);
+}
+
+}  // namespace road_curve
+}  // namespace malidrive

--- a/src/maliput_malidrive/road_curve/spiral_ground_curve.h
+++ b/src/maliput_malidrive/road_curve/spiral_ground_curve.h
@@ -1,0 +1,133 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven Planet. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <cmath>
+
+#include <maliput/common/range_validator.h>
+#include <maliput/math/vector.h>
+
+#include "maliput_malidrive/common/macros.h"
+#include "maliput_malidrive/road_curve/ground_curve.h"
+
+namespace malidrive {
+namespace road_curve {
+
+/// GroundCurve specification for a reference curve that describes a clothoid or
+/// Euler spiral.
+///
+/// Queries accept p ∈ [p0, p1] with a linear tolerance.
+class SpiralGroundCurve : public GroundCurve {
+ public:
+  MALIDRIVE_NO_COPY_NO_MOVE_NO_ASSIGN(SpiralGroundCurve);
+
+  SpiralGroundCurve() = delete;
+
+  /// Constructs an SpiralGroundCurve.
+  ///
+  /// @param linear_tolerance A non-negative value expected to be the same as
+  /// maliput::api::RoadGeometry::linear_tolerance().
+  /// @param xy0 A 2D vector that represents the first point of the spiral.
+  /// @param heading0 The orientation of the tangent vector at @p xy0.
+  /// @param curvature0 The curvature of the spiral at @p p0. The absolute difference
+  ///        of the curvatures at @p p1 and @p p0 must be greater than GroundCurve::kEpsilon.
+  /// @param curvature1 The curvature of the spiral at @p p1. The absolute difference
+  ///        of the curvatures at @p p1 and @p p0 must be greater than GroundCurve::kEpsilon.
+  /// @param arc_length The spiral's length. It must be greater or equal to
+  ///        GroundCurve::kEpsilon.
+  /// @param p0 The value of the @f$ p @f$ parameter at the beginning of the
+  ///        spiral, which must be non negative and smaller than @p p1 by at least
+  ///        GroundCurve::kEpsilon.
+  /// @param p1 The value of the @f$ p @f$ parameter at the end of the spiral,
+  ///        which must be greater than @p p0 by at least GroundCurve::kEpsilon.
+  /// @throws maliput::common::assertion_error When @p linear_tolerance is
+  ///         non-positive.
+  /// @throws maliput::common::assertion_error When @p arc_length is smaller
+  ///         than GroundCurve::kEpsilon.
+  /// @throws maliput::common::assertion_error When @p p0 is negative.
+  /// @throws maliput::common::assertion_error When @p p1 is not sufficiently
+  ///         larger than @p p0.
+  SpiralGroundCurve(double linear_tolerance, const maliput::math::Vector2& xy0, double heading0, double curvature0,
+                    double curvature1, double arc_length, double p0, double p1);
+
+ private:
+  // @{ NVI implementations.
+  double DoPFromP(double xodr_p) const override { return validate_p_(xodr_p); }
+  double DoArcLength() const override { return arc_length_; }
+  double do_linear_tolerance() const override { return linear_tolerance_; }
+  double do_p0() const override { return p0_; }
+  double do_p1() const override { return p1_; }
+  bool DoIsG1Contiguous() const override { return true; }
+  maliput::math::Vector2 DoG(double p) const override;
+  maliput::math::Vector2 DoGDot(double p) const override;
+  double DoGInverse(const maliput::math::Vector2&) const override;
+  double DoHeading(double p) const override;
+  double DoHeadingDot(double p) const override;
+  // @} NVI implementations.
+
+  // Converts the @p p value into a spiral t coordinate.
+  // Offsets @p p by `p0_`, scales the difference by `norm_` and then offsets it by `t0_`.
+  // @param p The parameter of the GroundCurve.
+  // @return The normalized parameter of the spiral.
+  inline double TFromP(double p) const { return (p - p0_) / norm_ + t0_; }
+
+  // The linear tolerance.
+  const double linear_tolerance_{};
+  // The first point of the spiral in the Inertial Frame coordinates.
+  const maliput::math::Vector2 xy0_{};
+  // The heading at `p0_`.
+  const double heading0_{};
+  // The curvature of the spiral at `p0_`.
+  const double curvature0_{};
+  // The curvature of the spiral at `p1_`.
+  const double curvature1_{};
+  // The length of the spiral.
+  const double arc_length_{};
+  // The derivative of the spiral.
+  const double k_dot_{};
+  // The normalization factor that is used to scale p and the spiral parameter.
+  const double norm_{};
+  // The value that the normalized spiral parameter takes at `p0_`.
+  const double t0_{};
+  // The position of the spiral at `p0_` before applying any isometry to respect the initial pose (`heading0_` and
+  // `xy0_`).
+  const maliput::math::Vector2 xy0_spiral_{};
+  // The heading of the spiral at `p0_` before applying any isometry to respect the initial pose (`heading0_` and
+  // `xy0_`).
+  const double heading0_spiral_{};
+  // The value of the p parameter at the start of the spiral.
+  const double p0_{};
+  // The value of the p parameter at the end of the spiral.
+  const double p1_{};
+  // Validates that p is within [p0, p1] with linear_tolerance.
+  const maliput::common::RangeValidator validate_p_;
+};
+
+}  // namespace road_curve
+}  // namespace malidrive

--- a/test/regression/road_curve/CMakeLists.txt
+++ b/test/regression/road_curve/CMakeLists.txt
@@ -21,6 +21,7 @@ set(UNIT_TEST_ROAD_CURVE_SOURCES
   road_curve_test.cc
   road_curve_offset_test.cc
   scaled_domain_function_test.cc
+  spiral_ground_curve_test.cc
 )
 
 maliput_malidrive_build_tests(${UNIT_TEST_ROAD_CURVE_SOURCES})

--- a/test/regression/road_curve/spiral_ground_curve_test.cc
+++ b/test/regression/road_curve/spiral_ground_curve_test.cc
@@ -1,0 +1,609 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven Planet. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/road_curve/spiral_ground_curve.h"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+#include <maliput/common/assertion_error.h>
+#include <maliput/math/compare.h>
+#include <maliput/math/vector.h>
+
+#include "assert_compare.h"
+
+namespace malidrive {
+namespace road_curve {
+namespace test {
+namespace {
+
+using malidrive::test::AssertCompare;
+using maliput::math::CompareVectors;
+using maliput::math::Vector2;
+
+// Test class to validate the constructor constraints of the SpiralGroundCurve.
+class SpiralGroundCurveConstructorTest : public ::testing::Test {
+ protected:
+  static constexpr double kLinearTolerance{1e-9};
+  const Vector2 kXy0{1., 0.};
+  static constexpr double kStartHeading{1.23};
+  static constexpr double kStartCurvature{0.1};
+  static constexpr double kEndCurvature{0.01};
+  static constexpr double kArcLength{100.};
+  static constexpr double kP0{1.};
+  static constexpr double kP1{10.};
+};
+
+TEST_F(SpiralGroundCurveConstructorTest, CorrectlyConstructedDoesNotThrow) {
+  EXPECT_NO_THROW(
+      SpiralGroundCurve(kLinearTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kArcLength, kP0, kP1));
+}
+
+TEST_F(SpiralGroundCurveConstructorTest, NegativeLinearToleranceThrows) {
+  static constexpr double kNegativeTolerance{-1.0};
+  EXPECT_THROW(
+      {
+        SpiralGroundCurve(kNegativeTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kArcLength, kP0,
+                          kP1);
+      },
+      maliput::common::assertion_error);
+}
+
+TEST_F(SpiralGroundCurveConstructorTest, SameCurvatureThrows) {
+  static constexpr double kSameCurvature{0.01};
+  EXPECT_THROW(
+      {
+        SpiralGroundCurve(kLinearTolerance, kXy0, kStartHeading, kSameCurvature, kSameCurvature, kArcLength, kP0, kP1);
+      },
+      maliput::common::assertion_error);
+}
+
+TEST_F(SpiralGroundCurveConstructorTest, SmallArcLengthThrows) {
+  static constexpr double kSmallArcLength{GroundCurve::kEpsilon / 2.};
+  EXPECT_THROW(
+      {
+        SpiralGroundCurve(kLinearTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kSmallArcLength, kP0,
+                          kP1);
+      },
+      maliput::common::assertion_error);
+}
+
+TEST_F(SpiralGroundCurveConstructorTest, NegativeP0Throws) {
+  static constexpr double kNegativeP0{-1.};
+  EXPECT_THROW(
+      {
+        SpiralGroundCurve(kLinearTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kArcLength,
+                          kNegativeP0, kP1);
+      },
+      maliput::common::assertion_error);
+}
+
+TEST_F(SpiralGroundCurveConstructorTest, NegativeP1Throws) {
+  static constexpr double kNegativeP1{-1.};
+  EXPECT_THROW(
+      {
+        SpiralGroundCurve(kLinearTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kArcLength, kP0,
+                          kNegativeP1);
+      },
+      maliput::common::assertion_error);
+}
+
+TEST_F(SpiralGroundCurveConstructorTest, P0AndP1AreAlmostEqualThrows) {
+  static constexpr double kAlmostP0P1{kP0 + GroundCurve::kEpsilon / 2.};
+  EXPECT_THROW(
+      {
+        SpiralGroundCurve(kLinearTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kArcLength, kP0,
+                          kAlmostP0P1);
+      },
+      maliput::common::assertion_error);
+}
+
+// Test class to validate the correct value retrieval of the accessors.
+class SpiralGroundCurveAccessorsTest : public ::testing::Test {
+ protected:
+  static constexpr double kTolerance{1e-12};
+  static constexpr double kLinearTolerance{1e-9};
+  const Vector2 kXy0{1., 0.};
+  static constexpr double kStartHeading{1.23};
+  static constexpr double kStartCurvature{0.1};
+  static constexpr double kEndCurvature{0.01};
+  static constexpr double kArcLength{100.};
+  static constexpr double kP0{1.};
+  static constexpr double kP1{10.};
+  const SpiralGroundCurve dut_{kLinearTolerance, kXy0,       kStartHeading, kStartCurvature,
+                               kEndCurvature,    kArcLength, kP0,           kP1};
+};
+
+TEST_F(SpiralGroundCurveAccessorsTest, LinearTolerance) {
+  EXPECT_NEAR(kLinearTolerance, dut_.linear_tolerance(), kTolerance);
+}
+
+TEST_F(SpiralGroundCurveAccessorsTest, p0) { EXPECT_NEAR(kP0, dut_.p0(), kTolerance); }
+
+TEST_F(SpiralGroundCurveAccessorsTest, p1) { EXPECT_NEAR(kP1, dut_.p1(), kTolerance); }
+
+TEST_F(SpiralGroundCurveAccessorsTest, ArcLength) { EXPECT_NEAR(kArcLength, dut_.ArcLength(), kTolerance); }
+
+TEST_F(SpiralGroundCurveAccessorsTest, IsG1Contiguous) { EXPECT_TRUE(dut_.IsG1Contiguous()); }
+
+// Approximates a path length lower bound for the given @p dut
+// from @p p0 to @p p1, by computing the same integral for a 2^@p k_order
+// linear approximation.
+//
+// @param dut The SpiralGroundCurve to compute path length for.
+// @param p0 The lower integration bound for the @f$ p @f$ coordinate.
+// @param p1 The upper integration bound for the @f$ p @f$ coordinate.
+// @param k_order Order k of the linear approximation, i.e. 2^k segments
+//                are used in the approximation.
+// @pre Given lower integration bound @p p0 doesn't meet the range `[road_curve.p0() ; road_curve.p1()]`
+// @pre Given upper integration bound @p p1 doesn't meet the range `[road_curve.p0() ; road_curve.p1()]`
+// @pre Given lower integration bound @p p0 is greater than or equal to 0.
+// @pre Given upper integration bound @p p1 is greater than or equal to the given lower integration bound @p p0.
+// @pre Given @p k_order for the linear approximation is a non-negative number.
+// @throws maliput::common::assertion_error if preconditions are not met.
+double BruteForcePathLengthIntegral(const SpiralGroundCurve& dut, double p0, double p1, int k_order) {
+  MALIDRIVE_IS_IN_RANGE(p0, dut.p0(), dut.p1());
+  MALIDRIVE_IS_IN_RANGE(p1, dut.p0(), dut.p1());
+  MALIPUT_THROW_UNLESS(p1 >= 0.);
+  MALIPUT_THROW_UNLESS(p1 >= p0);
+  MALIPUT_THROW_UNLESS(k_order >= 0);
+
+  double length = 0.0;
+  const int iterations = std::pow(2, k_order);
+  const double step_p = (p1 - p0) / static_cast<double>(iterations);
+  // Splits the [p0, p1] interval in 2^k intervals, computes the positions
+  // in the global frame for each interval boundary and sums up the path lengths
+  // of the segments in the global frame that correspond to each one of those
+  // intervals.
+  Vector2 pos_prev_p = dut.G(p0);
+  for (int i = 1; i <= iterations; ++i) {
+    const double p = p0 + static_cast<double>(i) * step_p;
+    const Vector2 pos_p = dut.G(p);
+    const double ith_step_length = (pos_p - pos_prev_p).norm();
+    length += ith_step_length;
+    pos_prev_p = pos_p;
+  }
+
+  return length;
+}
+
+// Evaluates the SpiralGroundCurve with a normalized spiral.
+// This tests asserts the internal Fresnel power series expansion are correct
+// when the normalization factors do not intervene.
+// Values here were retrieved against an alternative and simpler implementation in python
+// which does not account for normalization factors and evaluates directly the parameters.
+// A witness python script is provided below:
+// @code{.py}
+// import numpy as np
+// import math
+// import scipy.special as sp
+//
+// def rot_vec(x, y, angle):
+//     ca = math.cos(angle)
+//     sa = math.sin(angle)
+//     return (x * ca - y * sa, x * sa + y * ca)
+//
+// def fresnel(t):
+//     yx = sp.fresnel(t)
+//     return np.array([yx[1], yx[0]])
+//
+// def fresnel_heading(t, k_dot):
+//     return 0.5 * t * t * k_dot
+//
+// def heading(t, heading0, k_dot, heading0_spiral):
+//     return fresnel_heading(t, k_dot) - heading0_spiral + heading0
+//
+// def heading_dot(t, k_dot):
+//     return t * k_dot
+//
+// def g(t, heading0, norm, k_dot, heading0_spiral, xy0_spiral):
+//     xy = np.array(fresnel(t) * norm) - xy0_spiral
+//     h = heading(t, heading0, k_dot, heading0_spiral)
+//     x, y = rot_vec(xy[0], xy[1], h)
+//     return np.array([x, y])
+//
+// def g_dot(t, heading0, k_dot, heading0_spiral):
+//     h = heading(t, heading0, k_dot, heading0_spiral)
+//     return np.array([np.cos(h), np.sin(h)])
+//
+// def t_from_p(p, s0_spiral, norm):
+//     return (p - 0 + s0_spiral) / norm
+//
+// def arc_length(t1, heading0, k_order, norm, k_dot, heading0_spiral, xy0_spiral):
+//     iters = 2 ** k_order
+//     step_t = t1 / iters
+//     xy_prev = g(0, heading0, norm, k_dot, heading0_spiral, xy0_spiral)
+//     l = 0.
+//     for i in range(1, iters+1):
+//         t = step_t * i
+//         xy = g(t, heading0, norm, k_dot, heading0_spiral, xy0_spiral)
+//         l += np.linalg.norm(xy - xy_prev)
+//         xy_prev = xy
+//     return l
+//
+// # Change the following items to reproduce test results {
+// k0 = 0.
+// k1 = 0.2
+// L = 10.
+// heading0 = 0.
+// # }
+//
+// k_dot = (k1 - k0) / L
+// norm = math.sqrt(math.pi / abs(k_dot))
+// s0_spiral = k0 / k_dot
+// xy0_spiral = np.array(sp.fresnel(s0_spiral / norm)) * norm
+// heading0_spiral = fresnel_heading(s0_spiral / norm, k_dot)
+//
+// P = np.array([0., 5., 10.0])
+//
+// T = t_from_p(P, s0_spiral, norm)
+//
+// print(f"k_dot:{k_dot:.10f}")
+// print(f"norm:{norm:.10f}")
+// print(f"s0_spiral:{s0_spiral:.10f}")
+// print(f"xy0_spiral:{xy0_spiral}")
+// print(f"heading0_spiral:{heading0_spiral:.10f}")
+// print(f"heading0:{heading0:.10f}")
+// print("---")
+//
+// for i in range(0, len(T)):
+//     xy = g(T[i], heading0, norm, k_dot, heading0_spiral, xy0_spiral)
+//     xy_dot = g_dot(T[i], heading0, k_dot, heading0_spiral)
+//     h = heading(T[i], heading0, k_dot, heading0_spiral)
+//     h_dot = heading_dot(T[i], k_dot)
+//     print(f"t:{T[i]} , p:{P[i]}")
+//     print(f"g({T[i]}): ({xy[0]:.10f} , {xy[1]:.10f})")
+//     print(f"g_dot({T[i]}): ({xy_dot[0]:.10f} , {xy_dot[1]:.10f})")
+//     print(f"heading({T[i]}): {h}")
+//     print(f"heading_dot({T[i]}): {h_dot}")
+//     print(f"arc_length({T[i]}): {arc_length(T[i], heading0, 5, norm, k_dot, heading0_spiral, xy0_spiral)}")
+//     print("---")
+// @code
+// </pre>
+
+// Base class containing tolerances and brute force integration parameters.
+class BaseSpiralGroundCurveTest : public ::testing::Test {
+ protected:
+  static constexpr double kLinearTolerance{1e-10};
+  static constexpr double kGInverseTolerance{5e-2};  // TODO: reduce to 1e-6 or smaller.
+  static constexpr int kOrder{7};
+  static constexpr double kToleranceForBruteForceIntegral{5e-2};  // TODO: reduce to 1e-6 or smaller.
+};
+
+// Tests the SpiralGroundCurve with a curvature derivative of one, making it normalized.
+class NormalizedSpiralGroundCurveTest : public BaseSpiralGroundCurveTest {
+ protected:
+  const Vector2 kXy0{0., 0.};
+  static constexpr double kStartHeading{0.};
+  static constexpr double kStartCurvature{0.};
+  static constexpr double kEndCurvature{1.};
+  static constexpr double kArcLength{1.};
+  static constexpr double kP0{0.};
+  static constexpr double kMidP{0.5};
+  static constexpr double kP1{1.};
+  const SpiralGroundCurve dut_{kLinearTolerance, kXy0,       kStartHeading, kStartCurvature,
+                               kEndCurvature,    kArcLength, kP0,           kP1};
+};
+
+TEST_F(NormalizedSpiralGroundCurveTest, G) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({0., 0.}, dut_.G(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.4979964103, 0.0406516876}, dut_.G(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9370155385, 0.3162123412}, dut_.G(kP1), kLinearTolerance)));
+}
+
+TEST_F(NormalizedSpiralGroundCurveTest, GDot) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({1., 0.}, dut_.GDot(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9992085327, 0.0397782381}, dut_.GDot(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9873615638, 0.1584838866}, dut_.GDot(kP1), kLinearTolerance)));
+}
+
+TEST_F(NormalizedSpiralGroundCurveTest, Heading) {
+  EXPECT_NEAR(0., dut_.Heading(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.03978873577297383, dut_.Heading(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.15915494309189532, dut_.Heading(kP1), kLinearTolerance);
+}
+
+TEST_F(NormalizedSpiralGroundCurveTest, HeadingDot) {
+  EXPECT_NEAR(0., dut_.HeadingDot(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.28209479177387814, dut_.HeadingDot(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.5641895835477563, dut_.HeadingDot(kP1), kLinearTolerance);
+}
+
+TEST_F(NormalizedSpiralGroundCurveTest, GInverse) {
+  EXPECT_NEAR(kP0, dut_.GInverse({0., 0.}), kGInverseTolerance);
+  EXPECT_NEAR(kMidP, dut_.GInverse({0.4979964103, 0.0406516876}), kGInverseTolerance);
+  EXPECT_NEAR(kP1, dut_.GInverse({0.9370155385, 0.3162123412}), kGInverseTolerance);
+}
+
+TEST_F(NormalizedSpiralGroundCurveTest, ProperNormalizationYieldsArcLengthToBekP1MinuskP0) {
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kMidP, kOrder), dut_.ArcLength() / 2.,
+              kToleranceForBruteForceIntegral);
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kP1, kOrder), dut_.ArcLength(), kToleranceForBruteForceIntegral);
+}
+
+// Tests that an offset in the p-parameter of the GroundCurve does not affect the resulting geometry.
+class OffsetPNormalizedSpiralGroundCurveTest : public BaseSpiralGroundCurveTest {
+ protected:
+  const Vector2 kXy0{0., 0.};
+  static constexpr double kStartHeading{0.};
+  static constexpr double kStartCurvature{0.};
+  static constexpr double kEndCurvature{1.};
+  static constexpr double kArcLength{1.};
+  static constexpr double kP0{10.};
+  static constexpr double kMidP{10.5};
+  static constexpr double kP1{11.};
+  const SpiralGroundCurve dut_{kLinearTolerance, kXy0,       kStartHeading, kStartCurvature,
+                               kEndCurvature,    kArcLength, kP0,           kP1};
+};
+
+TEST_F(OffsetPNormalizedSpiralGroundCurveTest, G) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({0., 0.}, dut_.G(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.4979964103, 0.0406516876}, dut_.G(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9370155385, 0.3162123412}, dut_.G(kP1), kLinearTolerance)));
+}
+
+TEST_F(OffsetPNormalizedSpiralGroundCurveTest, GDot) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({1., 0.}, dut_.GDot(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9992085327, 0.0397782381}, dut_.GDot(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9873615638, 0.1584838866}, dut_.GDot(kP1), kLinearTolerance)));
+}
+
+TEST_F(OffsetPNormalizedSpiralGroundCurveTest, Heading) {
+  EXPECT_NEAR(0., dut_.Heading(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.03978873577297383, dut_.Heading(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.15915494309189532, dut_.Heading(kP1), kLinearTolerance);
+}
+
+TEST_F(OffsetPNormalizedSpiralGroundCurveTest, HeadingDot) {
+  EXPECT_NEAR(0., dut_.HeadingDot(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.28209479177387814, dut_.HeadingDot(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.5641895835477563, dut_.HeadingDot(kP1), kLinearTolerance);
+}
+
+TEST_F(OffsetPNormalizedSpiralGroundCurveTest, GInverse) {
+  EXPECT_NEAR(kP0, dut_.GInverse({0., 0.}), kGInverseTolerance);
+  EXPECT_NEAR(kMidP, dut_.GInverse({0.4968840292, 0.0414810243}), kGInverseTolerance);
+  EXPECT_NEAR(kP1, dut_.GInverse({0.9045242379, 0.3102683017}), kGInverseTolerance);
+}
+
+// Check the internal normalization parameter does not affect the construct arc length.
+TEST_F(OffsetPNormalizedSpiralGroundCurveTest, ProperNormalizationYieldsArcLengthToBekP1MinuskP0) {
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kMidP, kOrder), dut_.ArcLength() / 2.,
+              kToleranceForBruteForceIntegral);
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kP1, kOrder), dut_.ArcLength(), kToleranceForBruteForceIntegral);
+}
+
+// Tests how the spiral evolves with a positive curvatures but negative curvature derivative.
+class InvertedCurvatureNormalizedSpiralGroundCurveTest : public BaseSpiralGroundCurveTest {
+ protected:
+  const Vector2 kXy0{0., 0.};
+  static constexpr double kStartHeading{0.};
+  static constexpr double kStartCurvature{1.};
+  static constexpr double kEndCurvature{0.};
+  static constexpr double kArcLength{1.};
+  static constexpr double kP0{0.};
+  static constexpr double kMidP{0.5};
+  static constexpr double kP1{1.};
+  const SpiralGroundCurve dut_{kLinearTolerance, kXy0,       kStartHeading, kStartCurvature,
+                               kEndCurvature,    kArcLength, kP0,           kP1};
+};
+
+TEST_F(InvertedCurvatureNormalizedSpiralGroundCurveTest, G) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({0., 0.}, dut_.G(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.4896982421, -0.0851954681}, dut_.G(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9889076155, -0.0070775745}, dut_.G(kP1), kLinearTolerance)));
+}
+
+TEST_F(InvertedCurvatureNormalizedSpiralGroundCurveTest, GDot) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({1., 0.}, dut_.GDot(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9928843092, 0.1190829484}, dut_.GDot(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9873615638, 0.1584838866}, dut_.GDot(kP1), kLinearTolerance)));
+}
+
+TEST_F(InvertedCurvatureNormalizedSpiralGroundCurveTest, Heading) {
+  EXPECT_NEAR(0., dut_.Heading(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.11936620731892149, dut_.Heading(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.15915494309189532, dut_.Heading(kP1), kLinearTolerance);
+}
+
+TEST_F(InvertedCurvatureNormalizedSpiralGroundCurveTest, HeadingDot) {
+  EXPECT_NEAR(0.5641895835477563, dut_.HeadingDot(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.28209479177387814, dut_.HeadingDot(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0., dut_.HeadingDot(kP1), kLinearTolerance);
+}
+
+TEST_F(InvertedCurvatureNormalizedSpiralGroundCurveTest, GInverse) {
+  EXPECT_NEAR(kP0, dut_.GInverse({0., 0.}), kGInverseTolerance);
+  EXPECT_NEAR(kMidP, dut_.GInverse({0.4896982421, -0.0851954681}), kGInverseTolerance);
+  EXPECT_NEAR(kP1, dut_.GInverse({0.9889076155, -0.0070775745}), kGInverseTolerance);
+}
+
+// Check the internal normalization parameter does not affect the construct arc length.
+TEST_F(InvertedCurvatureNormalizedSpiralGroundCurveTest, ProperNormalizationYieldsArcLengthToBekP1MinuskP0) {
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kMidP, kOrder), dut_.ArcLength() / 2.,
+              kToleranceForBruteForceIntegral);
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kP1, kOrder), dut_.ArcLength(), kToleranceForBruteForceIntegral);
+}
+
+// Tests how the spiral evolves with a negative curvature derivative.
+class InvertedCurvatureGradientNormalizedSpiralGroundCurveTest : public BaseSpiralGroundCurveTest {
+ protected:
+  const Vector2 kXy0{0., 0.};
+  static constexpr double kStartHeading{0.};
+  static constexpr double kStartCurvature{0.};
+  static constexpr double kEndCurvature{-1.};
+  static constexpr double kArcLength{1.};
+  static constexpr double kP0{0.};
+  static constexpr double kMidP{0.5};
+  static constexpr double kP1{1.};
+  const SpiralGroundCurve dut_{kLinearTolerance, kXy0,       kStartHeading, kStartCurvature,
+                               kEndCurvature,    kArcLength, kP0,           kP1};
+};
+
+TEST_F(InvertedCurvatureGradientNormalizedSpiralGroundCurveTest, G) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({0., 0.}, dut_.G(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.4979964103, -0.0406516876}, dut_.G(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9370155385, -0.3162123412}, dut_.G(kP1), kLinearTolerance)));
+}
+
+TEST_F(InvertedCurvatureGradientNormalizedSpiralGroundCurveTest, GDot) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({1., 0.}, dut_.GDot(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9992085327, -0.0397782381}, dut_.GDot(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9873615638, -0.1584838866}, dut_.GDot(kP1), kLinearTolerance)));
+}
+
+TEST_F(InvertedCurvatureGradientNormalizedSpiralGroundCurveTest, Heading) {
+  EXPECT_NEAR(0., dut_.Heading(kP0), kLinearTolerance);
+  EXPECT_NEAR(-0.03978873577297383, dut_.Heading(kMidP), kLinearTolerance);
+  EXPECT_NEAR(-0.15915494309189532, dut_.Heading(kP1), kLinearTolerance);
+}
+
+TEST_F(InvertedCurvatureGradientNormalizedSpiralGroundCurveTest, HeadingDot) {
+  EXPECT_NEAR(0., dut_.HeadingDot(kP0), kLinearTolerance);
+  EXPECT_NEAR(-0.28209479177387814, dut_.HeadingDot(kMidP), kLinearTolerance);
+  EXPECT_NEAR(-0.5641895835477563, dut_.HeadingDot(kP1), kLinearTolerance);
+}
+
+TEST_F(InvertedCurvatureGradientNormalizedSpiralGroundCurveTest, GInverse) {
+  EXPECT_NEAR(kP0, dut_.GInverse({0., 0.}), kGInverseTolerance);
+  EXPECT_NEAR(kMidP, dut_.GInverse({0.4979964103, -0.0406516876}), kGInverseTolerance);
+  EXPECT_NEAR(kP1, dut_.GInverse({0.9370155385, -0.3162123412}), kGInverseTolerance);
+}
+
+TEST_F(InvertedCurvatureGradientNormalizedSpiralGroundCurveTest, ProperNormalizationYieldsArcLengthToBekP1MinuskP0) {
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kMidP, kOrder), dut_.ArcLength() / 2.,
+              kToleranceForBruteForceIntegral);
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kP1, kOrder), dut_.ArcLength(), kToleranceForBruteForceIntegral);
+}
+
+// Test that the start non zero heading rotates the spiral by that angle.
+class HeadingOffsetNormalizedSpiralGroundCurveTest : public BaseSpiralGroundCurveTest {
+ protected:
+  const Vector2 kXy0{0., 0.};
+  static constexpr double kStartHeading{M_PI * 0.25};
+  static constexpr double kStartCurvature{0.};
+  static constexpr double kEndCurvature{1.};
+  static constexpr double kArcLength{1.};
+  static constexpr double kP0{0.};
+  static constexpr double kMidP{0.5};
+  static constexpr double kP1{1.};
+  const SpiralGroundCurve dut_{kLinearTolerance, kXy0,       kStartHeading, kStartCurvature,
+                               kEndCurvature,    kArcLength, kP0,           kP1};
+};
+
+TEST_F(HeadingOffsetNormalizedSpiralGroundCurveTest, G) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({0., 0.}, dut_.G(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.3233915547, 0.3808817227}, dut_.G(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.4389741506, 0.8861659321}, dut_.G(kP1), kLinearTolerance)));
+}
+
+TEST_F(HeadingOffsetNormalizedSpiralGroundCurveTest, GDot) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.7071067812, 0.7071067812}, dut_.GDot(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.6784196674, 0.7346745912}, dut_.GDot(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.5861050263, 0.8102350882}, dut_.GDot(kP1), kLinearTolerance)));
+}
+
+TEST_F(HeadingOffsetNormalizedSpiralGroundCurveTest, Heading) {
+  EXPECT_NEAR(0.7853981633974483, dut_.Heading(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.8251868991704221, dut_.Heading(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.9445531064893435, dut_.Heading(kP1), kLinearTolerance);
+}
+
+TEST_F(HeadingOffsetNormalizedSpiralGroundCurveTest, HeadingDot) {
+  EXPECT_NEAR(0., dut_.HeadingDot(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.28209479177387814, dut_.HeadingDot(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.5641895835477563, dut_.HeadingDot(kP1), kLinearTolerance);
+}
+
+TEST_F(HeadingOffsetNormalizedSpiralGroundCurveTest, GInverse) {
+  EXPECT_NEAR(kP0, dut_.GInverse({0., 0.}), kGInverseTolerance);
+  EXPECT_NEAR(kMidP, dut_.GInverse({0.3233915547, 0.3808817227}), kGInverseTolerance);
+  EXPECT_NEAR(kP1, dut_.GInverse({0.4389741506, 0.8861659321}), kGInverseTolerance);
+}
+
+TEST_F(HeadingOffsetNormalizedSpiralGroundCurveTest, ProperNormalizationYieldsArcLengthToBekP1MinuskP0) {
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kMidP, kOrder), dut_.ArcLength() / 2.,
+              kToleranceForBruteForceIntegral);
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kP1, kOrder), dut_.ArcLength(), kToleranceForBruteForceIntegral);
+}
+
+// Tests the case in which the curvature derivative is not normalized.
+class DenormalizedSpiralGroundCurveTest : public BaseSpiralGroundCurveTest {
+ protected:
+  const Vector2 kXy0{0., 0.};
+  static constexpr double kStartHeading{0.};
+  static constexpr double kStartCurvature{0.};
+  static constexpr double kEndCurvature{0.2};
+  static constexpr double kArcLength{10.};
+  static constexpr double kP0{0.};
+  static constexpr double kMidP{5.};
+  static constexpr double kP1{10.};
+  const SpiralGroundCurve dut_{kLinearTolerance, kXy0,       kStartHeading, kStartCurvature,
+                               kEndCurvature,    kArcLength, kP0,           kP1};
+};
+
+TEST_F(DenormalizedSpiralGroundCurveTest, G) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({0., 0.}, dut_.G(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({4.9681738083, 0.4227178689}, dut_.G(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({9.0253069245, 3.1602035564}, dut_.G(kP1), kLinearTolerance)));
+}
+
+TEST_F(DenormalizedSpiralGroundCurveTest, GDot) {
+  EXPECT_TRUE(AssertCompare(CompareVectors({1., 0.}, dut_.GDot(kP0), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9999987335, 0.0015915488}, dut_.GDot(kMidP), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors({0.9999797358, 0.0063661547}, dut_.GDot(kP1), kLinearTolerance)));
+}
+
+TEST_F(DenormalizedSpiralGroundCurveTest, Heading) {
+  EXPECT_NEAR(0., dut_.Heading(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.0015915494309189536, dut_.Heading(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.006366197723675814, dut_.Heading(kP1), kLinearTolerance);
+}
+
+TEST_F(DenormalizedSpiralGroundCurveTest, HeadingDot) {
+  EXPECT_NEAR(0., dut_.HeadingDot(kP0), kLinearTolerance);
+  EXPECT_NEAR(0.007978845608028654, dut_.HeadingDot(kMidP), kLinearTolerance);
+  EXPECT_NEAR(0.015957691216057307, dut_.HeadingDot(kP1), kLinearTolerance);
+}
+
+TEST_F(DenormalizedSpiralGroundCurveTest, GInverse) {
+  EXPECT_NEAR(kP0, dut_.GInverse({0., 0.}), kGInverseTolerance);
+  EXPECT_NEAR(kMidP, dut_.GInverse({4.9681738083, 0.4227178689}), kGInverseTolerance);
+  EXPECT_NEAR(kP1, dut_.GInverse({9.0253069245, 3.1602035564}), kGInverseTolerance);
+}
+
+TEST_F(DenormalizedSpiralGroundCurveTest, ProperNormalizationYieldsArcLengthToBekP1MinuskP0) {
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kMidP, kOrder), dut_.ArcLength() / 2.,
+              kToleranceForBruteForceIntegral);
+  EXPECT_NEAR(BruteForcePathLengthIntegral(dut_, kP0, kP1, kOrder), dut_.ArcLength(), kToleranceForBruteForceIntegral);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace road_curve
+}  // namespace malidrive


### PR DESCRIPTION
# 🎉 New feature

Part of #265 

## Summary
Provides a spiral based `GroundCurve`.
This implementation uses the functions that maliput::math brings in that belong to the Cephes library. On top of that, it adds some customization that the libOpenDrive library incorporates as ad-hoc customizations.

The result is a tested GroundCurve implementation that explores different conditions of the input parameters such that multiple cases are evaluated shuffling input curvatures, initial pose and arc length of the spiral.

Due to numerical error, tolerances are yet to be constrained for the inverse and the brute force integral comparison.

## Test it

Via unit tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
