### PR TITLE
Bazel: Bump to use latest maliput and eigen release.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,9 +10,9 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
-bazel_dep(name = "eigen", version = "3.4.0")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.4.0")
+bazel_dep(name = "maliput", version = "1.4.1")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)


### PR DESCRIPTION
# :bug:  Bug fix

 - Depends on https://github.com/maliput/maliput/pull/647 and its BCR release
 - Depends on https://github.com/bazelbuild/bazel-central-registry/pull/4388

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
