### PR TITLE
Change all warn level logging to debug level.

### DIFF
--- a/src/maliput_malidrive/builder/road_curve_factory.cc
+++ b/src/maliput_malidrive/builder/road_curve_factory.cc
@@ -202,7 +202,7 @@ std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakePiecewiseGroundCu
   std::vector<std::unique_ptr<road_curve::GroundCurve>> ground_curves;
   for (const xodr::Geometry& geometry : geometries) {
     if (geometry.length < road_curve::GroundCurve::kEpsilon) {
-      maliput::log()->warn("A geometry description is discarded because its length is: ", geometry.length);
+      maliput::log()->debug("A geometry description is discarded because its length is: ", geometry.length);
       continue;
     }
     switch (geometry.type) {
@@ -268,7 +268,7 @@ std::vector<std::unique_ptr<malidrive::road_curve::Function>> RoadCurveFactory::
           MALIDRIVE_THROW_MESSAGE("Last laneWidth's function has invalid length: p0_i: " + std::to_string(p0_i) +
                                   " | p1_i: " + std::to_string(p1_i));
         } else {
-          maliput::log()->warn("Last laneWidth's function has null length: p0_i = p1_1 = ", p1_i);
+          maliput::log()->debug("Last laneWidth's function has null length: p0_i = p1_1 = ", p1_i);
           continue;
         }
       }
@@ -378,8 +378,8 @@ std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeCubicFrom
           MALIDRIVE_THROW_MESSAGE("Last " + xodr_data_type + "'s function has invalid length: p0_i: " +
                                   std::to_string(p0_i) + " | p1_i: " + std::to_string(p1_i));
         } else {
-          maliput::log()->warn("Last function that compounds ", xodr_data_type,
-                               " has null length: p0_i = p1_1 = ", p1_i);
+          maliput::log()->debug("Last function that compounds ", xodr_data_type,
+                                " has null length: p0_i = p1_1 = ", p1_i);
           continue;
         }
       }

--- a/src/maliput_malidrive/builder/road_geometry_builder.cc
+++ b/src/maliput_malidrive/builder/road_geometry_builder.cc
@@ -212,7 +212,7 @@ void RoadGeometryBuilder::VerifyNonNegativeLaneWidth(const std::vector<xodr::Lan
                             "] is negative at the beginning of the range, at [lane_width_s = " + std::to_string(p0) +
                             " | lane_s = " + std::to_string(lane_widths[i].s_0 + p0) +
                             "] with a width value of: " + std::to_string(f_p0)};
-      maliput::log()->warn(msg);
+      maliput::log()->debug(msg);
       if (!allow_negative_width) {
         MALIPUT_THROW_MESSAGE(msg);
       }
@@ -224,7 +224,7 @@ void RoadGeometryBuilder::VerifyNonNegativeLaneWidth(const std::vector<xodr::Lan
                             "] is negative at the end of the range, at [lane_width_s = " + std::to_string(p1) +
                             " | lane_s = " + std::to_string(lane_widths[i].s_0 + p1) +
                             "] with a width value of: " + std::to_string(f_p1)};
-      maliput::log()->warn(msg);
+      maliput::log()->debug(msg);
       if (!allow_negative_width) {
         MALIPUT_THROW_MESSAGE(msg);
       }
@@ -245,7 +245,7 @@ void RoadGeometryBuilder::VerifyNonNegativeLaneWidth(const std::vector<xodr::Lan
                                 "] presents negative values with a minimum value of [ " + std::to_string(min_width) +
                                 "] located at [lane_width_s = " + std::to_string(p_local_min.value()) +
                                 " | lane_s = " + std::to_string(p_local_min.value() + lane_widths[i].s_0) + "]"};
-          maliput::log()->warn(msg);
+          maliput::log()->debug(msg);
           if (!allow_negative_width) {
             MALIPUT_THROW_MESSAGE(msg);
           }
@@ -459,7 +459,7 @@ std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryBuilder::operator(
                            rg_config_.tolerances.angular_tolerance, "\n\t|__ scale_length = ", rg_config_.scale_length);
       return rg;
     } catch (maliput::common::assertion_error& e) {
-      maliput::log()->warn(
+      maliput::log()->debug(
           "Iteration [", i, "] failed with : (linear_tolerance: ", rg_config_.tolerances.linear_tolerance.value(),
           ", angular_tolerance: ", rg_config_.tolerances.angular_tolerance, ", scale_length: ", rg_config_.scale_length,
           "). "

--- a/src/maliput_malidrive/road_curve/piecewise_function.cc
+++ b/src/maliput_malidrive/road_curve/piecewise_function.cc
@@ -61,7 +61,7 @@ struct ContinuityChecker {
       const std::string f_msg{"Error when constructing piecewise function. Endpoint distance is <" +
                               std::to_string(f_distance) +
                               "> which is greater than tolerance: " + std::to_string(tolerance) + ">."};
-      maliput::log()->warn(f_msg);
+      maliput::log()->debug(f_msg);
       MALIDRIVE_VALIDATE(!(continuity_check == PiecewiseFunction::ContinuityCheck::kThrow),
                          maliput::common::assertion_error, f_msg);
       return false;
@@ -72,7 +72,7 @@ struct ContinuityChecker {
       const std::string f_dot_msg{"Error when constructing piecewise function. Endpoint derivative distance is <" +
                                   std::to_string(f_dot_distance) +
                                   "> which is greater than tolerance: " + std::to_string(tolerance) + ">."};
-      maliput::log()->warn(f_dot_msg);
+      maliput::log()->debug(f_dot_msg);
       MALIDRIVE_VALIDATE(!(continuity_check == PiecewiseFunction::ContinuityCheck::kThrow),
                          maliput::common::assertion_error, f_dot_msg);
       return false;

--- a/src/maliput_malidrive/road_curve/road_curve_offset.cc
+++ b/src/maliput_malidrive/road_curve/road_curve_offset.cc
@@ -71,14 +71,14 @@ struct ArcLengthDerivativeFunction {
   double operator()(double p, const maliput::math::Vector2& k) const {
     // The integrator may exceed the integration more than the allowed tolerance.
     if (p > p1_) {
-      maliput::log()->warn("The p value calculated by the integrator is ", p,
-                           " and exceeds the p1 of the road curve which is: ", p1_, ".");
+      maliput::log()->debug("The p value calculated by the integrator is ", p,
+                            " and exceeds the p1 of the road curve which is: ", p1_, ".");
       p = p1_;
     }
     // The integrator may exceed the minimum allowed p value for the lane offset function. See #123.
     if (p < p0_) {
-      maliput::log()->warn("The p value calculated by the integrator is ", p,
-                           " and is lower than the p0 of the road curve which is: ", p0_, ".");
+      maliput::log()->debug("The p value calculated by the integrator is ", p,
+                            " and is lower than the p0 of the road curve which is: ", p0_, ".");
       p = p0_;
     }
     return road_curve_->WDot({p, lane_offset_->f(p), k[1]}, lane_offset_).norm();
@@ -132,8 +132,8 @@ struct InverseArcLengthODEFunction {
     }
     // The integrator may exceed the minimum allowed p value for the lane offset function. See #123.
     if (p < p0_) {
-      maliput::log()->warn("The p value calculated by the integrator is ", p,
-                           " and is lower than the p0 of the road curve which is: ", p0_, ".");
+      maliput::log()->debug("The p value calculated by the integrator is ", p,
+                            " and is lower than the p0 of the road curve which is: ", p0_, ".");
       p = p0_;
     }
     return 1.0 / road_curve_->WDot({p, lane_offset_->f(p), k[1]}, lane_offset_).norm();

--- a/src/maliput_malidrive/xodr/db_manager.cc
+++ b/src/maliput_malidrive/xodr/db_manager.cc
@@ -465,7 +465,7 @@ class DBManager::Impl {
                                    : ") but its predecessor is not reciprocal. It points to RoadHeader(") +
                               link_s_road_link->element_id.string() + ")"};
         if (parser_configuration_.allow_semantic_errors) {
-          maliput::log()->warn(msg);
+          maliput::log()->debug(msg);
         } else {
           MALIDRIVE_THROW_MESSAGE(msg);
         }
@@ -480,7 +480,7 @@ class DBManager::Impl {
                               link_s_road_link->element_id.string() + ") and RoadHeader(" + road_header.id.string() +
                               ") has JunctionId(" + road_header.junction + ")"};
         if (parser_configuration_.allow_semantic_errors) {
-          maliput::log()->warn(msg);
+          maliput::log()->debug(msg);
         } else {
           MALIDRIVE_THROW_MESSAGE(msg);
         }
@@ -680,7 +680,7 @@ class DBManager::Impl {
           const std::string msg = std::string("Unknown successor lane ") + lane_link_a->id.string() +
                                   std::string(" for lane id ") + lane_id_lane_a.first.string();
           if (parser_configuration_.allow_semantic_errors) {
-            maliput::log()->warn(msg);
+            maliput::log()->debug(msg);
             continue;
           } else {
             MALIDRIVE_THROW_MESSAGE(msg);
@@ -692,7 +692,7 @@ class DBManager::Impl {
                                   " from one segment doesn't match successor/predecessor values with Lane id " +
                                   lane_id_lane_b->first.string() + " of the next segment.";
           if (parser_configuration_.allow_semantic_errors) {
-            maliput::log()->warn(msg);
+            maliput::log()->debug(msg);
             continue;
           } else {
             MALIDRIVE_THROW_MESSAGE(msg);
@@ -709,7 +709,7 @@ class DBManager::Impl {
           const std::string msg = std::string("Unknown predecessor lane ") + lane_link_b->id.string() +
                                   std::string(" for lane id ") + lane_id_lane_b.first.string();
           if (parser_configuration_.allow_semantic_errors) {
-            maliput::log()->warn(msg);
+            maliput::log()->debug(msg);
             continue;
           } else {
             MALIDRIVE_THROW_MESSAGE(msg);
@@ -721,7 +721,7 @@ class DBManager::Impl {
                                   " from one segment doesn't match successor/predecessor values with Lane id " +
                                   lane_id_lane_a->first.string() + " of the next segment.";
           if (parser_configuration_.allow_semantic_errors) {
-            maliput::log()->warn(msg);
+            maliput::log()->debug(msg);
             continue;
           } else {
             MALIDRIVE_THROW_MESSAGE(msg);

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -125,7 +125,7 @@ void AddPolynomialDescriptionToCollection(const T& new_function, const std::stri
       if (!allow_schema_errors) {
         MALIDRIVE_THROW_MESSAGE(msg);
       }
-      maliput::log()->warn(msg + "Discarding the first description starting at s = ", new_function.s_0);
+      maliput::log()->debug(msg + "Discarding the first description starting at s = ", new_function.s_0);
       functions->pop_back();
     }
   }
@@ -174,7 +174,7 @@ std::optional<double> AttributeParser::As(const std::string& attribute_name) con
   }
   if (std::isnan(value)) {
     std::string msg{"Attributes with NaN values has been found. " + ConvertXMLNodeToText(element_)};
-    maliput::log()->warn(msg);
+    maliput::log()->debug(msg);
     if (!parser_configuration_.allow_schema_errors) {
       MALIDRIVE_THROW_MESSAGE(msg);
     }
@@ -987,7 +987,7 @@ Junction NodeParser::As() const {
     if (!parser_configuration_.allow_schema_errors) {
       MALIDRIVE_THROW_MESSAGE(msg);
     }
-    maliput::log()->warn(msg);
+    maliput::log()->debug(msg);
   }
   std::unordered_map<Connection::Id, Connection> connections;
   while (connection_element) {


### PR DESCRIPTION
# 🎉 New feature

## Summary
All warning messages are now part of `DEBUG` log level. This is an effort to not spam the user with a lot of noisy messages when running maliput with a `permissive` strictness level.

## Example 
Running the following query:
```
maliput_to_obj --maliput_backend=malidrive --xodr_file_path=src/maliput_malidrive/resources/GapInLaneWidthDrivableLane.xodr  --linear_tolerance=0.05 --dirpath=src/maliput_malidrive/obj/ --file_name_root="GapIn
LaneWidth" --draw_elevation_bounds=False --standard_strictness_policy=permissive --log_level=info
```
used to output:
```
[INFO] Loading road network using malidrive backend implementation...

[WARNING] Error when constructing piecewise function. Endpoint distance is <1.200000> which is greater than tolerance: 0.050000>.

[INFO] RoadNetwork loaded successfully.

[INFO] OBJ files location: src/maliput_malidrive/obj/.

[INFO] Generating OBJ ...

[INFO] OBJ creation has finished.
```
and now:
```
[INFO] Loading road network using malidrive backend implementation...

[INFO] RoadNetwork loaded successfully.

[INFO] OBJ files location: src/maliput_malidrive/obj/.

[INFO] Generating OBJ ...

[INFO] OBJ creation has finished.

```

Running with `--log_leve=debug` shows the filtered message:
```
maliput_to_obj --maliput_backend=malidrive --xodr_file_path=src/maliput_malidrive/resources/GapInLaneWidthNonDrivableLane.xodr  --linear_tolerance=0.05 --dirpath=src/maliput_malidrive/obj/ --file_name_root="GapInLaneWidth" --draw_elevation_bounds=False --standard_strictness_policy=permissive --log_level=debug
[INFO] Loading road network using malidrive backend implementation...

[DEBUG] Building malidrive RoadNetwork.

[DEBUG] Error when constructing piecewise function. Endpoint distance is <1.200000> which is greater than tolerance: 0.050000>.

[INFO] RoadNetwork loaded successfully.

[INFO] OBJ files location: src/maliput_malidrive/obj/.

[INFO] Generating OBJ ...

[INFO] OBJ creation has finished.
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
