### PR TITLE
Provide method to obtain the road orientation from a OS RoadPosition.

### DIFF
--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -263,16 +263,16 @@ class CommandsHandler {
           rg_->OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(xodr_lane_position, d_lane, ds_lane,
                                                                                offset);
       return to_output_format(road_position);
-    } else if (command.name == "OpenScenarioRoadPositionReferenceLineOrientation") {
-      if (command.args.size() != 2) {
-        MALIDRIVE_THROW_MESSAGE(
-            std::string("OpenScenarioRoadPositionReferenceLineOrientation expects 2 arguments, got ") +
-            std::to_string(command.args.size()));
+    } else if (command.name == "GetRoadOrientationAtOpenScenarioRoadPosition") {
+      if (command.args.size() != 3) {
+        MALIDRIVE_THROW_MESSAGE(std::string("GetRoadOrientationAtOpenScenarioRoadPosition expects 3 arguments, got ") +
+                                std::to_string(command.args.size()));
       }
       const malidrive::RoadGeometry::OpenScenarioRoadPosition xodr_road_position{
-          std::stoi(std::string(command.args[0])), std::stod(std::string(command.args[1])), 0.};
+          std::stoi(std::string(command.args[0])), std::stod(std::string(command.args[1])),
+          std::stod(std::string(command.args[2]))};
       const maliput::math::RollPitchYaw rotation =
-          rg_->OpenScenarioRoadPositionReferenceLineOrientation(xodr_road_position);
+          rg_->GetRoadOrientationAtOpenScenarioRoadPosition(xodr_road_position);
       return to_output_format(rotation);
     } else {
       MALIDRIVE_THROW_MESSAGE(std::string("Unknown command: ") + std::string(command.name));
@@ -750,7 +750,7 @@ const Lane* RoadGeometry::ApplyOffsetToLane(const Lane* initial_lane, int lane_o
   return target_lane;
 }
 
-maliput::math::RollPitchYaw RoadGeometry::OpenScenarioRoadPositionReferenceLineOrientation(
+maliput::math::RollPitchYaw RoadGeometry::GetRoadOrientationAtOpenScenarioRoadPosition(
     const OpenScenarioRoadPosition& xodr_road_position) const {
   MALIDRIVE_THROW_UNLESS(xodr_road_position.road_id >= 0);
   MALIDRIVE_THROW_UNLESS(xodr_road_position.s >= 0.);

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -179,6 +179,14 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   maliput::api::RoadPosition OpenScenarioRelativeRoadPositionToMaliputRoadPosition(
       const OpenScenarioRoadPosition& xodr_reference_road_position, double xodr_ds, double xodr_dt) const;
 
+  /// Obtains the road's roll, pitch and yaw angles at the specified OpenScenario RoadPosition.
+  ///
+  /// @param xodr_road_position The OpenScenario RoadPosition to get the angles at.
+  ///
+  /// @returns A maliput RollPitchYaw.
+  maliput::math::RollPitchYaw OpenScenarioRoadPositionReferenceLineOrientation(
+      const OpenScenarioRoadPosition& xodr_road_position) const;
+
  private:
   // Holds the description of the Road.
   struct RoadCharacteristics {
@@ -246,6 +254,13 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   //   - See
   //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeRoadPosition.html
   //
+  // - OpenScenarioRoadPositionReferenceLineOrientation
+  //   - Obtains the orientation with respect to the (s,t)-coordinate system of the target road.
+  //   - In/Out:
+  //     - Input: "<xodr_road_id>,<xodr_s>"
+  //     - Output: "<roll>,<pitch>,<yaw>"
+  //   - See
+  //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
   // @param command The command string to be executed by the backend.
   // @returns The output string of the command execution.
   //

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -222,7 +222,7 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// @param xodr_road_position The OpenScenario RoadPosition to get the angles at.
   ///
   /// @returns A maliput RollPitchYaw.
-  maliput::math::RollPitchYaw OpenScenarioRoadPositionReferenceLineOrientation(
+  maliput::math::RollPitchYaw GetRoadOrientationAtOpenScenarioRoadPosition(
       const OpenScenarioRoadPosition& xodr_road_position) const;
 
  private:
@@ -308,10 +308,10 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   //   - See
   //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RelativeLanePosition.html
   //
-  // - OpenScenarioRoadPositionReferenceLineOrientation
-  //   - Obtains the orientation with respect to the (s,t)-coordinate system of the target road.
+  // - GetRoadOrientationAtOpenScenarioRoadPosition
+  //   - Obtains the road orientation at a OpenScenario RoadPosition.
   //   - In/Out:
-  //     - Input: "<xodr_road_id>,<xodr_s>"
+  //     - Input: "<xodr_road_id>,<xodr_s>,<xodr_t>"
   //     - Output: "<roll>,<pitch>,<yaw>"
   //   - See
   //   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -615,12 +615,12 @@ class RoadGeometryOpenScenarioConversionsLineVariableOffset : public ::testing::
   std::unique_ptr<maliput::api::RoadNetwork> road_network_{nullptr};
 };
 
-TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, OpenScenarioRoadPositionReferenceLineOrientation) {
+TEST_F(RoadGeometryOpenScenarioConversionsLineVariableOffset, GetRoadOrientationAtOpenScenarioRoadPosition) {
   const RoadGeometry::OpenScenarioRoadPosition xodr_road_position{1, 33., 0.};
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::math::RollPitchYaw expected_roll_pitch_roll{0., 0., 0.};
   const maliput::math::RollPitchYaw roll_pitch_roll =
-      rg->OpenScenarioRoadPositionReferenceLineOrientation(xodr_road_position);
+      rg->GetRoadOrientationAtOpenScenarioRoadPosition(xodr_road_position);
   EXPECT_TRUE(AssertCompare(CompareVectors(expected_roll_pitch_roll.vector(), roll_pitch_roll.vector(),
                                            constants::kAngularTolerance, maliput::math::CompareType::kAbsolute)));
 }
@@ -1121,12 +1121,12 @@ class RoadGeometryOpenScenarioConversionsSShapeSuperelevatedRoad : public ::test
   std::unique_ptr<maliput::api::RoadNetwork> road_network_{nullptr};
 };
 
-TEST_F(RoadGeometryOpenScenarioConversionsSShapeSuperelevatedRoad, OpenScenarioRoadPositionReferenceLineOrientation) {
+TEST_F(RoadGeometryOpenScenarioConversionsSShapeSuperelevatedRoad, GetRoadOrientationAtOpenScenarioRoadPosition) {
   const RoadGeometry::OpenScenarioRoadPosition xodr_road_position{1, 60., 0.};
   auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
   const maliput::math::RollPitchYaw expected_roll_pitch_roll{-0.745567, 0., 1.5};
   const maliput::math::RollPitchYaw roll_pitch_roll =
-      rg->OpenScenarioRoadPositionReferenceLineOrientation(xodr_road_position);
+      rg->GetRoadOrientationAtOpenScenarioRoadPosition(xodr_road_position);
   EXPECT_TRUE(AssertCompare(CompareVectors(expected_roll_pitch_roll.vector(), roll_pitch_roll.vector(),
                                            constants::kAngularTolerance, maliput::math::CompareType::kAbsolute)));
 }
@@ -1154,7 +1154,7 @@ std::vector<CommandsInputOutputs> InstanciateCommandsInputOutputsParameters() {
        {"1_0_-1,48.750000,-0.800000,0.000000"}},
       {{"OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition,1,-1,0.,1,50.,0.8"},
        {"1_0_1,50.000000,0.800000,0.000000"}},
-      {{"OpenScenarioRoadPositionReferenceLineOrientation,1,50."}, {"0.000000,-0.000000,1.250000"}},
+      {{"GetRoadOrientationAtOpenScenarioRoadPosition,1,50.,0."}, {"0.000000,-0.000000,1.250000"}},
   };
 }
 


### PR DESCRIPTION
# 🎉 New feature

```
// - GetRoadOrientationAtOpenScenarioRoadPosition
//   - Obtains the road orientation at a OpenScenario RoadPosition.
//   - In/Out:
//     - Input: "<xodr_road_id>,<xodr_s>,<xodr_t>"
//     - Output: "<roll>,<pitch>,<yaw>"
//   - See
//   https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/RoadPosition.html
```

## Summary
* Adds a custom command to obtain the `roll`, `pitch` and `yaw` angles at a RoadPosition.
* Added tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
