### PR TITLE
Bug fix for OpenScenarioLanePos to maliput lane conversion.

### DIFF
--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -318,8 +318,11 @@ const Lane* RoadGeometry::GetMaliputLaneFromOpenScenarioLanePosition(
     const Lane* mali_lane = dynamic_cast<const Lane*>(lane.second);
     if (mali_lane->get_track() == xodr_lane_position.road_id &&
         mali_lane->get_lane_id() == xodr_lane_position.lane_id) {
-      if (is_greater_than_or_close(xodr_lane_position.s, mali_lane->get_track_s_start()) &&
-          is_less_than_or_close(xodr_lane_position.s, mali_lane->get_track_s_end())) {
+      const auto segment = dynamic_cast<const Segment*>(mali_lane->segment());
+      MALIPUT_THROW_UNLESS(segment != nullptr);
+      const double xodr_lane_position_s_constrained = segment->road_curve()->PFromP(xodr_lane_position.s);
+      if (is_greater_than_or_close(xodr_lane_position_s_constrained, mali_lane->get_track_s_start()) &&
+          is_less_than_or_close(xodr_lane_position_s_constrained, mali_lane->get_track_s_end())) {
         if (target_lane != nullptr) {
           target_lane = target_lane->get_track_s_start() > mali_lane->get_track_s_start() ? target_lane : mali_lane;
         } else {

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -225,6 +225,12 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   maliput::math::RollPitchYaw GetRoadOrientationAtOpenScenarioRoadPosition(
       const OpenScenarioRoadPosition& xodr_road_position) const;
 
+  /// Finds the maliput lane that corresponds to the given OpenScenario LanePosition.
+  ///
+  /// @param xodr_lane_position The OpenScenario LanePosition to find the corresponding maliput lane.
+  /// @returns A pointer to the corresponding maliput Lane, or nullptr if not found.
+  const Lane* GetMaliputLaneFromOpenScenarioLanePosition(const OpenScenarioLanePosition& xodr_lane_position) const;
+
  private:
   // Holds the description of the Road.
   struct RoadCharacteristics {
@@ -317,9 +323,6 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
 
   // Finds the maliput segment that corresponds to the given OpenScenario RoadPosition.
   const Segment* FindSegmentByOpenScenarioRoadPosition(const OpenScenarioRoadPosition& xodr_road_position) const;
-
-  // Finds the maliput lane that corresponds to the given OpenScenario LanePosition.
-  const Lane* GetMaliputLaneFromOpenScenarioLanePosition(const OpenScenarioLanePosition& xodr_lane_position) const;
 
   // Finds the maliput lane that corresponds to the offset from the intial_lane.
   const Lane* ApplyOffsetToLane(const Lane* initial_lane, int lane_offset) const;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
 - xodr lane position wasn't correctly converted to a maliput lane.
 - tests were added to convert these cases.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
