### PR TITLE
Allow offset discontinuities when allowing semantic errors in XODRs.

### DIFF
--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -165,6 +165,9 @@ static constexpr char const* kSimplificationPolicy{"simplification_policy"};
 ///      disabled, except for the case described below.)
 ///      - 4. Adapts C1 discontinuities on piecewise-defined lane widths (only applying to driveable lanes) to meet the
 ///      continuity constraints.
+///      - 5. Allows lane offset discontinuities. This allows the user to create lane sections with discontiuous lane
+///      offsets, so that a lane ID N can continue as a lane ID M. It is up to them to ensure that the connecting roads
+///      form a contiguous surface.
 ///    - 4. @e "permissive": Allow all previous violations.
 ///   - Default: @e "permissive"
 static constexpr char const* kStandardStrictnessPolicy{"standard_strictness_policy"};

--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -166,8 +166,9 @@ static constexpr char const* kSimplificationPolicy{"simplification_policy"};
 ///      - 4. Adapts C1 discontinuities on piecewise-defined lane widths (only applying to driveable lanes) to meet the
 ///      continuity constraints.
 ///      - 5. Allows C1 discontinuities on piecewise-defined lane offset descriptions. In some scenarios,
-///      xodr lane offsets definitions are discontinuous, and yet the final road surface is continuous: This is not forbidden       ///      by the OpenDRIVE specification. It is up to the user to ensure that the connecting roads form a contiguous
-///      surface. See `maliput::API::RoadGeometry::CheckInvariants` method.
+///      xodr lane offsets definitions are discontinuous, and yet the final road surface is continuous: This is not
+///      forbidden       ///      by the OpenDRIVE specification. It is up to the user to ensure that the connecting
+///      roads form a contiguous surface. See `maliput::API::RoadGeometry::CheckInvariants` method.
 ///    - 4. @e "permissive": Allow all previous violations.
 ///   - Default: @e "permissive"
 static constexpr char const* kStandardStrictnessPolicy{"standard_strictness_policy"};

--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -165,9 +165,9 @@ static constexpr char const* kSimplificationPolicy{"simplification_policy"};
 ///      disabled, except for the case described below.)
 ///      - 4. Adapts C1 discontinuities on piecewise-defined lane widths (only applying to driveable lanes) to meet the
 ///      continuity constraints.
-///      - 5. Allows lane offset discontinuities. This allows the user to create lane sections with discontiuous lane
-///      offsets, so that a lane ID N can continue as a lane ID M. It is up to them to ensure that the connecting roads
-///      form a contiguous surface.
+///      - 5. Allows C1 discontinuities on piecewise-defined lane offset descriptions. In some scenarios,
+///      xodr lane offsets definitions are discontinuous, and yet the final road surface is continuous: This is not forbidden       ///      by the OpenDRIVE specification. It is up to the user to ensure that the connecting roads form a contiguous
+///      surface. See `maliput::API::RoadGeometry::CheckInvariants` method.
 ///    - 4. @e "permissive": Allow all previous violations.
 ///   - Default: @e "permissive"
 static constexpr char const* kStandardStrictnessPolicy{"standard_strictness_policy"};

--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -167,7 +167,7 @@ static constexpr char const* kSimplificationPolicy{"simplification_policy"};
 ///      continuity constraints.
 ///      - 5. Allows C1 discontinuities on piecewise-defined lane offset descriptions. In some scenarios,
 ///      xodr lane offsets definitions are discontinuous, and yet the final road surface is continuous: This is not
-///      forbidden       ///      by the OpenDRIVE specification. It is up to the user to ensure that the connecting
+///      forbidden by the OpenDRIVE specification. It is up to the user to ensure that the connecting
 ///      roads form a contiguous surface. See `maliput::API::RoadGeometry::CheckInvariants` method.
 ///    - 4. @e "permissive": Allow all previous violations.
 ///   - Default: @e "permissive"

--- a/src/maliput_malidrive/builder/road_curve_factory.cc
+++ b/src/maliput_malidrive/builder/road_curve_factory.cc
@@ -330,11 +330,11 @@ std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeLaneWidth
 }
 
 std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeReferenceLineOffset(
-    const std::vector<xodr::LaneOffset>& reference_offsets, double p0, double p1) const {
+    const std::vector<xodr::LaneOffset>& reference_offsets, double p0, double p1, bool assert_continuity) const {
   MALIDRIVE_THROW_UNLESS(p0 >= 0.);
   MALIDRIVE_THROW_UNLESS(p1 > p0);
   return MakeCubicFromXodr<xodr::LaneOffset>(reference_offsets, p0, p1, FillingGapPolicy::kZero,
-                                             road_curve::PiecewiseFunction::ContinuityCheck::kLog);
+                                             FromBoolToContiguityCheck(assert_continuity));
 }
 
 std::unique_ptr<road_curve::RoadCurve> RoadCurveFactory::MakeMalidriveRoadCurve(

--- a/src/maliput_malidrive/builder/road_curve_factory.h
+++ b/src/maliput_malidrive/builder/road_curve_factory.h
@@ -267,12 +267,15 @@ class RoadCurveFactoryBase {
   ///        negative and must be less than @p p1.
   /// @param p1 Upper bound extreme of the parameter range. It must be greater
   ///        than @p p0.
+  /// @param assert_continuity If true, C1 continuity is assert when function describing the reference lane offset is
+  /// built.
+  ///                          Otherwise only warning messages are printed.
   /// @returns A function that describes the lateral shift of the road reference line.
   ///
   /// @throws maliput::common::assertion_error When @p p0 is negative.
   /// @throws maliput::common::assertion_error When @p p1 is not greater enough than @p p0.
   virtual std::unique_ptr<malidrive::road_curve::Function> MakeReferenceLineOffset(
-      const std::vector<xodr::LaneOffset>& reference_offsets, double p0, double p1) const = 0;
+      const std::vector<xodr::LaneOffset>& reference_offsets, double p0, double p1, bool assert_continuity) const = 0;
 
   /// Makes a road_curve::MalidriveGroundCurve.
   ///
@@ -326,7 +329,8 @@ class RoadCurveFactory final : public RoadCurveFactoryBase {
                                                                  double p0, double p1, bool assert_continuity,
                                                                  bool adapt_lane_widths) const override;
   std::unique_ptr<malidrive::road_curve::Function> MakeReferenceLineOffset(
-      const std::vector<xodr::LaneOffset>& reference_offsets, double p0, double p1) const override;
+      const std::vector<xodr::LaneOffset>& reference_offsets, double p0, double p1,
+      bool assert_continuity) const override;
 
   std::unique_ptr<road_curve::RoadCurve> MakeMalidriveRoadCurve(std::unique_ptr<road_curve::GroundCurve> ground_curve,
                                                                 std::unique_ptr<road_curve::Function> elevation,

--- a/src/maliput_malidrive/builder/road_geometry_builder.cc
+++ b/src/maliput_malidrive/builder/road_geometry_builder.cc
@@ -514,7 +514,7 @@ std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryBuilder::DoBuild()
     auto road_curve = BuildRoadCurve(
         road_header.second, FilterGeometriesToSimplifyByRoadHeaderId(geometries_to_simplify, road_header.first));
     maliput::log()->trace("Creating ReferenceLineOffset for road id ", road_header.first.string());
-    // This enforces reference lane offset C1 continuity unless semantic errors are allowed.  
+    // This enforces reference lane offset C1 continuity unless semantic errors are allowed.
     const bool enforce_contiguity = !allow_semantic_errors;
     auto reference_line_offset = std::make_unique<road_curve::ScaledDomainFunction>(
         factory_->MakeReferenceLineOffset(road_header.second.lanes.lanes_offset, road_header.second.s0(),

--- a/src/maliput_malidrive/builder/road_geometry_builder.cc
+++ b/src/maliput_malidrive/builder/road_geometry_builder.cc
@@ -506,14 +506,19 @@ std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryBuilder::DoBuild()
                                      rg_config_.inertial_to_backend_frame_translation);
 
   maliput::log()->trace("Visiting XODR Roads...");
+  const bool allow_semantic_errors{(rg_config_.standard_strictness_policy &
+                                    RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors) ==
+                                   RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors};
   for (const auto& road_header : road_headers) {
     maliput::log()->trace("Visiting XODR Road ID: ", road_header.first);
     auto road_curve = BuildRoadCurve(
         road_header.second, FilterGeometriesToSimplifyByRoadHeaderId(geometries_to_simplify, road_header.first));
     maliput::log()->trace("Creating ReferenceLineOffset for road id ", road_header.first.string());
+    // This enforces reference lane offset C1 continuity unless semantic errors are allowed.  
+    const bool enforce_contiguity = !allow_semantic_errors;
     auto reference_line_offset = std::make_unique<road_curve::ScaledDomainFunction>(
         factory_->MakeReferenceLineOffset(road_header.second.lanes.lanes_offset, road_header.second.s0(),
-                                          road_header.second.s1()),
+                                          road_header.second.s1(), enforce_contiguity),
         road_curve->p0(), road_curve->p1(), rg_config_.tolerances.linear_tolerance.value());
     // Add RoadCurve and the reference-line-offset function to the RoadGeometry.
     rg->AddRoadCharacteristics(road_header.first, std::move(road_curve), std::move(reference_line_offset));


### PR DESCRIPTION
# 🎉 New feature

Closes #302

## Summary
This PR allows reference lane offset discontinuities by leaving in the user hands that the resulting roads form a contiguous surface.

Additionally, Maliput now throws an exception if the `standard_strictness_policy` is set to strict, and the reference lane offset is not contiguous.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
