### PR TITLE
Add builder param to tune integrator accuracy.

### DIFF
--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -180,6 +180,16 @@ static constexpr char const* kStandardStrictnessPolicy{"standard_strictness_poli
 ///   - Default: @e "true"
 static constexpr char const* kOmitNonDrivableLanes{"omit_nondrivable_lanes"};
 
+/// Modifier for the accuracy of the integrator used to build each RoadCurve in the maliput::api::RoadGeometry.
+/// This multiplier is expected to be used to increase the accuracy of the integrator in maps where its highly
+/// curved or has a lot of detail just in case the underlying heuristics of the integrator are not enough.
+/// It should be used with care, as it can lead to performance issues if set too high.
+///
+/// The closer to zero, the more accurate the integrator will be.
+/// The default value is 1.0, which means that the integrator will use its default accuracy.
+///   - Default: @e "1.0"
+static constexpr char const* kIntegratorAccuracyMultiplier{"integrator_accuracy_multiplier"};
+
 /// @}
 
 }  // namespace params

--- a/src/maliput_malidrive/base/lane.cc
+++ b/src/maliput_malidrive/base/lane.cc
@@ -54,7 +54,7 @@ using maliput::math::Vector3;
 Lane::Lane(const maliput::api::LaneId& id, int xodr_track, int xodr_lane_id,
            const maliput::api::HBounds& elevation_bounds, const road_curve::RoadCurve* road_curve,
            std::unique_ptr<road_curve::Function> lane_width, std::unique_ptr<road_curve::Function> lane_offset,
-           double p0, double p1)
+           double p0, double p1, double integrator_accuracy_multiplier)
     : maliput::geometry_base::Lane(id),
       xodr_track_(xodr_track),
       xodr_lane_id_(xodr_lane_id),
@@ -62,7 +62,7 @@ Lane::Lane(const maliput::api::LaneId& id, int xodr_track, int xodr_lane_id,
       road_curve_(road_curve),
       p0_(p0),
       p1_(p1),
-      road_curve_offset_(road_curve_, lane_offset.get(), p0, p1),
+      road_curve_offset_(road_curve_, lane_offset.get(), p0, p1, integrator_accuracy_multiplier),
       lane_width_(std::move(lane_width)),
       lane_offset_(std::move(lane_offset)) {
   MALIDRIVE_THROW_UNLESS(xodr_track >= 0);

--- a/src/maliput_malidrive/base/lane.h
+++ b/src/maliput_malidrive/base/lane.h
@@ -72,6 +72,10 @@ class Lane : public maliput::geometry_base::Lane {
   ///        matches the start of the Lane.
   /// @param p1 The value of the @f$ p @f$ parameter of @p road_curve that
   ///        matches the finish of the Lane.
+  /// @param integrator_accuracy_multiplier A multiplier to tune the accuracy of the integrator used under
+  /// RoadCurveOffset implementation.
+  ///        Using 1.0 is expected for most cases, but it can be adjusted to increase or decrease the accuracy of the
+  ///        integrator.
   /// @note When the ground curve's arc length in range `p1` - `p0` is less than
   ///       `road_curve->linear_tolerance()`, an instance will not host a
   ///       RoadCurveOffset to populate `p_from_s_` and `s_from_p_`. Instead,
@@ -85,7 +89,7 @@ class Lane : public maliput::geometry_base::Lane {
   ///         `road_curve->linear_tolerance()` of [ @p p0, @p p1 ] range.
   Lane(const maliput::api::LaneId& id, int xodr_track, int xodr_lane_id, const maliput::api::HBounds& elevation_bounds,
        const road_curve::RoadCurve* road_curve, std::unique_ptr<road_curve::Function> lane_width,
-       std::unique_ptr<road_curve::Function> lane_offset, double p0, double p1);
+       std::unique_ptr<road_curve::Function> lane_offset, double p0, double p1, double integrator_accuracy_multiplier);
 
   /// @return The OpenDRIVE Road Id, which is also referred to as Track Id. It
   ///         is a non-negative number.

--- a/src/maliput_malidrive/builder/road_geometry_builder.cc
+++ b/src/maliput_malidrive/builder/road_geometry_builder.cc
@@ -322,9 +322,9 @@ RoadGeometryBuilder::LaneConstructionResult RoadGeometryBuilder::BuildLane(
   adjacent_lane_functions->width = lane_width.get();
   adjacent_lane_functions->offset = lane_offset.get();
   maliput::log()->trace("Building lane id ", lane_id.string());
-  auto built_lane =
-      std::make_unique<Lane>(lane_id, xodr_track_id, xodr_lane_id, elevation_bounds, segment->road_curve(),
-                             std::move(lane_width), std::move(lane_offset), road_curve_p_0_lane, road_curve_p_1_lane);
+  auto built_lane = std::make_unique<Lane>(
+      lane_id, xodr_track_id, xodr_lane_id, elevation_bounds, segment->road_curve(), std::move(lane_width),
+      std::move(lane_offset), road_curve_p_0_lane, road_curve_p_1_lane, rg_config.integrator_accuracy_multiplier);
   return {segment, std::move(built_lane), {road_header, lane_section, xodr_lane_section_index, lane}};
 }
 

--- a/src/maliput_malidrive/builder/road_geometry_configuration.cc
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.cc
@@ -166,6 +166,11 @@ RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(
   if (it != road_geometry_configuration.end()) {
     rg_config.omit_nondrivable_lanes = ParseBoolean(it->second);
   }
+
+  it = road_geometry_configuration.find(params::kIntegratorAccuracyMultiplier);
+  if (it != road_geometry_configuration.end()) {
+    rg_config.integrator_accuracy_multiplier = std::stod(it->second);
+  }
   return rg_config;
 }
 
@@ -189,6 +194,7 @@ std::map<std::string, std::string> RoadGeometryConfiguration::ToStringMap() cons
   if (build_policy.num_threads.has_value()) {
     config_map.emplace(params::kNumThreads, std::to_string(build_policy.num_threads.value()));
   }
+  config_map.emplace(params::kIntegratorAccuracyMultiplier, std::to_string(integrator_accuracy_multiplier));
   return config_map;
 }
 

--- a/src/maliput_malidrive/builder/road_geometry_configuration.h
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.h
@@ -182,6 +182,7 @@ struct RoadGeometryConfiguration {
   // Lane 1 will not be considered but lane 2 yes. However, because of omitting
   // lane 1, the lane 2 will have an incorrect lane offset function.
   bool omit_nondrivable_lanes{true};
+  double integrator_accuracy_multiplier{1.0};
   /// @}
 };
 

--- a/src/maliput_malidrive/road_curve/road_curve_offset.h
+++ b/src/maliput_malidrive/road_curve/road_curve_offset.h
@@ -64,11 +64,15 @@ class RoadCurveOffset {
   ///        be nullptr.
   /// @param p0 Initial @f$ p @f$ parameter value of the curve.
   /// @param p1 Final @f$ p @f$ parameter value of the curve.
+  /// @param integrator_accuracy_multiplier A multiplier to tune the accuracy of the integrator. Using 1.0 is expected
+  ///        for most cases, but it can be adjusted to increase or decrease the accuracy of the integrator.
   /// @throws maliput::common::assertion_error When @p road_curve is nullptr.
   /// @throws maliput::common::assertion_error When @p lane_offset is nullptr.
   /// @throws maliput::common::assertion_error When @p p0 is negative.
   /// @throws maliput::common::assertion_error When @p p0 is greater than @p p1.
-  RoadCurveOffset(const RoadCurve* road_curve, const Function* lane_offset, double p0, double p1);
+  /// @throws maliput::common::assertion_error When @p integrator_accuracy_multiplier is equal to or less than zero.
+  RoadCurveOffset(const RoadCurve* road_curve, const Function* lane_offset, double p0, double p1,
+                  double integrator_accuracy_multiplier);
 
   /// Returns the constructor RoadCurve argument.
   const RoadCurve* road_curve() const { return road_curve_; }

--- a/test/regression/builder/road_geometry_configuration_test.cc
+++ b/test/regression/builder/road_geometry_configuration_test.cc
@@ -53,6 +53,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
   const double kMaxLinearTolerance{1e-4};
   const double kAngularTolerance{5e-5};
   const double kScaleLength{2.};
+  const double kIntegratorAccuracyMultiplier{0.1};
 
   void ExpectEqual(const RoadGeometryConfiguration& lhs, const RoadGeometryConfiguration& rhs) {
     EXPECT_EQ(lhs.id, rhs.id);
@@ -67,6 +68,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
     EXPECT_EQ(lhs.simplification_policy, rhs.simplification_policy);
     EXPECT_EQ(lhs.standard_strictness_policy, rhs.standard_strictness_policy);
     EXPECT_EQ(lhs.omit_nondrivable_lanes, rhs.omit_nondrivable_lanes);
+    EXPECT_EQ(lhs.integrator_accuracy_multiplier, rhs.integrator_accuracy_multiplier);
   }
 };
 
@@ -80,7 +82,8 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       kBuildPolicy,
       kSimplificationPolicy,
       kStandardStrictnessPolicy,
-      kOmitNondrivableLanes};
+      kOmitNondrivableLanes,
+      kIntegratorAccuracyMultiplier};
 
   const std::map<std::string, std::string> rg_config_map{
       {params::kRoadGeometryId, kRgId},
@@ -96,6 +99,7 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       {params::kStandardStrictnessPolicy,
        RoadGeometryConfiguration::FromStandardStrictnessPolicyToStr(kStandardStrictnessPolicy)},
       {params::kOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
+      {params::kIntegratorAccuracyMultiplier, std::to_string(kIntegratorAccuracyMultiplier)},
   };
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(rg_config_map)};
@@ -113,7 +117,8 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapUsingMaxLinearTolerance) {
       kBuildPolicy,
       kSimplificationPolicy,
       kStandardStrictnessPolicy,
-      kOmitNondrivableLanes};
+      kOmitNondrivableLanes,
+      kIntegratorAccuracyMultiplier};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);
@@ -129,7 +134,8 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapNotUsingMaxLinearTolerance) {
       kBuildPolicy,
       kSimplificationPolicy,
       kStandardStrictnessPolicy,
-      kOmitNondrivableLanes};
+      kOmitNondrivableLanes,
+      kIntegratorAccuracyMultiplier};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);


### PR DESCRIPTION
# 🎉 New feature

## Summary
 - Add builder param to tune integrator accuracy: `integrator_accuracy_multiplier`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
