### PR TITLE
Provides OpenScenarioRelativeLanePositionToMaliputRoadPosition conversion method

### DIFF
--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -533,9 +533,9 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeRoadPositionToMalip
     //  - we move forwards (positive ds) and next road is geometrically constructed in the opposite direction.
     //  - we move forwards (positive ds) and next road is geometrically constructed in the same direction.
     const bool forward_direction = xodr_ds >= 0.;
-    const double lane_s_to_road_end = forward_direction ? reference_road_curve->p1() - xodr_reference_road_position.s
+    const double xodr_s_to_road_end = forward_direction ? reference_road_curve->p1() - xodr_reference_road_position.s
                                                         : reference_road_curve->p0() - xodr_reference_road_position.s;
-    const double new_raw_xodr_ds = xodr_ds - lane_s_to_road_end;
+    const double new_raw_xodr_ds = xodr_ds - xodr_s_to_road_end;
     // We need to get the last road position before branching in order to identify which is the connected lane(ergo xodr
     // Road) to follow. So if we are moving forward we get the road position at p1, if we are moving backwards we get
     // the road position at p0.

--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -226,6 +226,26 @@ class CommandsHandler {
       const maliput::api::RoadPosition road_position =
           rg_->OpenScenarioRelativeRoadPositionToMaliputRoadPosition(xodr_road_position, ds, dt);
       return to_output_format(road_position);
+      // } else if (command.name == "OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition") {
+    } else if (command.name == "OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition") {
+      if (command.args.size() != 6) {
+        MALIDRIVE_THROW_MESSAGE(
+            std::string("OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition expects 6 arguments, got ") +
+            std::to_string(command.args.size()));
+      }
+      const malidrive::RoadGeometry::OpenScenarioLanePosition xodr_lane_position{
+          std::stoi(std::string(command.args[0])),
+          std::stod(std::string(command.args[2])),
+          std::stoi(std::string(command.args[1])),
+          0.,
+      };
+      const double d_lane = std::stod(std::string(command.args[3]));
+      const double ds_lane = std::stod(std::string(command.args[4]));
+      const double offset = std::stod(std::string(command.args[5]));
+      const maliput::api::RoadPosition road_position =
+          rg_->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(xodr_lane_position, d_lane, ds_lane,
+                                                                               offset);
+      return to_output_format(road_position);
     } else {
       MALIDRIVE_THROW_MESSAGE(std::string("Unknown command: ") + std::string(command.name));
     }
@@ -349,7 +369,7 @@ const Segment* RoadGeometry::FindSegmentByOpenScenarioRoadPosition(
   return target_segment;
 }
 
-maliput::api::RoadPosition RoadGeometry::OpenScenarioLanePositionToMaliputRoadPosition(
+const Lane* RoadGeometry::GetMaliputLaneFromOpenScenarioLanePosition(
     const OpenScenarioLanePosition& xodr_lane_position) const {
   MALIDRIVE_THROW_UNLESS(xodr_lane_position.road_id >= 0);
   MALIDRIVE_THROW_UNLESS(xodr_lane_position.s >= 0.);
@@ -377,6 +397,15 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioLanePositionToMaliputRoadPo
         std::to_string(xodr_lane_position.road_id) + ", s: " + std::to_string(xodr_lane_position.s) + ", LaneID: " +
         std::to_string(xodr_lane_position.lane_id) + ", offset: " + std::to_string(xodr_lane_position.offset));
   }
+  return target_lane;
+}
+
+maliput::api::RoadPosition RoadGeometry::OpenScenarioLanePositionToMaliputRoadPosition(
+    const OpenScenarioLanePosition& xodr_lane_position) const {
+  MALIDRIVE_THROW_UNLESS(xodr_lane_position.road_id >= 0);
+  MALIDRIVE_THROW_UNLESS(xodr_lane_position.s >= 0.);
+  MALIDRIVE_THROW_UNLESS(xodr_lane_position.lane_id != 0);
+  const Lane* target_lane = GetMaliputLaneFromOpenScenarioLanePosition(xodr_lane_position);
   const double mali_lane_s = target_lane->LaneSFromTrackS(xodr_lane_position.s);
   const auto segment = dynamic_cast<const Segment*>(target_lane->segment());
   const auto road_curve = segment->road_curve();
@@ -528,6 +557,83 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeRoadPositionToMalip
     return OpenScenarioRelativeRoadPositionToMaliputRoadPosition(new_xodr_reference_road_position, new_xodr_ds,
                                                                  new_xodr_dt);
   }
+}
+
+maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(
+    const OpenScenarioLanePosition& xodr_reference_lane_position, int d_lane, double ds_lane, double offset) const {
+  const Lane* reference_lane = GetMaliputLaneFromOpenScenarioLanePosition(xodr_reference_lane_position);
+  const double target_s = xodr_reference_lane_position.s + ds_lane;
+  const Segment* reference_segment = dynamic_cast<const Segment*>(reference_lane->segment());
+  MALIPUT_THROW_UNLESS(reference_segment != nullptr);
+  const road_curve::RoadCurve* reference_road_curve = reference_segment->road_curve();
+
+  maliput::api::RoadPosition target_position;
+  // Target is in the same road.
+  if (target_s >= reference_road_curve->p0() && target_s <= reference_road_curve->p1()) {
+    const OpenScenarioLanePosition new_os_lane_pos{xodr_reference_lane_position.road_id, target_s,
+                                                   xodr_reference_lane_position.lane_id, offset};
+    target_position = OpenScenarioLanePositionToMaliputRoadPosition(new_os_lane_pos);
+  } else {
+    // The target_s falls outside this xodr_road.
+    // We cover the case where:
+    //  - we move backwards (negative ds) and next road is geometrically constructed in the opposite direction.
+    //  - we move backwards (negative ds) and next road is geometrically constructed in the same direction.
+    //  - we move forwards (positive ds) and next road is geometrically constructed in the opposite direction.
+    //  - we move forwards (positive ds) and next road is geometrically constructed in the same direction.
+    const bool forward_direction = ds_lane >= 0.;
+    const double xodr_s_to_road_end = forward_direction ? reference_road_curve->p1() - xodr_reference_lane_position.s
+                                                        : reference_road_curve->p0() - xodr_reference_lane_position.s;
+    const double new_raw_ds_lane = ds_lane - xodr_s_to_road_end;
+    const maliput::api::RoadPosition last_road_position_before_branching =
+        OpenScenarioLanePositionToMaliputRoadPosition(
+            OpenScenarioLanePosition{xodr_reference_lane_position.road_id,
+                                     forward_direction ? reference_road_curve->p1() : reference_road_curve->p0(),
+                                     xodr_reference_lane_position.lane_id, xodr_reference_lane_position.offset});
+    const std::optional<LaneEnd> lane_end = last_road_position_before_branching.lane->GetDefaultBranch(
+        forward_direction ? LaneEnd::Which::kFinish : LaneEnd::Which::kStart);
+    if (lane_end == std::nullopt) {
+      // There is no default branch.
+      MALIDRIVE_THROW_MESSAGE("There is no connection road for the given OpenSCENARIO lane position: RoadID: " +
+                              std::to_string(xodr_reference_lane_position.road_id) +
+                              ", s: " + std::to_string(xodr_reference_lane_position.s) +
+                              ", LaneID: " + std::to_string(xodr_reference_lane_position.lane_id) +
+                              ", offset: " + std::to_string(xodr_reference_lane_position.offset));
+    }
+    const Segment* new_target_segment = ToMalidrive(lane_end->lane->segment());
+    const road_curve::RoadCurve* new_reference_road_curve = new_target_segment->road_curve();
+    const double new_xodr_reference_s =
+        lane_end->end == LaneEnd::Which::kFinish ? new_reference_road_curve->p1() : new_reference_road_curve->p0();
+    // Forward direction true + laneEnd::kStart -> no sign change for deltas
+    // Forward direction true + laneEnd::kFinish -> sign change for deltas
+    // Forward direction false + laneEnd::kStart -> sign change for deltas
+    // Forward direction false + laneEnd::kFinish -> no sign change for deltas
+    const double sign_for_new_deltas = forward_direction == (lane_end->end == LaneEnd::Which::kStart) ? 1. : -1.;
+    const double new_ds_lane = sign_for_new_deltas * new_raw_ds_lane;
+    const int new_d_lane = sign_for_new_deltas * d_lane;
+    const OpenScenarioLanePosition new_xodr_reference_lane_position{
+        ToMalidrive(lane_end->lane)->get_track(), new_xodr_reference_s, ToMalidrive(lane_end->lane)->get_lane_id(),
+        xodr_reference_lane_position.offset};
+    return OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(new_xodr_reference_lane_position, new_d_lane,
+                                                                           new_ds_lane, offset);
+  }
+
+  // d_lane
+  bool to_left = d_lane >= 0;
+  const Lane* target_lane = reference_lane;
+  if (d_lane != 0) {
+    for (int abs_d_lane = d_lane * d_lane / std::abs(d_lane); abs_d_lane != 0; --abs_d_lane) {
+      target_lane = dynamic_cast<const Lane*>(to_left ? target_lane->to_left() : target_lane->to_right());
+      if (target_lane == nullptr) {
+        MALIDRIVE_THROW_MESSAGE(
+            "A maliput lane can't be found for the given OpenSCENARIO lane position: "
+            "RoadID: " +
+            std::to_string(xodr_reference_lane_position.road_id) + ", s: " + std::to_string(target_s) + ", LaneID: " +
+            std::to_string(xodr_reference_lane_position.lane_id) + ", offset: " + std::to_string(offset));
+      }
+    }
+  }
+  target_position.lane = target_lane;
+  return target_position;
 }
 
 std::string RoadGeometry::DoBackendCustomCommand(const std::string& command) const {

--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -242,8 +242,7 @@ class CommandsHandler {
       const double xodr_ds = std::stod(std::string(command.args[4]));
       const double offset = std::stod(std::string(command.args[5]));
       const maliput::api::RoadPosition road_position =
-          rg_->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(xodr_lane_position, d_lane, xodr_ds,
-                                                                               offset);
+          rg_->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(xodr_lane_position, d_lane, xodr_ds, offset);
       return to_output_format(road_position);
     } else if (command.name == "OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition") {
       if (command.args.size() != 6) {

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -179,6 +179,9 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   maliput::api::RoadPosition OpenScenarioRelativeRoadPositionToMaliputRoadPosition(
       const OpenScenarioRoadPosition& xodr_reference_road_position, double xodr_ds, double xodr_dt) const;
 
+  maliput::api::RoadPosition OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(
+      const OpenScenarioLanePosition& xodr_reference_lane_position, int d_lane, double ds_lane, double offset) const;
+
  private:
   // Holds the description of the Road.
   struct RoadCharacteristics {
@@ -246,6 +249,22 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   //   - See
   //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeRoadPosition.html
   //
+  // - OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition
+  //   - Converts an OpenScenario RelativeLanePosition to a maliput RoadPosition.
+  //   - In/Out:
+  //     - Input: "<xodr_road_id>,<xodr_lane_id>,<xodr_s>,<d_lane>,<ds>,<offset>"
+  //     - Output: "<lane_id>,<s>,<r>,<h>"
+  //   - See
+  //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeLanePosition.html
+  //
+  // - OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition
+  //   - Converts an OpenScenario RelativeLanePosition to a maliput RoadPosition.
+  //   - In/Out:
+  //     - Input: "<xodr_road_id>,<xodr_lane_id>,<xodr_s>,<d_lane>,<ds_lane>,<offset>"
+  //     - Output: "<lane_id>,<s>,<r>,<h>"
+  //   - See
+  //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeLanePosition.html
+  //
   // @param command The command string to be executed by the backend.
   // @returns The output string of the command execution.
   //
@@ -254,6 +273,9 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
 
   // Finds the maliput segment that corresponds to the given OpenScenario RoadPosition.
   const Segment* FindSegmentByOpenScenarioRoadPosition(const OpenScenarioRoadPosition& xodr_road_position) const;
+
+  // Finds the maliput lane that corresponds to the given OpenScenario LanePosition.
+  const Lane* GetMaliputLaneFromOpenScenarioLanePosition(const OpenScenarioLanePosition& xodr_lane_position) const;
 
   std::unique_ptr<xodr::DBManager> manager_;
   std::unordered_map<xodr::RoadHeader::Id, RoadCharacteristics> road_characteristics_;

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -179,8 +179,43 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   maliput::api::RoadPosition OpenScenarioRelativeRoadPositionToMaliputRoadPosition(
       const OpenScenarioRoadPosition& xodr_reference_road_position, double xodr_ds, double xodr_dt) const;
 
+  /// Converts an OpenScenario RelativeLanePosition to a maliput RoadPosition.
+  /// See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeLanePosition.html
+  ///
+  /// When ds_lane makes xodr_s to be out of bounds of the road, the calculation continues with the connecting road.
+  /// This make sense when only having a single connecting road (road successor in the xodr). When having multiple
+  /// connecting roads, the calculation will arbitrarily choose one of the connecting roads. (Default branch via maliput
+  /// api). This might need to change in the future as we probably want to have a more deterministic behavior that could
+  /// reflect the expecting routing of the vehicle acting as reference.
+  /// @param xodr_reference_lane_position The OpenScenario LanePosition used as reference.
+  /// @param d_lane The lane offset relative to the lane the reference.
+  /// @param ds_lane The offset along the center line of the lane, where the reference entity is located.
+  /// @param offset The lateral offset to the center line of the target lane (along the t-axis of the target lane center
+  /// line).
+  ///
+  /// @returns A maliput RoadPosition.
   maliput::api::RoadPosition OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(
       const OpenScenarioLanePosition& xodr_reference_lane_position, int d_lane, double ds_lane, double offset) const;
+
+  /// Converts an OpenScenario RelativeLanePosition to a maliput RoadPosition.
+  /// See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeRoadPosition.html
+  ///
+  /// When xodr_ds makes xodr_s to be out of bounds of the road, the calculation continues with the connecting road.
+  /// This make sense when only having a single connecting road (road successor in the xodr). When having multiple
+  /// connecting roads, the calculation will arbitrarily choose one of the connecting roads. (Default branch via maliput
+  /// api). This might need to change in the future as we probably want to have a more deterministic behavior that could
+  /// reflect the expecting routing of the vehicle acting as reference.
+  /// @param xodr_reference_lane_position The OpenScenario LanePosition used as reference.
+  /// @param d_lane The lane offset relative to the lane the reference.
+  /// @param xodr_ds The offset along the road's reference line relative to the s-coordinate of the reference entity.
+  /// @param offset The lateral offset to the center line of the target lane (along the t-axis of the target lane center
+  /// line).
+  ///
+  /// @returns A maliput RoadPosition.
+  maliput::api::RoadPosition OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(
+      const OpenScenarioLanePosition& xodr_reference_lane_position, int d_lane, double xodr_ds, double offset) const;
 
  private:
   // Holds the description of the Road.
@@ -252,7 +287,7 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   // - OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition
   //   - Converts an OpenScenario RelativeLanePosition to a maliput RoadPosition.
   //   - In/Out:
-  //     - Input: "<xodr_road_id>,<xodr_lane_id>,<xodr_s>,<d_lane>,<ds>,<offset>"
+  //     - Input: "<xodr_road_id>,<xodr_lane_id>,<xodr_s>,<d_lane>,<xodr_ds>,<offset>"
   //     - Output: "<lane_id>,<s>,<r>,<h>"
   //   - See
   //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeLanePosition.html
@@ -276,6 +311,9 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
 
   // Finds the maliput lane that corresponds to the given OpenScenario LanePosition.
   const Lane* GetMaliputLaneFromOpenScenarioLanePosition(const OpenScenarioLanePosition& xodr_lane_position) const;
+
+  // Finds the maliput lane that corresponds to the offset from the intial_lane.
+  const Lane* ApplyOffsetToLane(const Lane* initial_lane, int lane_offset) const;
 
   std::unique_ptr<xodr::DBManager> manager_;
   std::unordered_map<xodr::RoadHeader::Id, RoadCharacteristics> road_characteristics_;

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -658,7 +658,8 @@ TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, RoundTripOpenScena
   }
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition) {
+TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset,
+       OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition) {
   ///////////////////////////////////////////////////////
   // RelativeLanePosition falling within the same Road //
   ///////////////////////////////////////////////////////
@@ -674,9 +675,8 @@ TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRelati
     const maliput::api::LaneId expected_lane_id("1_0_1");
     const maliput::api::LanePosition expected_lane_position(22.4592, 0.5, 0.);
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
-    const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
-                                                                            offset);
+    const maliput::api::RoadPosition mali_road_pos = rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(
+        input_xodr_lane_position, d_lane, xodr_ds, offset);
     EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
@@ -693,16 +693,16 @@ TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRelati
     const maliput::api::LaneId expected_lane_id("1_0_-2");
     const maliput::api::LanePosition expected_lane_position(51.1802, -0.5, 0.);
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
-    const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
-                                                                            offset);
+    const maliput::api::RoadPosition mali_road_pos = rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(
+        input_xodr_lane_position, d_lane, xodr_ds, offset);
     EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
   }
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition) {
+TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset,
+       OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition) {
   ///////////////////////////////////////////////////////
   // RelativeLanePosition falling within the same Road //
   ///////////////////////////////////////////////////////
@@ -887,9 +887,8 @@ TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
     const maliput::api::LaneId expected_lane_id("2_0_1");
     const maliput::api::LanePosition expected_lane_position(7., 0.5, 0.);
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
-    const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
-                                                                            offset);
+    const maliput::api::RoadPosition mali_road_pos = rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(
+        input_xodr_lane_position, d_lane, xodr_ds, offset);
     EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
@@ -905,9 +904,8 @@ TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
     const maliput::api::LaneId expected_lane_id("2_0_-1");
     const maliput::api::LanePosition expected_lane_position(7., 0.5, 0.);
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
-    const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
-                                                                            offset);
+    const maliput::api::RoadPosition mali_road_pos = rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(
+        input_xodr_lane_position, d_lane, xodr_ds, offset);
     EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
@@ -921,7 +919,7 @@ TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
     const double offset = 0.5;
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
     EXPECT_THROW(rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane,
-                                                                                     xodr_ds, offset),
+                                                                                 xodr_ds, offset),
                  maliput::common::assertion_error);
   }
   ///////////////////////////////////////////////////////////
@@ -938,9 +936,8 @@ TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
     const maliput::api::LaneId expected_lane_id("1_0_-1");
     const maliput::api::LanePosition expected_lane_position(5., 0.5, 0.);
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
-    const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
-                                                                            offset);
+    const maliput::api::RoadPosition mali_road_pos = rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(
+        input_xodr_lane_position, d_lane, xodr_ds, offset);
     EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
@@ -956,9 +953,8 @@ TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
     const maliput::api::LaneId expected_lane_id("1_0_-1");
     const maliput::api::LanePosition expected_lane_position(8., -0.5, 0.);
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
-    const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
-                                                                            offset);
+    const maliput::api::RoadPosition mali_road_pos = rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(
+        input_xodr_lane_position, d_lane, xodr_ds, offset);
     EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
@@ -974,9 +970,8 @@ TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
     const maliput::api::LaneId expected_lane_id("3_0_1");
     const maliput::api::LanePosition expected_lane_position(3., 0.5, 0.);
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
-    const maliput::api::RoadPosition mali_road_pos =
-        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
-                                                                            offset);
+    const maliput::api::RoadPosition mali_road_pos = rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(
+        input_xodr_lane_position, d_lane, xodr_ds, offset);
     EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
         AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
@@ -1121,8 +1116,10 @@ std::vector<CommandsInputOutputs> InstanciateCommandsInputOutputsParameters() {
       {{"MaliputRoadPositionToOpenScenarioRoadPosition,1_0_-1,51.25,0.,0."}, {"1,50.000000,-1.000000"}},
       {{"MaliputRoadPositionToOpenScenarioRoadPosition,1_0_1,48.75,0.,0."}, {"1,50.000000,1.000000"}},
       {{"OpenScenarioRelativeRoadPositionToMaliputRoadPosition,1,0.,1.,50.,1."}, {"1_0_1,48.750000,1.000000,0.000000"}},
-      {{"OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition,1,1,0.,-1,50.,-0.8"}, {"1_0_-1,48.750000,-0.800000,0.000000"}},
-      {{"OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition,1,-1,0.,1,50.,0.8"}, {"1_0_1,50.000000,0.800000,0.000000"}},
+      {{"OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition,1,1,0.,-1,50.,-0.8"},
+       {"1_0_-1,48.750000,-0.800000,0.000000"}},
+      {{"OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition,1,-1,0.,1,50.,0.8"},
+       {"1_0_1,50.000000,0.800000,0.000000"}},
   };
 }
 

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -658,6 +658,94 @@ TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, RoundTripOpenScena
   }
 }
 
+TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition) {
+  ///////////////////////////////////////////////////////
+  // RelativeLanePosition falling within the same Road //
+  ///////////////////////////////////////////////////////
+  // Final pos in same lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 20., 1,
+                                                                          0.};  // Lane 1_0_1's srh(20.3756,0,0)
+    const int d_lane = 0;
+    const double xodr_ds = 2.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("1_0_1");
+    const maliput::api::LanePosition expected_lane_position(22.4592, 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos in other lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 20., 1,
+                                                                          0.};  // Lane 1_0_1's srh(20.3756,0,0)
+    const int d_lane = -2;
+    const double xodr_ds = 30.;
+    const double offset = -0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("1_0_-2");
+    const maliput::api::LanePosition expected_lane_position(51.1802, -0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+}
+
+TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition) {
+  ///////////////////////////////////////////////////////
+  // RelativeLanePosition falling within the same Road //
+  ///////////////////////////////////////////////////////
+  // Final pos in same lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 20., 1,
+                                                                          0.};  // Lane 1_0_1's srh(20.3756,0,0)
+    const int d_lane = 0;
+    const double ds_lane = 2.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("1_0_1");
+    const maliput::api::LanePosition expected_lane_position(22.3756, 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane, ds_lane,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos in other lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 20., 1,
+                                                                          0.};  // Lane 1_0_1's srh(20.3756,0,0)
+    const int d_lane = -2;
+    const double ds_lane = 30.;
+    const double offset = -0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("1_0_-2");
+    const maliput::api::LanePosition expected_lane_position(50.3756, -0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane, ds_lane,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+}
+
 class RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -776,6 +864,118 @@ TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
     auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
     const maliput::api::RoadPosition mali_road_pos =
         rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane, ds_lane,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+}
+
+TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
+       OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition) {
+  ///////////////////////////////////////////////////////
+  // RelativeLanePosition falling within the same Road //
+  ///////////////////////////////////////////////////////
+  // Final pos in same lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 5., 1, 0.};  // Lane 2_0_1's srh(5,0,0)
+    const int d_lane = 0;
+    const double xodr_ds = 2.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("2_0_1");
+    const maliput::api::LanePosition expected_lane_position(7., 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos in other lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 5., 1, 0.};  // Lane 2_0_1's srh(5,0,0)
+    const int d_lane = -1;
+    const double xodr_ds = 2.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("2_0_-1");
+    const maliput::api::LanePosition expected_lane_position(7., 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos out of bounds
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 5., 1, 0.};  // Lane 2_0_1's srh(5,0,0)
+    const int d_lane = 1;
+    const double xodr_ds = 2.;
+    const double offset = 0.5;
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    EXPECT_THROW(rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane,
+                                                                                     xodr_ds, offset),
+                 maliput::common::assertion_error);
+  }
+  ///////////////////////////////////////////////////////////
+  // RelativeLanePosition not falling within the same Road //
+  ///////////////////////////////////////////////////////////
+  // Final pos in same lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 5., 1, 0.};  // Lane 2_0_1's srh(5, 0, 0)
+    const int d_lane = 0;
+    const double xodr_ds = 10.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("1_0_-1");
+    const maliput::api::LanePosition expected_lane_position(5., 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos in other lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 7., -1, 0.};  // Lane 2_0_-1's srh(7, 0, 0)
+    const int d_lane = 1;
+    const double xodr_ds = 5.;
+    const double offset = -0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("1_0_-1");
+    const maliput::api::LanePosition expected_lane_position(8., -0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos in other lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 7., 1, 0.};  // Lane 2_0_1's srh(7, 0, 0)
+    const int d_lane = -1;
+    const double xodr_ds = -10.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("3_0_1");
+    const maliput::api::LanePosition expected_lane_position(3., 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(input_xodr_lane_position, d_lane, xodr_ds,
                                                                             offset);
     EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
     EXPECT_TRUE(
@@ -921,6 +1121,8 @@ std::vector<CommandsInputOutputs> InstanciateCommandsInputOutputsParameters() {
       {{"MaliputRoadPositionToOpenScenarioRoadPosition,1_0_-1,51.25,0.,0."}, {"1,50.000000,-1.000000"}},
       {{"MaliputRoadPositionToOpenScenarioRoadPosition,1_0_1,48.75,0.,0."}, {"1,50.000000,1.000000"}},
       {{"OpenScenarioRelativeRoadPositionToMaliputRoadPosition,1,0.,1.,50.,1."}, {"1_0_1,48.750000,1.000000,0.000000"}},
+      {{"OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition,1,1,0.,-1,50.,-0.8"}, {"1_0_-1,48.750000,-0.800000,0.000000"}},
+      {{"OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition,1,-1,0.,1,50.,0.8"}, {"1_0_1,50.000000,0.800000,0.000000"}},
   };
 }
 

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -672,6 +672,118 @@ class RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange : public ::t
 };
 
 TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
+       OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition) {
+  ///////////////////////////////////////////////////////
+  // RelativeLanePosition falling within the same Road //
+  ///////////////////////////////////////////////////////
+  // Final pos in same lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 5., 1, 0.};  // Lane 2_0_1's srh(5,0,0)
+    const int d_lane = 0;
+    const double ds_lane = 2.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("2_0_1");
+    const maliput::api::LanePosition expected_lane_position(7., 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane, ds_lane,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos in other lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 5., 1, 0.};  // Lane 2_0_1's srh(5,0,0)
+    const int d_lane = -1;
+    const double ds_lane = 2.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("2_0_-1");
+    const maliput::api::LanePosition expected_lane_position(7., 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane, ds_lane,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos out of bounds
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 5., 1, 0.};  // Lane 2_0_1's srh(5,0,0)
+    const int d_lane = 1;
+    const double ds_lane = 2.;
+    const double offset = 0.5;
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    EXPECT_THROW(rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane,
+                                                                                     ds_lane, offset),
+                 maliput::common::assertion_error);
+  }
+  ///////////////////////////////////////////////////////////
+  // RelativeLanePosition not falling within the same Road //
+  ///////////////////////////////////////////////////////////
+  // Final pos in same lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 5., 1, 0.};  // Lane 2_0_1's srh(5, 0, 0)
+    const int d_lane = 0;
+    const double ds_lane = 10.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("1_0_-1");
+    const maliput::api::LanePosition expected_lane_position(5., 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane, ds_lane,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos in other lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 7., -1, 0.};  // Lane 2_0_-1's srh(7, 0, 0)
+    const int d_lane = 1;
+    const double ds_lane = 5.;
+    const double offset = -0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("1_0_-1");
+    const maliput::api::LanePosition expected_lane_position(8., -0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane, ds_lane,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+  // Final pos in other lane
+  {
+    // OpenScenario/OpenDrive parameters.
+    const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{2, 7., 1, 0.};  // Lane 2_0_1's srh(7, 0, 0)
+    const int d_lane = -1;
+    const double ds_lane = -10.;
+    const double offset = 0.5;
+    // Maliput expected results.
+    const maliput::api::LaneId expected_lane_id("3_0_1");
+    const maliput::api::LanePosition expected_lane_position(3., 0.5, 0.);
+    auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(input_xodr_lane_position, d_lane, ds_lane,
+                                                                            offset);
+    EXPECT_EQ(expected_lane_id, mali_road_pos.lane->id());
+    EXPECT_TRUE(
+        AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  }
+}
+
+TEST_F(RoadGeometryOpenScenarioConversionsSingleRoadSDirectionChange,
        OpenScenarioRelativeRoadPositionToMaliputRoadPosition) {
   ///////////////////////////////////////////////////////////
   // RelativeRoadPosition not falling within the same Road //


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
* Provides conversion from OpenScenario RelativeLanePosition to Maliput via the `BackendCustomCommand` API.
* Two different commands are added:
  * `WithDs`: `s` coordinate offset through the road's reference line.
  * `WithDsLane`: `s` coordinate offset through the lane's center line.
```
  // - OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition
  //   - Converts an OpenScenario RelativeLanePosition to a maliput RoadPosition.
  //   - In/Out:
  //     - Input: "<xodr_road_id>,<xodr_lane_id>,<xodr_s>,<d_lane>,<xodr_ds>,<offset>"
  //     - Output: "<lane_id>,<s>,<r>,<h>"
  //   - See
  //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeLanePosition.html
  //
  // - OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition
  //   - Converts an OpenScenario RelativeLanePosition to a maliput RoadPosition.
  //   - In/Out:
  //     - Input: "<xodr_road_id>,<xodr_lane_id>,<xodr_s>,<d_lane>,<ds_lane>,<offset>"
  //     - Output: "<lane_id>,<s>,<r>,<h>"
  //   - See
  //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeLanePosition.html
```


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
