### PR TITLE
Useful conversions from Maliput to OpenScenario Position types.

### DIFF
--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -427,25 +427,11 @@ RoadGeometry::OpenScenarioRoadPosition RoadGeometry::MaliputRoadPositionToOpenSc
   const auto mali_lane = dynamic_cast<const Lane*>(road_position.lane);
   xodr_road_position.road_id = mali_lane->get_track();
   xodr_road_position.s = mali_lane->TrackSFromLaneS(road_position.pos.s());
+
+  double t = mali_lane->to_reference_r(xodr_road_position.s, road_position.pos.r());
   const auto segment = dynamic_cast<const Segment*>(mali_lane->segment());
-  double t = 0.;
-
-  int t_direction = mali_lane->get_lane_id() > 0 ? 1 : -1;
-  int n_lanes = segment->num_lanes();
-  // Start at 1 to ignore lane 0.
-  for (int i = 1; i < std::abs(mali_lane->get_lane_id()); ++i) {
-    int index = n_lanes / 2 + i * t_direction + (t_direction > 0 ? -1 : 0);
-    const Lane* curr_mali_lane = dynamic_cast<const Lane*>(segment->lane(index));
-    const double width = curr_mali_lane->lane_width_at(xodr_road_position.s);
-    const double roll_at_p = segment->road_curve()->superelevation()->f(xodr_road_position.s);
-    t += width * std::cos(roll_at_p) * t_direction;
-  }
-
   const double roll_at_p = segment->road_curve()->superelevation()->f(xodr_road_position.s);
-  const double width = mali_lane->lane_width_at(xodr_road_position.s);
-  t += (road_position.pos.r() * t_direction + width / 2.) * std::cos(roll_at_p) * t_direction;
-  t += segment->reference_line_offset()->f(xodr_road_position.s);
-  xodr_road_position.t = t;
+  xodr_road_position.t = t * std::cos(roll_at_p);
   return xodr_road_position;
 }
 

--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -431,9 +431,11 @@ RoadGeometry::OpenScenarioRoadPosition RoadGeometry::MaliputRoadPositionToOpenSc
   double t = 0.;
 
   int t_direction = mali_lane->get_lane_id() > 0 ? 1 : -1;
+  int n_lanes = segment->num_lanes();
   // Start at 1 to ignore lane 0.
   for (int i = 1; i < std::abs(mali_lane->get_lane_id()); ++i) {
-    const Lane* curr_mali_lane = dynamic_cast<const Lane*>(segment->lane(i * t_direction));
+    int index = n_lanes / 2 + i * t_direction + (t_direction > 0 ? -1 : 0);
+    const Lane* curr_mali_lane = dynamic_cast<const Lane*>(segment->lane(index));
     const double width = curr_mali_lane->lane_width_at(xodr_road_position.s);
     const double roll_at_p = segment->road_curve()->superelevation()->f(xodr_road_position.s);
     t += width * std::cos(roll_at_p) * t_direction;

--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -153,12 +153,11 @@ class CommandsHandler {
         MALIDRIVE_THROW_MESSAGE(std::string("OpenScenarioLanePositionToMaliputRoadPosition expects 4 arguments, got ") +
                                 std::to_string(command.args.size()));
       }
-      const int xodr_road_id = std::stoi(std::string(command.args[0]));
-      const double xodr_s = std::stod(std::string(command.args[1]));
-      const int xodr_lane_id = std::stoi(std::string(command.args[2]));
-      const double offset = std::stod(std::string(command.args[3]));
+      const malidrive::RoadGeometry::OpenScenarioLanePosition xodr_lane_position{
+          std::stoi(std::string(command.args[0])), std::stod(std::string(command.args[1])),
+          std::stoi(std::string(command.args[2])), std::stod(std::string(command.args[3]))};
       const maliput::api::RoadPosition road_position =
-          rg_->OpenScenarioLanePositionToMaliputRoadPosition(xodr_road_id, xodr_s, xodr_lane_id, offset);
+          rg_->OpenScenarioLanePositionToMaliputRoadPosition(xodr_lane_position);
       return to_output_format(road_position);
     }
     if (command.name == "OpenScenarioRoadPositionToMaliputRoadPosition") {
@@ -166,11 +165,11 @@ class CommandsHandler {
         MALIDRIVE_THROW_MESSAGE(std::string("OpenScenarioRoadPositionToMaliputRoadPosition expects 3 arguments, got ") +
                                 std::to_string(command.args.size()));
       }
-      const int xodr_road_id = std::stoi(std::string(command.args[0]));
-      const double xodr_s = std::stod(std::string(command.args[1]));
-      const double xodr_t = std::stod(std::string(command.args[2]));
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition xodr_road_position{
+          std::stoi(std::string(command.args[0])), std::stod(std::string(command.args[1])),
+          std::stod(std::string(command.args[2]))};
       const maliput::api::RoadPosition road_position =
-          rg_->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_road_id, xodr_s, xodr_t);
+          rg_->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_road_position);
       return to_output_format(road_position);
     }
     if (command.name == "MaliputRoadPositionToOpenScenarioLanePosition") {
@@ -298,19 +297,19 @@ std::vector<maliput::api::RoadPositionResult> RoadGeometry::DoFindRoadPositions(
   return maliput::geometry_base::BruteForceFindRoadPositionsStrategy(this, inertial_position, radius);
 }
 
-maliput::api::RoadPosition RoadGeometry::OpenScenarioLanePositionToMaliputRoadPosition(int xodr_road_id, double xodr_s,
-                                                                                       int xodr_lane_id,
-                                                                                       double offset) const {
-  MALIDRIVE_THROW_UNLESS(xodr_road_id >= 0);
-  MALIDRIVE_THROW_UNLESS(xodr_s >= 0.);
-  MALIDRIVE_THROW_UNLESS(xodr_lane_id != 0);
+maliput::api::RoadPosition RoadGeometry::OpenScenarioLanePositionToMaliputRoadPosition(
+    const OpenScenarioLanePosition& xodr_lane_position) const {
+  MALIDRIVE_THROW_UNLESS(xodr_lane_position.road_id >= 0);
+  MALIDRIVE_THROW_UNLESS(xodr_lane_position.s >= 0.);
+  MALIDRIVE_THROW_UNLESS(xodr_lane_position.lane_id != 0);
   const std::unordered_map<maliput::api::LaneId, const maliput::api::Lane*> all_lanes = this->ById().GetLanes();
   const Lane* target_lane{nullptr};
   for (const auto& lane : all_lanes) {
     const Lane* mali_lane = dynamic_cast<const Lane*>(lane.second);
-    if (mali_lane->get_track() == xodr_road_id && mali_lane->get_lane_id() == xodr_lane_id) {
-      if (is_greater_than_or_close(xodr_s, mali_lane->get_track_s_start()) &&
-          is_less_than_or_close(xodr_s, mali_lane->get_track_s_end())) {
+    if (mali_lane->get_track() == xodr_lane_position.road_id &&
+        mali_lane->get_lane_id() == xodr_lane_position.lane_id) {
+      if (is_greater_than_or_close(xodr_lane_position.s, mali_lane->get_track_s_start()) &&
+          is_less_than_or_close(xodr_lane_position.s, mali_lane->get_track_s_end())) {
         if (target_lane != nullptr) {
           target_lane = target_lane->get_track_s_start() > mali_lane->get_track_s_start() ? target_lane : mali_lane;
         } else {
@@ -323,23 +322,24 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioLanePositionToMaliputRoadPo
     MALIDRIVE_THROW_MESSAGE(
         "A maliput lane can't be found for the given OpenSCENARIO lane position: "
         "RoadID: " +
-        std::to_string(xodr_road_id) + ", s: " + std::to_string(xodr_s) + ", LaneID: " + std::to_string(xodr_lane_id) +
-        ", offset: " + std::to_string(offset));
+        std::to_string(xodr_lane_position.road_id) + ", s: " + std::to_string(xodr_lane_position.s) + ", LaneID: " +
+        std::to_string(xodr_lane_position.lane_id) + ", offset: " + std::to_string(xodr_lane_position.offset));
   }
-  const double mali_lane_s = target_lane->LaneSFromTrackS(xodr_s);
+  const double mali_lane_s = target_lane->LaneSFromTrackS(xodr_lane_position.s);
   const auto segment = dynamic_cast<const Segment*>(target_lane->segment());
   const auto road_curve = segment->road_curve();
-  const double p = road_curve->PFromP(xodr_s);
+  const double p = road_curve->PFromP(xodr_lane_position.s);
   const double roll_at_p = road_curve->superelevation()->f(p);
-  const double r = offset / std::cos(roll_at_p);
+  const double r = xodr_lane_position.offset / std::cos(roll_at_p);
   const double r_max = target_lane->lane_bounds(mali_lane_s).max();
   const double r_min = target_lane->lane_bounds(mali_lane_s).min();
   if (r_min > r || r_max < r) {
     MALIDRIVE_THROW_MESSAGE(
         "The lane offset is out of bounds for the given OpenSCENARIO lane position: "
         "RoadID: " +
-        std::to_string(xodr_road_id) + ", s: " + std::to_string(xodr_s) + ", LaneID: " + std::to_string(xodr_lane_id) +
-        ", offset: " + std::to_string(offset) + " | Maliput LaneID: " + target_lane->id().string() +
+        std::to_string(xodr_lane_position.road_id) + ", s: " + std::to_string(xodr_lane_position.s) +
+        ", LaneID: " + std::to_string(xodr_lane_position.lane_id) +
+        ", offset: " + std::to_string(xodr_lane_position.offset) + " | Maliput LaneID: " + target_lane->id().string() +
         ", Maliput Lane's s-coordinate: " + std::to_string(mali_lane_s) + ", Maliput Lane's r-coordinate: " +
         std::to_string(r) + ", Maliput Lane's r-coordinate bounds: [" + std::to_string(r_min) + ", " +
         std::to_string(r_max) + "]" + ", Superelevation at s: " + std::to_string(roll_at_p));
@@ -356,14 +356,14 @@ RoadGeometry::OpenScenarioLanePosition RoadGeometry::MaliputRoadPositionToOpenSc
   xodr_lane_position.s = mali_lane->TrackSFromLaneS(road_position.pos.s());
   const auto segment = dynamic_cast<const Segment*>(mali_lane->segment());
   const auto roll_at_p = segment->road_curve()->superelevation()->f(xodr_lane_position.s);
-  xodr_lane_position.offset = road_position.pos.r() / std::cos(roll_at_p);
+  xodr_lane_position.offset = road_position.pos.r() * std::cos(roll_at_p);
   return xodr_lane_position;
 }
 
-maliput::api::RoadPosition RoadGeometry::OpenScenarioRoadPositionToMaliputRoadPosition(int xodr_road_id, double xodr_s,
-                                                                                       double xodr_t) const {
-  MALIDRIVE_THROW_UNLESS(xodr_road_id >= 0);
-  MALIDRIVE_THROW_UNLESS(xodr_s >= 0.);
+maliput::api::RoadPosition RoadGeometry::OpenScenarioRoadPositionToMaliputRoadPosition(
+    const OpenScenarioRoadPosition& xodr_road_position) const {
+  MALIDRIVE_THROW_UNLESS(xodr_road_position.road_id >= 0);
+  MALIDRIVE_THROW_UNLESS(xodr_road_position.s >= 0.);
   const std::unordered_map<maliput::api::LaneId, const maliput::api::Lane*> all_lanes = this->ById().GetLanes();
   const Segment* target_segment{nullptr};
   // Identify which is the segment that could contain position determined by xodr_road_id / xodr_s / xodr_t.
@@ -372,8 +372,9 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRoadPositionToMaliputRoadPo
     const Lane* mali_lane = dynamic_cast<const Lane*>(lane.second);
     MALIPUT_THROW_UNLESS(mali_lane != nullptr);
 
-    if (mali_lane->get_track() == xodr_road_id && is_greater_than_or_close(xodr_s, mali_lane->get_track_s_start()) &&
-        is_less_than_or_close(xodr_s, mali_lane->get_track_s_end())) {
+    if (mali_lane->get_track() == xodr_road_position.road_id &&
+        is_greater_than_or_close(xodr_road_position.s, mali_lane->get_track_s_start()) &&
+        is_less_than_or_close(xodr_road_position.s, mali_lane->get_track_s_end())) {
       target_segment = dynamic_cast<const Segment*>(mali_lane->segment());
       MALIPUT_THROW_UNLESS(target_segment != nullptr);
       break;
@@ -383,9 +384,10 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRoadPositionToMaliputRoadPo
     MALIDRIVE_THROW_MESSAGE(
         "A maliput segment can't be found for the given OpenSCENARIO road position: "
         "RoadID: " +
-        std::to_string(xodr_road_id) + ", s: " + std::to_string(xodr_s) + ", t: " + std::to_string(xodr_t));
+        std::to_string(xodr_road_position.road_id) + ", s: " + std::to_string(xodr_road_position.s) +
+        ", t: " + std::to_string(xodr_road_position.t));
   }
-  const double p = target_segment->road_curve()->PFromP(xodr_s);
+  const double p = target_segment->road_curve()->PFromP(xodr_road_position.s);
   const Lane* target_lane{nullptr};
   double r{};
   double mali_lane_s{};
@@ -398,14 +400,14 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRoadPositionToMaliputRoadPo
     const double r_road_curve_max = r_road_curve + width / 2.;
     // r-coordinates are located in RoadCurve FRAME while t-coordinate are respect to Road Reference Line in the ground.
     const double roll_at_p = target_segment->road_curve()->superelevation()->f(p);
-    const double xodr_t_projected_on_r = xodr_t / std::cos(roll_at_p);
+    const double xodr_t_projected_on_r = xodr_road_position.t / std::cos(roll_at_p);
     if (is_greater_than_or_close(xodr_t_projected_on_r, r_road_curve_min) &&
         is_less_than_or_close(xodr_t_projected_on_r, r_road_curve_max)) {
       // If the lane r value lies the limit of lanes then the right lane is the target lane as lanes are iterated from
       // right to left by definition.
       target_lane = mali_lane;
       r = mali_lane->to_lane_r(p, xodr_t_projected_on_r);
-      mali_lane_s = target_lane->LaneSFromTrackS(xodr_s);
+      mali_lane_s = target_lane->LaneSFromTrackS(xodr_road_position.s);
       break;
     }
   }
@@ -413,7 +415,8 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRoadPositionToMaliputRoadPo
     MALIDRIVE_THROW_MESSAGE(
         "A maliput lane can't be found for the given OpenSCENARIO road position: "
         "RoadID: " +
-        std::to_string(xodr_road_id) + ", s: " + std::to_string(xodr_s) + ", t: " + std::to_string(xodr_t));
+        std::to_string(xodr_road_position.road_id) + ", s: " + std::to_string(xodr_road_position.s) +
+        ", t: " + std::to_string(xodr_road_position.t));
   }
   return maliput::api::RoadPosition{target_lane, maliput::api::LanePosition{mali_lane_s, r, 0.}};
 }
@@ -430,15 +433,16 @@ RoadGeometry::OpenScenarioRoadPosition RoadGeometry::MaliputRoadPositionToOpenSc
   int t_direction = mali_lane->get_lane_id() > 0 ? 1 : -1;
   // Start at 1 to ignore lane 0.
   for (int i = 1; i < std::abs(mali_lane->get_lane_id()); ++i) {
-    const Lane* curr_mali_lane = dynamic_cast<const Lane*>(segment->lane(i));
+    const Lane* curr_mali_lane = dynamic_cast<const Lane*>(segment->lane(i * t_direction));
     const double width = curr_mali_lane->lane_width_at(xodr_road_position.s);
     const double roll_at_p = segment->road_curve()->superelevation()->f(xodr_road_position.s);
-    t += width / std::cos(roll_at_p) * t_direction;
+    t += width * std::cos(roll_at_p) * t_direction;
   }
 
+  const double roll_at_p = segment->road_curve()->superelevation()->f(xodr_road_position.s);
   const double width = mali_lane->lane_width_at(xodr_road_position.s);
-  t += (road_position.pos.r() * t_direction + width / 2.) * t_direction;
-  t += segment->reference_line_offset()->f(xodr_road_position.s) * t_direction;
+  t += (road_position.pos.r() * t_direction + width / 2.) * std::cos(roll_at_p) * t_direction;
+  t += segment->reference_line_offset()->f(xodr_road_position.s);
   xodr_road_position.t = t;
   return xodr_road_position;
 }

--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -172,6 +172,36 @@ class CommandsHandler {
       const maliput::api::RoadPosition road_position =
           rg_->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_road_id, xodr_s, xodr_t);
       return to_output_format(road_position);
+    }
+    if (command.name == "MaliputRoadPositionToOpenScenarioLanePosition") {
+      if (command.args.size() != 4) {
+        MALIDRIVE_THROW_MESSAGE(std::string("MaliputRoadPositionToOpenScenarioLanePosition expects 4 arguments, got ") +
+                                std::to_string(command.args.size()));
+      }
+      const maliput::api::LaneId lane_id(std::string(command.args[0]));
+      const double s = std::stod(std::string(command.args[1]));
+      const double r = std::stod(std::string(command.args[2]));
+      const double h = std::stod(std::string(command.args[3]));
+      const maliput::api::RoadPosition road_position =
+          maliput::api::RoadPosition{rg_->ById().GetLane(lane_id), maliput::api::LanePosition{s, r, h}};
+      const malidrive::RoadGeometry::OpenScenarioLanePosition xodr_lane_position =
+          rg_->MaliputRoadPositionToOpenScenarioLanePosition(road_position);
+      return to_output_format(xodr_lane_position);
+    }
+    if (command.name == "MaliputRoadPositionToOpenScenarioRoadPosition") {
+      if (command.args.size() != 4) {
+        MALIDRIVE_THROW_MESSAGE(std::string("MaliputRoadPositionToOpenScenarioRoadPosition expects 4 arguments, got ") +
+                                std::to_string(command.args.size()));
+      }
+      const maliput::api::LaneId lane_id(std::string(command.args[0]));
+      const double s = std::stod(std::string(command.args[1]));
+      const double r = std::stod(std::string(command.args[2]));
+      const double h = std::stod(std::string(command.args[3]));
+      const maliput::api::RoadPosition road_position =
+          maliput::api::RoadPosition{rg_->ById().GetLane(lane_id), maliput::api::LanePosition{s, r, h}};
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition xodr_road_position =
+          rg_->MaliputRoadPositionToOpenScenarioRoadPosition(road_position);
+      return to_output_format(xodr_road_position);
 
     } else {
       MALIDRIVE_THROW_MESSAGE(std::string("Unknown command: ") + std::string(command.name));
@@ -183,6 +213,19 @@ class CommandsHandler {
   std::string to_output_format(const maliput::api::RoadPosition& road_position) {
     return road_position.lane->id().string() + "," + std::to_string(road_position.pos.s()) + "," +
            std::to_string(road_position.pos.r()) + "," + std::to_string(road_position.pos.h());
+  }
+
+  // Converts an OpenScenarioLanePosition to a string using the format:
+  // "<xodr_road_id>,<xodr_s>,<xodr_lane_id>,<offset>"
+  std::string to_output_format(const malidrive::RoadGeometry::OpenScenarioLanePosition& lane_position) {
+    return std::to_string(lane_position.road_id) + "," + std::to_string(lane_position.s) + "," +
+           std::to_string(lane_position.lane_id) + "," + std::to_string(lane_position.offset);
+  }
+
+  // Converts an OpenScenarioRoadPosition to a string using the format: "<xodr_road_id>,<xodr_s>,<xodr_t>"
+  std::string to_output_format(const malidrive::RoadGeometry::OpenScenarioRoadPosition& road_position) {
+    return std::to_string(road_position.road_id) + "," + std::to_string(road_position.s) + "," +
+           std::to_string(road_position.t);
   }
 
   const malidrive::RoadGeometry* rg_;

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -46,6 +46,32 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
  public:
   MALIDRIVE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadGeometry);
 
+  /// @brief Represents a OSC-XML Lane Position.
+  /// See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
+  struct OpenScenarioLanePosition {
+    /// The id of the road in the OpenDrive file.
+    int road_id;
+    /// The s-coordinate taken along the road's reference line from the start point of the target road.
+    double s;
+    /// The lane id.
+    int lane_id;
+    /// The lateral offset to the center line of the target lane.
+    double offset;
+  };
+
+  /// @brief Represents a OSC-XML Road Position.
+  /// See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
+  struct OpenScenarioRoadPosition {
+    /// The id of the road in the OpenDrive file.
+    int road_id;
+    /// The s-coordinate taken along the road's reference line from the start point of the target road.
+    double s;
+    /// The t-coordinate taken on the axis orthogonal to the reference line of the road.
+    double t;
+  };
+
   /// Constructs a RoadGeometry.
   ///
   /// @param id see @ref
@@ -96,24 +122,11 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// @throw maliput::common::assertion_error When there is no a function described for `road_id`.
   const road_curve::Function* GetReferenceLineOffset(const xodr::RoadHeader::Id& road_id) const;
 
-  /// @brief Represents a OSC-XML Lane Position.
-  /// See
-  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
-  struct OpenScenarioLanePosition {
-    /// The id of the road in the OpenDrive file.
-    int road_id;
-    /// The s-coordinate taken along the road's reference line from the start point of the target road.
-    double s;
-    /// The lane id.
-    int lane_id;
-    /// The lateral offset to the center line of the target lane.
-    double offset;
-  };
-
   /// Converts an OpenScenario LanePosition to a maliput RoadPosition.
   /// See
   /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
   ///
+  /// @param xodr_lane_position The lane position to get the maliput road position from.
   /// @returns A maliput RoadPosition.
   ///
   /// @throws When the correspondent maliput lane is not found.
@@ -130,18 +143,6 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// @throws When the correspondent open scenario road is not found.
   OpenScenarioLanePosition MaliputRoadPositionToOpenScenarioLanePosition(
       const maliput::api::RoadPosition& road_position) const;
-
-  /// @brief Represents a OSC-XML Road Position.
-  /// See
-  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
-  struct OpenScenarioRoadPosition {
-    /// The id of the road in the OpenDrive file.
-    int road_id;
-    /// The s-coordinate taken along the road's reference line from the start point of the target road.
-    double s;
-    /// The t-coordinate taken on the axis orthogonal to the reference line of the road.
-    double t;
-  };
 
   /// Converts an OpenScenario RoadPosition to a maliput RoadPosition.
   /// See
@@ -203,9 +204,6 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   //   - See
   //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
   //
-  // @param command The command string to be executed by the backend.
-  // @returns The output string of the command execution.
-  //
   // - MaliputRoadPositionToOpenScenarioLanePosition
   //   - Converts a maliput RoadPosition to an OpenScenario Lane Position
   //   - In/Out:
@@ -221,6 +219,9 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   //     - Output: "<xodr_road_id>,<xodr_s>,<xodr_t>"
   //   - See
   //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
+  //
+  // @param command The command string to be executed by the backend.
+  // @returns The output string of the command execution.
   //
   // @throws When the command is unknown or can't be executed.
   std::string DoBackendCustomCommand(const std::string& command) const override;

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -206,6 +206,22 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   // @param command The command string to be executed by the backend.
   // @returns The output string of the command execution.
   //
+  // - MaliputRoadPositionToOpenScenarioLanePosition
+  //   - Converts a maliput RoadPosition to an OpenScenario Lane Position
+  //   - In/Out:
+  //     - Input: "<lane_id>,<s>,<r>,<h>"
+  //     - Output: "<xodr_road_id>,<xodr_s>,<xodr_lane_id>,<offset>"
+  //   - See
+  //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
+  //
+  // - MaliputRoadPositionToOpenScenarioRoadPosition
+  //   - Converts a maliput RoadPosition to an OpenScenario Road Position
+  //   - In/Out:
+  //     - Input: "<lane_id>,<s>,<r>,<h>"
+  //     - Output: "<xodr_road_id>,<xodr_s>,<xodr_t>"
+  //   - See
+  //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
+  //
   // @throws When the command is unknown or can't be executed.
   std::string DoBackendCustomCommand(const std::string& command) const override;
 

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -100,9 +100,13 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// See
   /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
   struct OpenScenarioLanePosition {
+    /// The id of the road in the OpenDrive file.
     int road_id;
-    int lane_id;
+    /// The s-coordinate taken along the road's reference line from the start point of the target road.
     double s;
+    /// The lane id.
+    int lane_id;
+    /// The lateral offset to the center line of the target lane.
     double offset;
   };
 
@@ -110,15 +114,11 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// See
   /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
   ///
-  /// @param xodr_road_id The id of the road in the OpenDrive file.
-  /// @param xodr_s The s-coordinate taken along the road's reference line from the start point of the target road.
-  /// @param xodr_lane_id The lane id.
-  /// @param offset The lateral offset to the center line of the target lane.
   /// @returns A maliput RoadPosition.
   ///
   /// @throws When the correspondent maliput lane is not found.
-  maliput::api::RoadPosition OpenScenarioLanePositionToMaliputRoadPosition(int xodr_road_id, double xodr_s,
-                                                                           int xodr_lane_id, double offset) const;
+  maliput::api::RoadPosition OpenScenarioLanePositionToMaliputRoadPosition(
+      const OpenScenarioLanePosition& xodr_lane_position) const;
 
   /// Converts a maliput RoadPosition to an OpenScenario LanePosition.
   /// See
@@ -135,8 +135,11 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// See
   /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
   struct OpenScenarioRoadPosition {
+    /// The id of the road in the OpenDrive file.
     int road_id;
+    /// The s-coordinate taken along the road's reference line from the start point of the target road.
     double s;
+    /// The t-coordinate taken on the axis orthogonal to the reference line of the road.
     double t;
   };
 
@@ -144,12 +147,9 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// See
   /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
   ///
-  /// @param xodr_road_id The id of the road in the OpenDrive file.
-  /// @param xodr_s The s-coordinate taken along the road's reference line from the start point of the target road.
-  /// @param xodr_t The t-coordinate taken on the axis orthogonal to the reference line of the road.
   /// @returns A maliput RoadPosition.
-  maliput::api::RoadPosition OpenScenarioRoadPositionToMaliputRoadPosition(int xodr_road_id, double xodr_s,
-                                                                           double xodr_t) const;
+  maliput::api::RoadPosition OpenScenarioRoadPositionToMaliputRoadPosition(
+      const OpenScenarioRoadPosition& xodr_road_position) const;
 
   /// Converts a maliput RoadPosition to an OpenScenario RoadPosition.
   /// See

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -96,6 +96,16 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// @throw maliput::common::assertion_error When there is no a function described for `road_id`.
   const road_curve::Function* GetReferenceLineOffset(const xodr::RoadHeader::Id& road_id) const;
 
+  /// @brief Represents a OSC-XML Lane Position.
+  /// See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
+  struct OpenScenarioLanePosition {
+    int road_id;
+    int lane_id;
+    double s;
+    double offset;
+  };
+
   /// Converts an OpenScenario LanePosition to a maliput RoadPosition.
   /// See
   /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
@@ -110,6 +120,26 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   maliput::api::RoadPosition OpenScenarioLanePositionToMaliputRoadPosition(int xodr_road_id, double xodr_s,
                                                                            int xodr_lane_id, double offset) const;
 
+  /// Converts a maliput RoadPosition to an OpenScenario LanePosition.
+  /// See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
+  ///
+  /// @param road_position The road position to get the OS lane position from.
+  /// @returns An Open Scenario LanePosition.
+  ///
+  /// @throws When the correspondent open scenario road is not found.
+  OpenScenarioLanePosition MaliputRoadPositionToOpenScenarioLanePosition(
+      const maliput::api::RoadPosition& road_position) const;
+
+  /// @brief Represents a OSC-XML Road Position.
+  /// See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
+  struct OpenScenarioRoadPosition {
+    int road_id;
+    double s;
+    double t;
+  };
+
   /// Converts an OpenScenario RoadPosition to a maliput RoadPosition.
   /// See
   /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
@@ -118,10 +148,17 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// @param xodr_s The s-coordinate taken along the road's reference line from the start point of the target road.
   /// @param xodr_t The t-coordinate taken on the axis orthogonal to the reference line of the road.
   /// @returns A maliput RoadPosition.
-  ///
-  /// @throws When the correspondent maliput lane is not found.
   maliput::api::RoadPosition OpenScenarioRoadPositionToMaliputRoadPosition(int xodr_road_id, double xodr_s,
                                                                            double xodr_t) const;
+
+  /// Converts a maliput RoadPosition to an OpenScenario RoadPosition.
+  /// See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
+  ///
+  /// @param road_position The road position to get the OS road position from.
+  /// @returns An Open Scenario RoadPosition.
+  OpenScenarioRoadPosition MaliputRoadPositionToOpenScenarioRoadPosition(
+      const maliput::api::RoadPosition& road_position) const;
 
  private:
   // Holds the description of the Road.

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -219,118 +219,106 @@ class RoadGeometryOpenScenarioConversionsArcLane : public ::testing::Test {
   std::unique_ptr<maliput::api::RoadNetwork> road_network_{nullptr};
 };
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioLanePositionToMaliputRoadPositionAtCenterline) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioLanePositionToMaliputRoadPositionAtCenterline) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;
-  const int xodr_lane_id = -1;
-  const double offset = 0.;
+  const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, 0.};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const maliput::api::LanePosition expected_lane_position(51.25, 0., 0.);
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioLanePositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_lane_id, offset);
+      rg->OpenScenarioLanePositionToMaliputRoadPosition(input_xodr_lane_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
   const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
       rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
-  EXPECT_EQ(xodr_track_id, xodr_lane_pos.road_id);
-  EXPECT_TRUE(std::abs(xodr_s - xodr_lane_pos.s) < constants::kLinearTolerance);
-  EXPECT_EQ(xodr_lane_id, xodr_lane_pos.lane_id);
-  EXPECT_TRUE(std::abs(offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.road_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioLanePositionToMaliputRoadPositionWithOffset) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioLanePositionToMaliputRoadPositionWithOffset) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;
-  const int xodr_lane_id = -1;
-  const double offset = 0.5;
+  const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, 0.5};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const maliput::api::LanePosition expected_lane_position(51.25, 0.5, 0.);
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioLanePositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_lane_id, offset);
+      rg->OpenScenarioLanePositionToMaliputRoadPosition(input_xodr_lane_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
   const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
       rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
-  EXPECT_EQ(xodr_track_id, xodr_lane_pos.road_id);
-  EXPECT_TRUE(std::abs(xodr_s - xodr_lane_pos.s) < constants::kLinearTolerance);
-  EXPECT_EQ(xodr_lane_id, xodr_lane_pos.lane_id);
-  EXPECT_TRUE(std::abs(offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.road_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioRoadPositionToMaliputRoadPositionAtCenterline) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioRoadPositionToMaliputRoadPositionAtCenterline) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;
-  const double xodr_t = 0.;
+  const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., 0.};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const maliput::api::LanePosition expected_lane_position(51.25, 1., 0.);
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+      rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
   const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
       rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
-  EXPECT_EQ(xodr_track_id, xodr_road_pos.road_id);
-  EXPECT_TRUE(std::abs(xodr_s - xodr_road_pos.s) < constants::kLinearTolerance);
-  EXPECT_TRUE(std::abs(xodr_t - xodr_road_pos.t) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioRoadPositionToMaliputRoadPositionWithOffset) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioRoadPositionToMaliputRoadPositionWithOffset) {
   {
     // OpenScenario/OpenDrive parameters.
-    const int xodr_track_id = 1;
-    const double xodr_s = 50.;
-    const double xodr_t = -1.;
+    const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., -1.};
     // Maliput expected results.
     const maliput::api::LaneId lane_id("1_0_-1");
     const maliput::api::LanePosition expected_lane_position(51.25, 0., 0.);
 
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
     const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+        rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
     EXPECT_EQ(lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
     const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
         rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
-    EXPECT_EQ(xodr_track_id, xodr_road_pos.road_id);
-    EXPECT_TRUE(std::abs(xodr_s - xodr_road_pos.s) < constants::kLinearTolerance);
-    EXPECT_TRUE(std::abs(xodr_t - xodr_road_pos.t) < constants::kLinearTolerance);
+    EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+    EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+    EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
   }
   {
     // OpenScenario/OpenDrive parameters.
-    const int xodr_track_id = 1;
-    const double xodr_s = 50.;
-    const double xodr_t = 1.;
+    const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., 1.};
     // Maliput expected results.
     const maliput::api::LaneId lane_id("1_0_1");
     const maliput::api::LanePosition expected_lane_position(48.75, 0., 0.);
 
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
     const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+        rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
     EXPECT_EQ(lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
     const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
         rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
-    EXPECT_EQ(xodr_track_id, xodr_road_pos.road_id);
-    EXPECT_TRUE(std::abs(xodr_s - xodr_road_pos.s) < constants::kLinearTolerance);
-    EXPECT_TRUE(std::abs(xodr_t - xodr_road_pos.t) < constants::kLinearTolerance);
+    EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+    EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+    EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
   }
 }
 
@@ -347,12 +335,10 @@ class RoadGeometryOpenScenarioConversionsArcLaneRolled : public ::testing::Test 
   std::unique_ptr<maliput::api::RoadNetwork> road_network_{nullptr};
 };
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled, OpenScenarioLanePositionToMaliputRoadPositionAtCenterline) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled,
+       RoundTripOpenScenarioLanePositionToMaliputRoadPositionAtCenterline) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;  // middle of the road
-  const int xodr_lane_id = -1;
-  const double offset = 0.;
+  const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, 0.};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const double expected_s = road_network_->road_geometry()->ById().GetLane(lane_id)->length() / 2.;
@@ -360,37 +346,46 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled, OpenScenarioLanePositio
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioLanePositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_lane_id, offset);
+      rg->OpenScenarioLanePositionToMaliputRoadPosition(input_xodr_lane_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
+      rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_lane_position.road_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled, OpenScenarioLanePositionToMaliputRoadPositionWithOffset) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled,
+       RoundTripOpenScenarioLanePositionToMaliputRoadPositionWithOffset) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;  // middle of the road
-  const int xodr_lane_id = -1;
-  const double offset = 0.5;
+  const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, 0.5};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const double expected_s = road_network_->road_geometry()->ById().GetLane(lane_id)->length() / 2.;
-  const double expected_r = offset / (std::sqrt(2.) / 2.);  // The road is rolled 45 degrees
+  const double expected_r = input_xodr_lane_position.offset / (std::sqrt(2.) / 2.);  // The road is rolled 45 degrees
   const maliput::api::LanePosition expected_lane_position(expected_s, expected_r, 0.);
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioLanePositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_lane_id, offset);
+      rg->OpenScenarioLanePositionToMaliputRoadPosition(input_xodr_lane_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
+      rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_lane_position.road_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled, OpenScenarioRoadPositionToMaliputRoadPositionAtCenterline) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled,
+       RoundTripOpenScenarioRoadPositionToMaliputRoadPositionAtCenterline) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;  // middle of the road
-  const double xodr_t = 0.;
+  const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., 0.};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const double expected_s = road_network_->road_geometry()->ById().GetLane(lane_id)->length() / 2.;
@@ -398,31 +393,41 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled, OpenScenarioRoadPositio
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+      rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+      rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled, OpenScenarioRoadPositionToMaliputRoadPositionWithOffset) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled,
+       RoundTripOpenScenarioRoadPositionToMaliputRoadPositionWithOffset) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;  // middle of the road
-  const double xodr_t = -0.5;
+  const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., -0.5};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const maliput::api::Lane* lane{road_network_->road_geometry()->ById().GetLane(lane_id)};
   const double expected_s = lane->length() / 2.;
   const double expected_r =
-      lane->lane_bounds(expected_s).max() - std::abs(xodr_t / (std::sqrt(2.) / 2.));  // The road is rolled 45 degrees
+      lane->lane_bounds(expected_s).max() -
+      std::abs(input_xodr_road_position.t / (std::sqrt(2.) / 2.));  // The road is rolled 45 degrees
   const maliput::api::LanePosition expected_lane_position(expected_s, expected_r, 0.);
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+      rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+      rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
 }
 
 // This map differs with ArcLaneRolled with respect to a lane offset entry of 2m
@@ -440,11 +445,9 @@ class RoadGeometryOpenScenarioConversionsArcLaneRolledAndOffset : public ::testi
 };
 
 TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolledAndOffset,
-       OpenScenarioRoadPositionToMaliputRoadPositionAtRoadsReferenceLine) {
+       RoundTripOpenScenarioRoadPositionToMaliputRoadPositionAtRoadsReferenceLine) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;  // middle of the road
-  const double xodr_t = 0.;   // At RoadsReferenceLine
+  const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., 0.};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const double expected_s = road_network_->road_geometry()->ById().GetLane(lane_id)->length() / 2.;
@@ -452,32 +455,41 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolledAndOffset,
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+      rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+      rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
 }
 
 TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolledAndOffset,
-       OpenScenarioRoadPositionToMaliputRoadPositionWithOffset) {
+       RoundTripOpenScenarioRoadPositionToMaliputRoadPositionWithOffset) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;  // middle of the road
-  const double xodr_t = 1;
+  const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., 1.};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const maliput::api::Lane* lane{road_network_->road_geometry()->ById().GetLane(lane_id)};
   const double expected_s = lane->length() / 2.;
   const double expected_r =
-      lane->lane_bounds(expected_s).min() + std::abs(xodr_t / (std::sqrt(2.) / 2.));  // The road is rolled 45 degrees
+      lane->lane_bounds(expected_s).min() +
+      std::abs(input_xodr_road_position.t / (std::sqrt(2.) / 2.));  // The road is rolled 45 degrees
   const maliput::api::LanePosition expected_lane_position(expected_s, expected_r, 0.);
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+      rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+      rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+  EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
 }
 
 class RoadGeometryOpenScenarioConversionsLineMultipleSections : public ::testing::Test {
@@ -493,41 +505,48 @@ class RoadGeometryOpenScenarioConversionsLineMultipleSections : public ::testing
   std::unique_ptr<maliput::api::RoadNetwork> road_network_{nullptr};
 };
 
-TEST_F(RoadGeometryOpenScenarioConversionsLineMultipleSections, OpenScenarioLanePositionToMaliputRoadPosition) {
+TEST_F(RoadGeometryOpenScenarioConversionsLineMultipleSections,
+       RoundTripOpenScenarioLanePositionToMaliputRoadPosition) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 50.;
-  const int xodr_lane_id = -1;
-  const double offset = 0.;
+  const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, 0.};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_1_-1");
   const maliput::api::LanePosition expected_lane_position(16.7, 0., 0.);
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioLanePositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_lane_id, offset);
+      rg->OpenScenarioLanePositionToMaliputRoadPosition(input_xodr_lane_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
+      rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_lane_position.road_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
 TEST_F(RoadGeometryOpenScenarioConversionsLineMultipleSections,
-       OpenScenarioLanePositionToMaliputRoadPositionAtLaneEnd) {
+       RoundTripOpenScenarioLanePositionToMaliputRoadPositionAtLaneEnd) {
   // OpenScenario/OpenDrive parameters.
-  const int xodr_track_id = 1;
-  const double xodr_s = 33.3;
-  const int xodr_lane_id = -1;
-  const double offset = 0.;
+  const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 33.3, -1, 0.};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_1_-1");
   const maliput::api::LanePosition expected_lane_position(0, 0., 0.);
 
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::api::RoadPosition mali_road_pos =
-      rg->OpenScenarioLanePositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_lane_id, offset);
+      rg->OpenScenarioLanePositionToMaliputRoadPosition(input_xodr_lane_position);
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
+      rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_lane_position.road_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
 class RoadGeometryOpenScenarioConversionsLineVariableOffset : public ::testing::Test {
@@ -545,28 +564,29 @@ class RoadGeometryOpenScenarioConversionsLineVariableOffset : public ::testing::
 
 // Test at the begining of the lane 1_0_3 and in the middle of the lane 1_0_-3.
 // It should be the same xodr_t due to the effect of the lane offset in this map
-TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRoadPositionToMaliputRoadPosition) {
+TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, RoundTripOpenScenarioRoadPositionToMaliputRoadPosition) {
   {
     // OpenScenario/OpenDrive parameters.
-    const int xodr_track_id = 1;
-    const double xodr_s = 0.;  // middle of the road
-    const double xodr_t = 5.;  // At RoadsReferenceLine
+    const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 0., 5.};
     // Maliput expected results.
     const maliput::api::LaneId lane_id("1_0_3");
     const maliput::api::LanePosition expected_lane_position(0., 0., 0.);
 
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
     const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+        rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
     EXPECT_EQ(lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+    const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+        rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+    EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+    EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+    EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
   }
   {
     // OpenScenario/OpenDrive parameters.
-    const int xodr_track_id = 1;
-    const double xodr_s = 50.;  // middle of the road
-    const double xodr_t = 5.;   // At RoadsReferenceLine
+    const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., 5.};
     // Maliput expected results.
     const maliput::api::LaneId lane_id("1_0_-3");
     const double expected_s = road_network_->road_geometry()->ById().GetLane(lane_id)->length() / 2.;
@@ -574,10 +594,15 @@ TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRoadPo
 
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
     const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRoadPositionToMaliputRoadPosition(xodr_track_id, xodr_s, xodr_t);
+        rg->OpenScenarioRoadPositionToMaliputRoadPosition(input_xodr_road_position);
     EXPECT_EQ(lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+    const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+        rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+    EXPECT_EQ(input_xodr_road_position.road_id, xodr_road_pos.road_id);
+    EXPECT_TRUE(std::abs(input_xodr_road_position.s - xodr_road_pos.s) < constants::kLinearTolerance);
+    EXPECT_TRUE(std::abs(input_xodr_road_position.t - xodr_road_pos.t) < constants::kLinearTolerance);
   }
 }
 

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -235,6 +235,12 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioLanePositionToMal
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
+      rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+  EXPECT_EQ(xodr_track_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(xodr_s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(xodr_lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
 TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioLanePositionToMaliputRoadPositionWithOffset) {
@@ -253,6 +259,12 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioLanePositionToMal
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
+      rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+  EXPECT_EQ(xodr_track_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(xodr_s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(xodr_lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
 TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioRoadPositionToMaliputRoadPositionAtCenterline) {
@@ -270,6 +282,11 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioRoadPositionToMal
   EXPECT_EQ(lane_id, mali_road_pos.lane->id());
   EXPECT_TRUE(
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+      rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+  EXPECT_EQ(xodr_track_id, xodr_road_pos.road_id);
+  EXPECT_TRUE(std::abs(xodr_s - xodr_road_pos.s) < constants::kLinearTolerance);
+  EXPECT_TRUE(std::abs(xodr_t - xodr_road_pos.t) < constants::kLinearTolerance);
 }
 
 TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioRoadPositionToMaliputRoadPositionWithOffset) {
@@ -288,6 +305,11 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioRoadPositionToMal
     EXPECT_EQ(lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+    const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+        rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+    EXPECT_EQ(xodr_track_id, xodr_road_pos.road_id);
+    EXPECT_TRUE(std::abs(xodr_s - xodr_road_pos.s) < constants::kLinearTolerance);
+    EXPECT_TRUE(std::abs(xodr_t - xodr_road_pos.t) < constants::kLinearTolerance);
   }
   {
     // OpenScenario/OpenDrive parameters.
@@ -304,6 +326,11 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioRoadPositionToMal
     EXPECT_EQ(lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+    const RoadGeometry::OpenScenarioRoadPosition xodr_road_pos =
+        rg->MaliputRoadPositionToOpenScenarioRoadPosition(mali_road_pos);
+    EXPECT_EQ(xodr_track_id, xodr_road_pos.road_id);
+    EXPECT_TRUE(std::abs(xodr_s - xodr_road_pos.s) < constants::kLinearTolerance);
+    EXPECT_TRUE(std::abs(xodr_t - xodr_road_pos.t) < constants::kLinearTolerance);
   }
 }
 

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -594,6 +594,11 @@ std::vector<CommandsInputOutputs> InstanciateCommandsInputOutputsParameters() {
       {{"OpenScenarioRoadPositionToMaliputRoadPosition,1,50,0."}, {"1_0_-1,51.250000,1.000000,0.000000"}},
       {{"OpenScenarioRoadPositionToMaliputRoadPosition,1,50,-1."}, {"1_0_-1,51.250000,0.000000,0.000000"}},
       {{"OpenScenarioRoadPositionToMaliputRoadPosition,1,50,1."}, {"1_0_1,48.750000,0.000000,0.000000"}},
+      {{"MaliputRoadPositionToOpenScenarioLanePosition,1_0_-1,51.25,0.,0."}, {"1,50.000000,-1,0.000000"}},
+      {{"MaliputRoadPositionToOpenScenarioLanePosition,1_0_-1,51.25,0.5,0."}, {"1,50.000000,-1,0.500000"}},
+      {{"MaliputRoadPositionToOpenScenarioRoadPosition,1_0_-1,51.25,1.,0."}, {"1,50.000000,0.000000"}},
+      {{"MaliputRoadPositionToOpenScenarioRoadPosition,1_0_-1,51.25,0.,0."}, {"1,50.000000,-1.000000"}},
+      {{"MaliputRoadPositionToOpenScenarioRoadPosition,1_0_1,48.75,0.,0."}, {"1,50.000000,1.000000"}},
   };
 }
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://maliput.readthedocs.io/en/latest/contributing.html
-->

# 🎉 New feature


## Summary
* [x] Provides conversion from Maliput RoadPosition to [OpenScenarion::LanePosition](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html)
* [x] Provides conversion from Maliput RoadPosition to [OpenScenarion::RoadPosition](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
