### PR TITLE
Parse Lane attributes added in OpenDRIVE 1.8

### DIFF
--- a/src/maliput_malidrive/xodr/lane.cc
+++ b/src/maliput_malidrive/xodr/lane.cc
@@ -95,6 +95,32 @@ const std::map<Lane::Type, std::string> type_to_str_map{
     {Lane::Type::kMwyExit, "mwyExit"},
 };
 
+const std::map<std::string, Lane::Advisory> str_to_advisory_map{
+    {"none", Lane::Advisory::kNone},
+    {"inner", Lane::Advisory::kInner},
+    {"outer", Lane::Advisory::kOuter},
+    {"both", Lane::Advisory::kBoth},
+};
+
+const std::map<Lane::Advisory, std::string> advisory_to_str_map{
+    {Lane::Advisory::kNone, "none"},
+    {Lane::Advisory::kInner, "inner"},
+    {Lane::Advisory::kOuter, "outer"},
+    {Lane::Advisory::kBoth, "both"},
+};
+
+const std::map<std::string, Lane::Direction> str_to_direction_map{
+    {"standard", Lane::Direction::kStandard},
+    {"reversed", Lane::Direction::kReversed},
+    {"both", Lane::Direction::kBoth},
+};
+
+const std::map<Lane::Direction, std::string> direction_to_str_map{
+    {Lane::Direction::kStandard, "standard"},
+    {Lane::Direction::kReversed, "reversed"},
+    {Lane::Direction::kBoth, "both"},
+};
+
 }  // namespace
 
 std::string Lane::type_to_str(Type type) { return type_to_str_map.at(type); }
@@ -104,6 +130,24 @@ Lane::Type Lane::str_to_type(const std::string& type) {
     MALIDRIVE_THROW_MESSAGE(type + " lane type is not available.");
   }
   return str_to_type_map.at(type);
+}
+
+std::string Lane::advisory_to_str(Advisory advisory) { return advisory_to_str_map.at(advisory); }
+
+Lane::Advisory Lane::str_to_advisory(const std::string& advisory) {
+  if (str_to_advisory_map.find(advisory) == str_to_advisory_map.end()) {
+    MALIDRIVE_THROW_MESSAGE(advisory + " advisory is not available.");
+  }
+  return str_to_advisory_map.at(advisory);
+}
+
+std::string Lane::direction_to_str(Direction direction) { return direction_to_str_map.at(direction); }
+
+Lane::Direction Lane::str_to_direction(const std::string& direction) {
+  if (str_to_direction_map.find(direction) == str_to_direction_map.end()) {
+    MALIDRIVE_THROW_MESSAGE(direction + " direction is not available.");
+  }
+  return str_to_direction_map.at(direction);
 }
 
 bool Lane::operator==(const Lane& other) const {

--- a/src/maliput_malidrive/xodr/lane.cc
+++ b/src/maliput_malidrive/xodr/lane.cc
@@ -152,7 +152,10 @@ Lane::Direction Lane::str_to_direction(const std::string& direction) {
 
 bool Lane::operator==(const Lane& other) const {
   return id == other.id && type == other.type && level == other.level && lane_link == other.lane_link &&
-         width_description == other.width_description && speed == other.speed && user_data == other.user_data;
+         width_description == other.width_description && speed == other.speed && user_data == other.user_data &&
+         advisory == other.advisory && direction == other.direction &&
+         dynamic_lane_direction == other.dynamic_lane_direction && dynamic_lane_type == other.dynamic_lane_type &&
+         road_works == other.road_works;
 }
 
 bool Lane::operator!=(const Lane& other) const { return !(*this == other); }

--- a/src/maliput_malidrive/xodr/lane.h
+++ b/src/maliput_malidrive/xodr/lane.h
@@ -149,6 +149,7 @@ struct Lane {
     kStandard,
     /// Directly opposite to the standard direction.
     kReversed,
+    /// Bidirectional, both directions are valid.
     kBoth,
   };
 

--- a/src/maliput_malidrive/xodr/lane.h
+++ b/src/maliput_malidrive/xodr/lane.h
@@ -92,6 +92,11 @@ struct Lane {
   static constexpr const char* kId = "id";
   static constexpr const char* kType = "type";
   static constexpr const char* kLevel = "level";
+  static constexpr const char* kAdvisory = "advisory";
+  static constexpr const char* kDirection = "direction";
+  static constexpr const char* kDynamicLaneDirection = "dynamicLaneDirection";
+  static constexpr const char* kDynamicLaneType = "dynamicLaneType";
+  static constexpr const char* kRoadWorks = "roadWorks";
   static constexpr const char* kUserData = "userData";
 
   /// Holds types of lanes.
@@ -127,6 +132,24 @@ struct Lane {
     kHOV,
     kMwyEntry,
     kMwyExit,
+  };
+
+  /// Holds advisory attributes of the lane.
+  enum class Advisory {
+    kNone,
+    kInner,
+    kOuter,
+    kBoth,
+  };
+
+  /// Lane traffic direction.
+  enum class Direction {
+    /// Direction is determined by the combination of <left> or <right> lane grouping and the values LHT or RHT of the
+    /// @rule attribute of a road.
+    kStandard,
+    /// Directly opposite to the standard direction.
+    kReversed,
+    kBoth,
   };
 
   /// Speed description.
@@ -166,6 +189,28 @@ struct Lane {
   /// @throw maliput::common::assertion_error When `type` doesn't match with a Type.
   static Type str_to_type(const std::string& type);
 
+  /// Matches string with an Advisory.
+  /// @param advisory Is an Advisory.
+  /// @returns A string that matches with `advisory`.
+  static std::string advisory_to_str(Advisory advisory);
+
+  /// Matches Advisory with a string.
+  /// @param advisory Is a string.
+  /// @returns An Advisory that matches with `advisory`.
+  /// @throw maliput::common::assertion_error When `advisory` doesn't match with an Advisory.
+  static Advisory str_to_advisory(const std::string& advisory);
+
+  /// Matches string with a Direction.
+  /// @param direction Is a Direction.
+  /// @returns A string that matches with `direction`.
+  static std::string direction_to_str(Direction direction);
+
+  /// Matches Direction with a string.
+  /// @param direction Is a string.
+  /// @returns A Direction that matches with `direction`.
+  /// @throw maliput::common::assertion_error When `direction` doesn't match with a Direction.
+  static Direction str_to_direction(const std::string& direction);
+
   /// Equality operator.
   bool operator==(const Lane& other) const;
 
@@ -188,6 +233,16 @@ struct Lane {
   std::vector<Speed> speed{};
   /// Contains ancillary data in XML format. It holds the entire userData node.
   std::optional<std::string> user_data{std::nullopt};
+  /// Indicates which of the adjacent lanes can be used as an advisory lane.
+  std::optional<Advisory> advisory{std::nullopt};
+  /// Traffic direction of the lane.
+  std::optional<Direction> direction{std::nullopt};
+  /// Indicates whether the lane direction can change dynamically by the scenario during the simulation.
+  std::optional<bool> dynamic_lane_direction{std::nullopt};
+  /// Indicates whether the lane type can change dynamically by the scenario during the simulation.
+  std::optional<bool> dynamic_lane_type{std::nullopt};
+  /// Indicates if the lane is under construction.
+  std::optional<bool> road_works{std::nullopt};
 };
 
 }  // namespace xodr

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -216,6 +216,28 @@ std::optional<Lane::Type> AttributeParser::As(const std::string& attribute_name)
   }
 }
 
+// Specialization to parse as `Lane::Advisory` the attribute's value.
+template <>
+std::optional<Lane::Advisory> AttributeParser::As(const std::string& attribute_name) const {
+  const std::optional<std::string> advisory = As<std::string>(attribute_name);
+  if (advisory.has_value()) {
+    return Lane::str_to_advisory(advisory.value());
+  } else {
+    return std::nullopt;
+  }
+}
+
+// Specialization to parse as `Lane::Direction` the attribute's value.
+template <>
+std::optional<Lane::Direction> AttributeParser::As(const std::string& attribute_name) const {
+  const std::optional<std::string> direction = As<std::string>(attribute_name);
+  if (direction.has_value()) {
+    return Lane::str_to_direction(direction.value());
+  } else {
+    return std::nullopt;
+  }
+}
+
 // Specialization to parse as `RoadLink::ElementType` the attribute's value.
 template <>
 std::optional<RoadLink::ElementType> AttributeParser::As(const std::string& attribute_name) const {
@@ -530,6 +552,11 @@ Lane NodeParser::As() const {
   // Optional attributes.
   // @{
   const auto level = attribute_parser.As<bool>(Lane::kLevel);
+  const auto advisory = attribute_parser.As<Lane::Advisory>(Lane::kAdvisory);
+  const auto direction = attribute_parser.As<Lane::Direction>(Lane::kDirection);
+  const auto dynamic_lane_direction = attribute_parser.As<bool>(Lane::kDynamicLaneDirection);
+  const auto dynamic_lane_type = attribute_parser.As<bool>(Lane::kDynamicLaneType);
+  const auto road_works = attribute_parser.As<bool>(Lane::kRoadWorks);
   // @}
 
   // Elements.
@@ -571,7 +598,18 @@ Lane NodeParser::As() const {
   if (user_data_element != nullptr) {
     user_data = ConvertXMLNodeToText(user_data_element);
   }
-  return {Lane::Id(id.value()), type.value(), level, lane_link, width_description, speeds, user_data};
+  return {Lane::Id(id.value()),
+          type.value(),
+          level,
+          lane_link,
+          width_description,
+          speeds,
+          user_data,
+          advisory,
+          direction,
+          dynamic_lane_direction,
+          dynamic_lane_type,
+          road_works};
 }
 
 namespace {

--- a/test/regression/xodr/lane_test.cc
+++ b/test/regression/xodr/lane_test.cc
@@ -113,6 +113,73 @@ GTEST_TEST(LaneTypeTest, StrToTypeThrowsWithUnknownToken) {
 INSTANTIATE_TEST_CASE_P(GroupTypeStringConversionTest, TypeStringConversionTest,
                         ::testing::ValuesIn(GetTestingLaneTypeAndStringTypes()));
 
+// Holds the Lane::Advisory and its string representation.
+struct LaneAdvisoryAndStrAdvisory {
+  Lane::Advisory advisory{};
+  std::string str_advisory{};
+};
+
+std::vector<LaneAdvisoryAndStrAdvisory> GetTestingLaneAdvisoryAndStringAdvisories() {
+  return std::vector<LaneAdvisoryAndStrAdvisory>{
+      {Lane::Advisory::kNone, "none"},
+      {Lane::Advisory::kInner, "inner"},
+      {Lane::Advisory::kOuter, "outer"},
+      {Lane::Advisory::kBoth, "both"},
+  };
+}
+
+// Tests Lane::Advisory to and from string conversion.
+class AdvisoryStringConversionTest : public ::testing::TestWithParam<LaneAdvisoryAndStrAdvisory> {
+ public:
+  const Lane::Advisory advisory_{GetParam().advisory};
+  const std::string str_advisory_{GetParam().str_advisory};
+};
+
+TEST_P(AdvisoryStringConversionTest, AdvisoryToStr) { ASSERT_EQ(str_advisory_, Lane::advisory_to_str(advisory_)); }
+
+TEST_P(AdvisoryStringConversionTest, StrToAdvisory) { ASSERT_EQ(advisory_, Lane::str_to_advisory(str_advisory_)); }
+
+GTEST_TEST(LaneAdvisoryTest, StrToAdvisoryThrowsWithUnknownToken) {
+  const std::string kWrongValue{"WrongValue"};
+  EXPECT_THROW(Lane::str_to_advisory(kWrongValue), maliput::common::assertion_error);
+}
+
+INSTANTIATE_TEST_CASE_P(GroupAdvisoryStringConversionTest, AdvisoryStringConversionTest,
+                        ::testing::ValuesIn(GetTestingLaneAdvisoryAndStringAdvisories()));
+
+// Holds the Lane::Direction and its string representation.
+struct LaneDirectionAndStrDirection {
+  Lane::Direction direction{};
+  std::string str_direction{};
+};
+
+std::vector<LaneDirectionAndStrDirection> GetTestingLaneDirectionAndStringDirections() {
+  return std::vector<LaneDirectionAndStrDirection>{
+      {Lane::Direction::kStandard, "standard"},
+      {Lane::Direction::kReversed, "reversed"},
+      {Lane::Direction::kBoth, "both"},
+  };
+}
+
+// Tests Lane::Direction to and from string conversion.
+class DirectionStringConversionTest : public ::testing::TestWithParam<LaneDirectionAndStrDirection> {
+ public:
+  const Lane::Direction direction_{GetParam().direction};
+  const std::string str_direction_{GetParam().str_direction};
+};
+
+TEST_P(DirectionStringConversionTest, DirectionToStr) { ASSERT_EQ(str_direction_, Lane::direction_to_str(direction_)); }
+
+TEST_P(DirectionStringConversionTest, StrToDirection) { ASSERT_EQ(direction_, Lane::str_to_direction(str_direction_)); }
+
+GTEST_TEST(LaneDirectionTest, StrToDirectionThrowsWithUnknownToken) {
+  const std::string kWrongValue{"WrongValue"};
+  EXPECT_THROW(Lane::str_to_direction(kWrongValue), maliput::common::assertion_error);
+}
+
+INSTANTIATE_TEST_CASE_P(GroupDirectionStringConversionTest, DirectionStringConversionTest,
+                        ::testing::ValuesIn(GetTestingLaneDirectionAndStringDirections()));
+
 GTEST_TEST(Lane, EqualityOperator) {
   const LaneLink lane_link{LaneLink::LinkAttributes{LaneLink::LinkAttributes::Id("35")},
                            LaneLink::LinkAttributes{LaneLink::LinkAttributes::Id("70")}};
@@ -123,7 +190,12 @@ GTEST_TEST(Lane, EqualityOperator) {
       lane_link /* lane_link */,
       {{1.1 /* sOffset */, 2.2 /* a */}, {6.6 /* sOffset */, 7.7 /* a */}} /* widths */,
       {{0. /* sOffset */, 15. /* max */, Unit::kMph /* unit */}} /* speed */,
-      std::nullopt /* userData */
+      std::nullopt /* userData */,
+      Lane::Advisory::kOuter /* advisory */,
+      Lane::Direction::kStandard /* direction */,
+      false /* dynamic_lane_direction */,
+      false /* dynamic_lane_type */,
+      true /* road_works */
   };
   Lane lane = kLane;
 
@@ -149,6 +221,26 @@ GTEST_TEST(Lane, EqualityOperator) {
   lane.user_data = std::make_optional<std::string>("<root></root>");
   EXPECT_NE(kLane, lane);
   lane.user_data = std::nullopt;
+  EXPECT_EQ(kLane, lane);
+  lane.advisory = Lane::Advisory::kInner;
+  EXPECT_NE(kLane, lane);
+  lane.advisory = Lane::Advisory::kOuter;
+  EXPECT_EQ(kLane, lane);
+  lane.direction = Lane::Direction::kReversed;
+  EXPECT_NE(kLane, lane);
+  lane.direction = Lane::Direction::kStandard;
+  EXPECT_EQ(kLane, lane);
+  lane.dynamic_lane_direction = std::make_optional<bool>(true);
+  EXPECT_NE(kLane, lane);
+  lane.dynamic_lane_direction = std::make_optional<bool>(false);
+  EXPECT_EQ(kLane, lane);
+  lane.dynamic_lane_type = std::make_optional<bool>(true);
+  EXPECT_NE(kLane, lane);
+  lane.dynamic_lane_type = std::make_optional<bool>(false);
+  EXPECT_EQ(kLane, lane);
+  lane.road_works = std::make_optional<bool>(false);
+  EXPECT_NE(kLane, lane);
+  lane.road_works = std::make_optional<bool>(true);
   EXPECT_EQ(kLane, lane);
 }
 

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -817,9 +817,10 @@ std::string GetLane(const std::string& id, const std::string& type, const std::s
                     const std::string& road_works) {
   std::stringstream ss;
   ss << "<root>";
-  ss << "<lane id='" << id << "' type='" << type << "' level='" << level << "' advisory='" << advisory
-     << "' direction='" << direction << "' dynamic_lane_direction='" << dynamic_lane_direction
-     << "' dynamic_lane_type='" << dynamic_lane_type << "' road_works='" << road_works << "'>";
+  ss << "<lane " << Lane::kId << "='" << id << "' " << Lane::kType << "='" << type << "' " << Lane::kLevel << "='"
+     << level << "' " << Lane::kAdvisory << "='" << advisory << "' " << Lane::kDirection << "='" << direction << "' "
+     << Lane::kDynamicLaneDirection << "='" << dynamic_lane_direction << "' " << Lane::kDynamicLaneType << "='"
+     << dynamic_lane_type << "' " << Lane::kRoadWorks << "='" << road_works << "'>";
   ss << "<link>";
   ss << "<predecessor id='50'/>";
   ss << "<successor id='80'/>";
@@ -865,12 +866,11 @@ TEST_F(ParsingTests, NodeParserLane) {
       kRoadWorks /* road_works */
   };
   const std::string xml_description = GetLane(
-      kExpectedLane.id.string(), Lane::type_to_str(kExpectedLane.type), kExpectedLane.level.value() ? "true" :
-      "false", kUserData.value(), Lane::advisory_to_str(kExpectedLane.advisory.value()),
+      kExpectedLane.id.string(), Lane::type_to_str(kExpectedLane.type), kExpectedLane.level.value() ? "true" : "false",
+      kUserData.value(), Lane::advisory_to_str(kExpectedLane.advisory.value()),
       Lane::direction_to_str(kExpectedLane.direction.value()),
       kExpectedLane.dynamic_lane_direction.value() ? "true" : "false",
-      kExpectedLane.dynamic_lane_type.value() ? "true" : "false", kExpectedLane.road_works.value() ? "true" :
-      "false");
+      kExpectedLane.dynamic_lane_type.value() ? "true" : "false", kExpectedLane.road_works.value() ? "true" : "false");
   std::cout << "XML description: " << xml_description << std::endl;
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Lane::kLaneTag),

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -804,6 +804,12 @@ TEST_F(ParsingTests, NodeParserLaneLink) {
 // @param id The id value.
 // @param type The type value.
 // @param level The level value.
+// @param user_data The userData XODR node value.
+// @param advisory The advisory value.
+// @param direction The direction value.
+// @param dynamic_lane_direction The dynamicLaneDirection value.
+// @param dynamic_lane_type The dynamicLaneType value.
+// @param road_works The roadWorks value.
 // @returns A string that contains a XML description of a XODR Lane node.
 std::string GetLane(const std::string& id, const std::string& type, const std::string& level,
                     const std::string& user_data, const std::string& advisory, const std::string& direction,
@@ -813,7 +819,7 @@ std::string GetLane(const std::string& id, const std::string& type, const std::s
   ss << "<root>";
   ss << "<lane id='" << id << "' type='" << type << "' level='" << level << "' advisory='" << advisory
      << "' direction='" << direction << "' dynamic_lane_direction='" << dynamic_lane_direction
-     << "' dynamic_lane_type='" << dynamic_lane_type << "' road_works='" << road_works << "' >";
+     << "' dynamic_lane_type='" << dynamic_lane_type << "' road_works='" << road_works << "'>";
   ss << "<link>";
   ss << "<predecessor id='50'/>";
   ss << "<successor id='80'/>";
@@ -838,37 +844,49 @@ TEST_F(ParsingTests, NodeParserLane) {
       {6.6 /* sOffset */, 7.7 /* a */, 8.8 /* b */, 9.9 /* c */, 10.1 /* d */}};
   const std::vector<Lane::Speed> kSpeed{{0.1 /* sOffset */, 45. /* max */, Unit::kMph /* unit */},
                                         {0.5 /* sOffset */, 3. /* max */, Unit::kMs /* unit */}};
-  const std::optional<std::string> kUserData{"<userData/>"};
+  const std::optional<std::string> kUserData{"<userData/>\n"};
   const std::optional<Lane::Advisory> kAdvisory{Lane::Advisory::kInner};
   const std::optional<Lane::Direction> kDirection{Lane::Direction::kStandard};
-  const std::optional<bool> kDynamicLaneDirection{false};
+  const std::optional<bool> kDynamicLaneDirection{true};
   const std::optional<bool> kDynamicLaneType{false};
   const std::optional<bool> kRoadWorks{false};
-  const Lane kExpectedLane{Lane::Id("test_id") /* id */,
-                           Lane::Type::kDriving /* type */,
-                           false /* level */,
-                           lane_link /* lane_link */,
-                           kWidthDescription /* widths */,
-                           kSpeed /* speed */,
-                           kUserData /* user_data */,
-                           kAdvisory /* advisory */,
-                           kDirection /* direction */,
-                           kDynamicLaneDirection /* dynamic_lane_direction */,
-                           kDynamicLaneType /* dynamic_lane_type */,
-                           kRoadWorks /* road_works */};
-
+  const Lane kExpectedLane{
+      Lane::Id("test_id") /* id */,
+      Lane::Type::kDriving /* type */,
+      false /* level */,
+      lane_link /* lane_link */,
+      kWidthDescription /* widths */,
+      kSpeed /*speed*/,
+      kUserData /* user_data */,
+      kAdvisory /* advisory */,
+      kDirection /* direction */,
+      kDynamicLaneDirection /* dynamic_lane_direction */,
+      kDynamicLaneType /* dynamic_lane_type */,
+      kRoadWorks /* road_works */
+  };
   const std::string xml_description = GetLane(
-      kExpectedLane.id.string(), Lane::type_to_str(kExpectedLane.type), kExpectedLane.level.value() ? "true" : "false",
-      kUserData.value(), Lane::advisory_to_str(kExpectedLane.advisory.value()),
+      kExpectedLane.id.string(), Lane::type_to_str(kExpectedLane.type), kExpectedLane.level.value() ? "true" :
+      "false", kUserData.value(), Lane::advisory_to_str(kExpectedLane.advisory.value()),
       Lane::direction_to_str(kExpectedLane.direction.value()),
       kExpectedLane.dynamic_lane_direction.value() ? "true" : "false",
-      kExpectedLane.dynamic_lane_type.value() ? "true" : "false", kExpectedLane.road_works.value() ? "true" : "false");
+      kExpectedLane.dynamic_lane_type.value() ? "true" : "false", kExpectedLane.road_works.value() ? "true" :
+      "false");
   std::cout << "XML description: " << xml_description << std::endl;
 
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Lane::kLaneTag),
                        {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_EQ(Lane::kLaneTag, dut.GetName());
   const Lane lane = dut.As<Lane>();
+  EXPECT_EQ(kExpectedLane.id, lane.id);
+  EXPECT_EQ(kExpectedLane.type, lane.type);
+  EXPECT_EQ(kExpectedLane.level, lane.level);
+  EXPECT_EQ(kExpectedLane.speed, lane.speed);
+  EXPECT_EQ(kExpectedLane.advisory, lane.advisory);
+  EXPECT_EQ(kExpectedLane.direction, lane.direction);
+  EXPECT_EQ(kExpectedLane.dynamic_lane_direction, lane.dynamic_lane_direction);
+  EXPECT_EQ(kExpectedLane.dynamic_lane_type, lane.dynamic_lane_type);
+  EXPECT_EQ(kExpectedLane.road_works, lane.road_works);
+  EXPECT_EQ(kExpectedLane.user_data.value(), lane.user_data.value());
   EXPECT_EQ(kExpectedLane, lane);
 }
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
Support to parse XODR Lane attributes added in OpenDRIVE version 1.8 such as:
*  Advisory
* Direction
* DynamicLaneDirection
* DynamicLaneType
* RoadWorks

See for more info: https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/11_lanes/11_02_lane_groups.html

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
