### PR TITLE
Prepare for release 0.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package maliput_malidrive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.0 (2024-04-29)
+------------------
+* Flags spiral support. (`#279 <https://github.com/ToyotaResearchInstitute/maliput_malidrive/issues/279>`_)
+* Spiral Lane integration (`#277 <https://github.com/ToyotaResearchInstitute/maliput_malidrive/issues/277>`_)
+* Adds bazel version information to presubmit.yml file. (`#275 <https://github.com/ToyotaResearchInstitute/maliput_malidrive/issues/275>`_)
+* Add curbs to the builder. (`#274 <https://github.com/ToyotaResearchInstitute/maliput_malidrive/issues/274>`_)
+
+  ---------
+* Contributors: Agustin Alba Chicar, Franco Cipollone
+
 0.2.1 (2024-02-02)
 ------------------
 * [bazel] Guarantee shared library creation for the plugin (`#269 <https://github.com/maliput/maliput_malidrive/issues/269>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##############################################################################
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(maliput_malidrive LANGUAGES C CXX VERSION 0.2.1)
+project(maliput_malidrive LANGUAGES C CXX VERSION 0.3.0)
 
 ##############################################################################
 # CMake Support

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,14 +5,14 @@ Welcome to Maliput Malidrive!
 module(
     name = "maliput_malidrive",
     compatibility_level = 1,
-    version = "0.2.1",
+    version = "0.3.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.2.0")
+bazel_dep(name = "maliput", version = "1.3.0")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>maliput_malidrive</name>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
   <description>maliput_malidrive backend</description>
   <license file="LICENSE">BSD Clause 3</license>
   <maintainer email="andrew.best@tri.global">Andrew Best</maintainer>


### PR DESCRIPTION
# 🎉 New feature

Prepare for release 0.3.0

## Summary

Depends on:
- #279
- https://github.com/maliput/maliput/pull/630 and the posterior bazel release.

## Test it
N/A

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
