### PR TITLE
Bazel: Bumps maliput to 1.3.1.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.3.0")
+bazel_dep(name = "maliput", version = "1.3.1")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)


### PR DESCRIPTION
# 🎉 New feature

## Summary

Point to latest maliput version in BCR. Related to https://github.com/maliput/maliput/pull/641

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

