### PR TITLE
Prepare for maliput_malidrive minor release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,15 @@
 Changelog for package maliput_malidrive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2025-05-21)
+------------------
+* Use KDTree strategy in malidrive for improving query times (`#226 <https://github.com/maliput/maliput_malidrive/issues/226>`_)
+* Contributors: Eloy Briceno, Franco Cipollone
+
 0.5.0 (2025-05-20)
 ------------------
-* Allow offset discontinuities when allowing semantic errors in XODRs. (`#306 https://github.com/maliput/maliput_malidrive/issues/306`)
-* Adapt driveable lane's widths so they are C1 continuous. (`#305 https://github.com/maliput/maliput_malidrive/issues/305`)
+* Allow offset discontinuities when allowing semantic errors in XODRs. (`#306 https://github.com/maliput/maliput_malidrive/issues/306`_)
+* Adapt driveable lane's widths so they are C1 continuous. (`#305 https://github.com/maliput/maliput_malidrive/issues/305`_)
 * Contributors: Santiago Lopez
 
 0.4.4 (2025-04-22)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##############################################################################
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(maliput_malidrive LANGUAGES C CXX VERSION 0.5.0)
+project(maliput_malidrive LANGUAGES C CXX VERSION 0.6.0)
 
 ##############################################################################
 # CMake Support

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.4.2")
+bazel_dep(name = "maliput", version = "1.5.0")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ Welcome to Maliput Malidrive!
 module(
     name = "maliput_malidrive",
     compatibility_level = 1,
-    version = "0.5.0",
+    version = "0.6.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>maliput_malidrive</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>maliput_malidrive backend</description>
   <license file="LICENSE">BSD Clause 3</license>
   <maintainer email="andrew.best@tri.global">Andrew Best</maintainer>


### PR DESCRIPTION
# :balloon: Release

## Summary
Point to `maliput` `1.5.0` version.
Prepare for `maliput_malidrive` `0.6.0` release.

## After merge
- [ ] Push `0.6.0` tag to trigger BCR release.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
