### PR TITLE
Prepare for maliput_malidrive release 0.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package maliput_malidrive
 0.5.0 (2025-05-20)
 ------------------
 * Allow offset discontinuities when allowing semantic errors in XODRs. (`#306 https://github.com/maliput/maliput_malidrive/issues/306`)
+* Adapt driveable lane's widths so they are C1 continuous. (`#305 https://github.com/maliput/maliput_malidrive/issues/305`)
 * Contributors: Santiago Lopez
 
 0.4.4 (2025-04-22)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package maliput_malidrive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2025-05-20)
+------------------
+* Allow offset discontinuities when allowing semantic errors in XODRs. (`#306 https://github.com/maliput/maliput_malidrive/issues/306`)
+* Contributors: Santiago Lopez
+
 0.4.4 (2025-04-22)
 ------------------
 * Bazel: Bump to use latest maliput and eigen release. (`#303 <https://github.com/maliput/maliput_malidrive/issues/303>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##############################################################################
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(maliput_malidrive LANGUAGES C CXX VERSION 0.4.4)
+project(maliput_malidrive LANGUAGES C CXX VERSION 0.5.0)
 
 ##############################################################################
 # CMake Support

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,14 +5,14 @@ Welcome to Maliput Malidrive!
 module(
     name = "maliput_malidrive",
     compatibility_level = 1,
-    version = "0.4.4",
+    version = "0.5.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.4.1")
+bazel_dep(name = "maliput", version = "1.4.2")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>maliput_malidrive</name>
-  <version>0.4.4</version>
+  <version>0.5.0</version>
   <description>maliput_malidrive backend</description>
   <license file="LICENSE">BSD Clause 3</license>
   <maintainer email="andrew.best@tri.global">Andrew Best</maintainer>


### PR DESCRIPTION
# :balloon: Release

* Depends on #305  and #306 

## Summary
Prepare for release 0.5.0.
Point to maliput 1.4.2.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
