### PR TITLE
Support to bazel 8.x.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  bazel: [6.x, 7.x]
+  bazel: [6.x, 7.x, 8.x]
   platform: ["ubuntu2004"]  # "debian10", "macos", "windows"
 tasks:
   verify_targets:
@@ -14,7 +14,7 @@ tasks:
 bcr_test_module:
   module_path: "."
   matrix:
-    bazel: [6.x, 7.x]
+    bazel: [6.x, 7.x, 8.x]
     platform: ["ubuntu2004"]  # "debian10", "macos", "windows"
   tasks:
     run_tests:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -104,14 +104,6 @@ cc_library(
 )
 
 cc_library(
-    name = "private_loader_headers",
-    hdrs = glob(["src/maliput_malidrive/loader/*.h"]),
-    copts = COPTS,
-    strip_include_prefix = "src",
-    visibility = ["//visibility:private"],
-)
-
-cc_library(
     name = "loader",
     srcs = glob(["src/maliput_malidrive/loader/*.cc"]),
     hdrs = glob(["include/maliput_malidrive/loader/*.h"]),
@@ -119,7 +111,6 @@ cc_library(
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
-        ":private_loader_headers",
         ":builder",
         ":common",
         "@maliput//:api",


### PR DESCRIPTION
# 🎉 New feature

## Summary
- Removes unnecessary library that bazel 8.x was complaining about due to unresolved regex 
- Adds 8.x to bcr's presubmit

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
