### PR TITLE
Use road::rule XODR attribute to convert to a traffic direction rule.

### DIFF
--- a/resources/StraightRoadMultipleLaneDirections.xodr
+++ b/resources/StraightRoadMultipleLaneDirections.xodr
@@ -2,7 +2,7 @@
 <!--
  BSD 3-Clause License
 
- Copyright (c) 2022, Woven Planet. All rights reserved.
+ Copyright (c) 2025, Woven Planet. All rights reserved.
  Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <OpenDRIVE>
-    <header revMajor="1" revMinor="1" name="StraightRoadMultipleLaneDirections" version="1.00" date="Wed Jul 2 12:00:00 2025" north="0.0" south="0.0" east="0.0" west="0.0" maxRoad="2" maxJunc="0" maxPrg="0">
+    <header revMajor="1" revMinor="8" name="StraightRoadMultipleLaneDirections" version="1.00" date="Wed Jul 2 12:00:00 2025" north="0.0" south="0.0" east="0.0" west="0.0" maxRoad="2" maxJunc="0" maxPrg="0">
     </header>
     <road name="RightHandTraffic" length="10.0" id="1" junction="-1" rule="RHT">
         <link>
@@ -85,7 +85,7 @@
                     </lane>
                 </left>
                 <center>
-                    <lane id="0" type="driving" level= "0">
+                    <lane id="0" type="none" level= "0">
                         <link>
                         </link>
                         <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>
@@ -187,7 +187,7 @@
                     </lane>
                 </left>
                 <center>
-                    <lane id="0" type="driving" level= "0">
+                    <lane id="0" type="none" level= "0">
                         <link>
                         </link>
                         <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>
@@ -288,7 +288,7 @@
                     </lane>
                 </left>
                 <center>
-                    <lane id="0" type="driving" level= "0">
+                    <lane id="0" type="none" level= "0">
                         <link>
                         </link>
                         <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>

--- a/resources/StraightRoadMultipleLaneDirections.xodr
+++ b/resources/StraightRoadMultipleLaneDirections.xodr
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2022, Woven Planet. All rights reserved.
+ Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="1" name="StraightRoadMultipleLaneDirections" version="1.00" date="Wed Jul 2 12:00:00 2025" north="0.0" south="0.0" east="0.0" west="0.0" maxRoad="2" maxJunc="0" maxPrg="0">
+    </header>
+    <road name="RightHandTraffic" length="10.0" id="1" junction="-1" rule="RHT">
+        <link>
+            <successor elementType="road" elementId="2" contactPoint="start" />
+        </link>
+        <planView>
+            <geometry s="0.0" x="0.0" y="0.0" hdg="0.0" length="10.0">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="4" type="driving" level= "0">
+                        <link>
+                            <successor id="4"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='bidirectional'/>
+                        </userData>
+                    </lane>
+                    <lane id="3" type="driving" level= "0" direction="both">
+                        <link>
+                            <successor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='forward'/>
+                        </userData>
+                    </lane>
+                    <lane id="2" type="driving" level= "0" direction="standard">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="1" type="driving" level= "0" direction="reversed">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "0" direction="both">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="-2" type="driving" level= "0">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="-3" type="driving" level= "0">
+                        <link>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='backward'/>
+                        </userData>
+                    </lane>
+                    <lane id="-4" type="driving" level= "0">
+                        <link>
+                            <successor id="-4"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='undirected'/>
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+    </road>
+    <road name="LeftHandTraffic" length="10.0" id="2" junction="-1" rule="LHT">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+            <successor elementType="road" elementId="3" contactPoint="start" />
+        </link>
+        <planView>
+            <geometry s="0.0" x="10.0" y="0.0" hdg="0.0" length="10.0">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="4" type="driving" level= "0" direction="reversed">
+                        <link>
+                            <successor id="4"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='bidirectional'/>
+                        </userData>
+                    </lane>
+                    <lane id="3" type="driving" level= "0" direction="both">
+                        <link>
+                            <successor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='forward'/>
+                        </userData>
+                    </lane>
+                    <lane id="2" type="driving" level= "0" direction="standard">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="1" type="driving" level= "0" direction="reversed">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "0" direction="both">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="-2" type="driving" level= "0">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="-3" type="driving" level= "0">
+                        <link>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='backward'/>
+                        </userData>
+                    </lane>
+                    <lane id="-4" type="driving" level= "0">
+                        <link>
+                            <successor id="-4"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='undirected'/>
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+    </road>
+    <road name="DefaultHandTraffic" length="10.0" id="3" junction="-1">
+        <link>
+            <predecessor elementType="road" elementId="2" contactPoint="end" />
+        </link>
+        <planView>
+            <geometry s="0." x="20.0" y="0.0" hdg="0.0" length="10.0">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="4" type="driving" level= "0" direction="both">
+                        <link>
+                            <successor id="4"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='bidirectional'/>
+                        </userData>
+                    </lane>
+                    <lane id="3" type="driving" level= "0" direction="both">
+                        <link>
+                            <successor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='forward'/>
+                        </userData>
+                    </lane>
+                    <lane id="2" type="driving" level= "0" direction="standard">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="1" type="driving" level= "0" direction="reversed">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "0" direction="both">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="-2" type="driving" level= "0">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                    <lane id="-3" type="driving" level= "0">
+                        <link>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='backward'/>
+                        </userData>
+                    </lane>
+                    <lane id="-4" type="driving" level= "0">
+                        <link>
+                            <successor id="-4"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                        <userData>
+                            <vectorLane travelDir='undirected'/>
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -280,7 +280,7 @@ const std::map<LaneTravelDirection::Direction, std::string> xodr_to_maliput_dire
 
 LaneTravelDirection::LaneTravelDirection(const Direction& direction) : travel_dir_(direction) {}
 
-LaneTravelDirection LaneTravelDirection::CreateFromUserData(const std::optional<std::string>& user_data) {
+LaneTravelDirection LaneTravelDirection::FromUserData(const std::optional<std::string>& user_data) {
   LaneTravelDirection travel_direction(LaneTravelDirection::Direction::kUndefined);
   if (!user_data.has_value()) {
     return travel_direction;
@@ -306,13 +306,13 @@ LaneTravelDirection LaneTravelDirection::CreateFromUserData(const std::optional<
   return travel_direction;
 }
 
-LaneTravelDirection LaneTravelDirection::CreateFromLaneGroupDirection(
+LaneTravelDirection LaneTravelDirection::FromLaneGroupDirection(
     int lane_id, const xodr::Lane::Direction& hand_traffic_rule_direction,
     const std::optional<xodr::RoadHeader::HandTrafficRule>& hand_traffic_rule) {
   if (hand_traffic_rule_direction == xodr::Lane::Direction::kBoth) {
     return LaneTravelDirection(LaneTravelDirection::Direction::kBidirectional);
   }
-  LaneTravelDirection travel_direction = CreateFromHandTrafficRule(lane_id, hand_traffic_rule);
+  LaneTravelDirection travel_direction = FromHandTrafficRule(lane_id, hand_traffic_rule);
   if (hand_traffic_rule_direction == xodr::Lane::Direction::kStandard) {
     return travel_direction;
   }
@@ -326,7 +326,7 @@ LaneTravelDirection LaneTravelDirection::CreateFromLaneGroupDirection(
   return travel_direction;
 }
 
-LaneTravelDirection LaneTravelDirection::CreateFromHandTrafficRule(
+LaneTravelDirection LaneTravelDirection::FromHandTrafficRule(
     int lane_id, const std::optional<xodr::RoadHeader::HandTrafficRule>& hand_traffic_rule) {
   LaneTravelDirection travel_direction(LaneTravelDirection::Direction::kUndefined);
   const auto rule = hand_traffic_rule.value_or(xodr::RoadHeader::HandTrafficRule::kRHT);
@@ -448,19 +448,19 @@ const xodr::Lane& GetXodrLaneFromMalidriveLane(const Lane* lane) {
 }
 
 std::string GetDirectionUsageRuleStateType(const xodr::RoadHeader& xodr_road, const xodr::Lane& xodr_lane) {
-  const LaneTravelDirection user_data_travel_dir = LaneTravelDirection::CreateFromUserData(xodr_lane.user_data);
+  const LaneTravelDirection user_data_travel_dir = LaneTravelDirection::FromUserData(xodr_lane.user_data);
   if (user_data_travel_dir.GetXodrTravelDir() != LaneTravelDirection::Direction::kUndefined) {
     return user_data_travel_dir.GetMaliputTravelDir();
   }
 
   int lane_id = std::stoi(xodr_lane.id.string());
   if (xodr_lane.direction.has_value()) {
-    return LaneTravelDirection::CreateFromLaneGroupDirection(lane_id, xodr_lane.direction.value(), xodr_road.rule)
+    return LaneTravelDirection::FromLaneGroupDirection(lane_id, xodr_lane.direction.value(), xodr_road.rule)
         .GetMaliputTravelDir();
   }
 
   const LaneTravelDirection hand_traffic_rule_travel_dir =
-      LaneTravelDirection::CreateFromHandTrafficRule(lane_id, xodr_road.rule);
+      LaneTravelDirection::FromHandTrafficRule(lane_id, xodr_road.rule);
   return hand_traffic_rule_travel_dir.GetMaliputTravelDir();
 }
 

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -305,20 +305,16 @@ LaneTravelDirection LaneTravelDirection::CreateFromUserData(const std::optional<
 }
 
 LaneTravelDirection LaneTravelDirection::CreateFromLaneGroupDirection(
-    int lane_id, const std::optional<xodr::Lane::Direction>& hand_traffic_rule_direction,
+    int lane_id, const xodr::Lane::Direction& hand_traffic_rule_direction,
     const std::optional<xodr::RoadHeader::HandTrafficRule>& hand_traffic_rule) {
-  if (!hand_traffic_rule_direction.has_value()) {
-    return LaneTravelDirection(LaneTravelDirection::Direction::kUndefined);
-  }
-  auto lane_direction = hand_traffic_rule_direction.value();
-  if (lane_direction == xodr::Lane::Direction::kBoth) {
+  if (hand_traffic_rule_direction == xodr::Lane::Direction::kBoth) {
     return LaneTravelDirection(LaneTravelDirection::Direction::kBidirectional);
   }
   LaneTravelDirection travel_direction = CreateFromHandTrafficRule(lane_id, hand_traffic_rule);
-  if (lane_direction == xodr::Lane::Direction::kStandard) {
+  if (hand_traffic_rule_direction == xodr::Lane::Direction::kStandard) {
     return travel_direction;
   }
-  if (lane_direction == xodr::Lane::Direction::kReversed) {
+  if (hand_traffic_rule_direction == xodr::Lane::Direction::kReversed) {
     if (travel_direction.travel_dir_ == LaneTravelDirection::Direction::kForward) {
       travel_direction.travel_dir_ = LaneTravelDirection::Direction::kBackward;
     } else if (travel_direction.travel_dir_ == LaneTravelDirection::Direction::kBackward) {
@@ -456,10 +452,9 @@ std::string GetDirectionUsageRuleStateType(const xodr::RoadHeader& xodr_road, co
   }
 
   int lane_id = std::stoi(xodr_lane.id.string());
-  const LaneTravelDirection lane_group_travel_dir =
-      LaneTravelDirection::CreateFromLaneGroupDirection(lane_id, xodr_lane.direction, xodr_road.rule);
-  if (lane_group_travel_dir.GetXodrTravelDir() != LaneTravelDirection::Direction::kUndefined) {
-    return lane_group_travel_dir.GetMaliputTravelDir();
+  if (xodr_lane.direction.has_value()) {
+    return LaneTravelDirection::CreateFromLaneGroupDirection(lane_id, xodr_lane.direction.value(), xodr_road.rule)
+        .GetMaliputTravelDir();
   }
 
   const LaneTravelDirection hand_traffic_rule_travel_dir =

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -278,6 +278,8 @@ const std::map<LaneTravelDirection::Direction, std::string> xodr_to_maliput_dire
 
 }  // namespace
 
+LaneTravelDirection::LaneTravelDirection(const Direction& direction) : travel_dir_(direction) {}
+
 LaneTravelDirection LaneTravelDirection::CreateFromUserData(const std::optional<std::string>& user_data) {
   LaneTravelDirection travel_direction(LaneTravelDirection::Direction::kUndefined);
   if (!user_data.has_value()) {

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -158,8 +158,6 @@ class LaneTravelDirection {
   /// Note: "Undefined" refer to when travel direction information is omitted or node isn't well formed.
   enum class Direction { kUndirected = 0, kForward, kBackward, kBidirectional, kUndefined };
 
-  explicit LaneTravelDirection(Direction direction) : travel_dir_(direction) {}
-
   /// Constructs a LaneTravelDirection from userData.
   /// @param user_data Contains a UserData XMLNode that holds information
   ///                  about the direction of the lane.
@@ -210,6 +208,8 @@ class LaneTravelDirection {
   std::string GetMaliputTravelDir() const;
 
  private:
+  LaneTravelDirection(const Direction& direction) : travel_dir_(direction) {}
+
   // Matches Direction with a string.
   // @param direction Is a string.
   // @returns A Direction that matches with `direction`.
@@ -344,10 +344,16 @@ const xodr::Lane& GetXodrLaneFromMalidriveLane(const Lane* lane);
 /// @returns The direction usage value of the target lane. It is one in the string set
 /// `{"AgainstS", "WithS", "Bidirectional", "Undefined"}`.
 /// This method obtains the direction based on 3 different sources, in the priority detailed below:
-/// 1 - If the userData is set as part of the lane description, it takes precedence.
-/// 2 - If the lane has a direction attribute, the road::rule is used with the lane direction modifier.
-/// 3 - The road::rule determines the direction based on the lane ID.
-/// 4 - If road::rule is not set, the direction is set to "WithS".
+/// 1. If the userData is set as part of the lane description, it takes precedence.
+/// 2. If the lane has a direction attribute, the road::rule is used with the lane direction modifier.
+/// 3. The road::rule determines the direction based on the lane ID and wheter it is set as RHT or LHT.
+/// 4. If road::rule is not set, it is assumed as it was RHT.
+///
+/// See:
+///   * [UserData](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/07_additional_data/07_00_additional_data.html#_additional_user_data)
+///   * [LaneGroups](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/11_lanes/11_02_lane_groups.html)
+///   * [LaneDirection](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/16_annexes/enumerations/map_uml_enumerations.html#top-EAID_BDEEA32B_3F22_4f2c_A327_04437D41CC3D)
+///   * [RoadRule](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/10_roads/10_01_introduction.html)
 ///
 /// @param xodr_road The XODR RoadHeader that contains the lane.
 /// @param xodr_lane The XODR Lane to obtain the direction usage value from.

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -168,7 +168,7 @@ class LaneTravelDirection {
   ///  </userData>
   /// @endcode
   /// @returns A LaneTravelDirection.
-  static LaneTravelDirection CreateFromUserData(const std::optional<std::string>& user_data);
+  static LaneTravelDirection FromUserData(const std::optional<std::string>& user_data);
 
   /// Constructs a LaneTravelDirection from a specific lane direction.
   /// @param lane_id The ID of the lane to obtain the direction from.
@@ -181,7 +181,7 @@ class LaneTravelDirection {
   ///  </lane>
   /// @endcode
   /// @returns A LaneTravelDirection.
-  static LaneTravelDirection CreateFromLaneGroupDirection(
+  static LaneTravelDirection FromLaneGroupDirection(
       int lane_id, const xodr::Lane::Direction& hand_traffic_rule_direction,
       const std::optional<xodr::RoadHeader::HandTrafficRule>& hand_traffic_rule);
 
@@ -195,7 +195,7 @@ class LaneTravelDirection {
   ///  </road>
   /// @endcode
   /// @returns A LaneTravelDirection.
-  static LaneTravelDirection CreateFromHandTrafficRule(
+  static LaneTravelDirection FromHandTrafficRule(
       int lane_id, const std::optional<xodr::RoadHeader::HandTrafficRule>& hand_traffic_rule);
 
   /// @returns The direction of the lane describend in the XML node.

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -149,29 +149,49 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsForInnerLaneSection(
     const maliput::api::RoadGeometry* rg, const maliput::api::LaneEnd& lane_end,
     const MalidriveXodrLaneProperties& xodr_lane_properties);
 
-/// Hold the travel direction of a lane obtained from parsing a userData XML node.
-/// An userData node example:
-/// @code{.xml}
-///  <userData>
-///      <vectorLane travelDir="undirected"/>
-///  </userData>
-/// @endcode
+/// Hold the travel direction of a lane from parsing an XML node.
 class LaneTravelDirection {
  public:
   MALIDRIVE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LaneTravelDirection)
   LaneTravelDirection() = delete;
-
-  /// Constructs a LaneTravelDirection.
-  /// @param user_data Contains a UserData XMLNode that holds information
-  ///                  about the direction of the lane.
-  /// @throw maliput::common::assertion_error When the travel direction information is not compatible.
-  explicit LaneTravelDirection(const std::optional<std::string>& user_data);
-
   /// Possible directions obtained from the XODR.
   /// Note: "Undefined" refer to when travel direction information is omitted or node isn't well formed.
   enum class Direction { kUndirected = 0, kForward, kBackward, kBidirectional, kUndefined };
 
-  /// @returns The direction of the lane describend in the userData XML node.
+  explicit LaneTravelDirection(Direction direction) : travel_dir_(direction) {}
+
+  /// Constructs a LaneTravelDirection from userData.
+  /// @param user_data Contains a UserData XMLNode that holds information
+  ///                  about the direction of the lane.
+  /// An userData node example:
+  /// @code{.xml}
+  ///  <userData>
+  ///      <vectorLane travelDir="undirected"/>
+  ///  </userData>
+  /// @endcode
+  /// @returns A LaneTravelDirection.
+  /// @throw maliput::common::assertion_error When the travel direction information is not compatible.
+  static LaneTravelDirection CreateFromUserData(const std::optional<std::string>& user_data);
+
+  /// Constructs a LaneTravelDirection from a specific lane direction.
+  /// @param direction Direction for the lane.
+  /// @returns A LaneTravelDirection.
+  static LaneTravelDirection CreateFromLaneGroupDirection(Direction direction);
+
+  /// Constructs a LaneTravelDirection from a hand traffic rule.
+  /// @param hand_traffic_rule Contains a rule parameter that holds information about the direction of lanes in a road.
+  /// @param lane Contains the lane to obtain the direction from @p hand_traffic_rule.
+  /// A road node example:
+  /// @code{.xml}
+  ///  <road name="Road 0" id="0" rule="RHT|LHT">
+  ///      <lanes/>
+  ///  </road>
+  /// @endcode
+  /// @returns A LaneTravelDirection.
+  static LaneTravelDirection CreateFromHandTrafficRule(
+      const std::optional<xodr::RoadHeader::HandTrafficRule>& hand_traffic_rule, const Lane* lane);
+
+  /// @returns The direction of the lane describend in the XML node.
   Direction GetXodrTravelDir() const { return travel_dir_; };
 
   /// Matches the travel direction with Maliput's standard.

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -168,7 +168,6 @@ class LaneTravelDirection {
   ///  </userData>
   /// @endcode
   /// @returns A LaneTravelDirection.
-  /// @throw maliput::common::assertion_error When the travel direction information is not compatible.
   static LaneTravelDirection CreateFromUserData(const std::optional<std::string>& user_data);
 
   /// Constructs a LaneTravelDirection from a specific lane direction.

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -341,7 +341,7 @@ const xodr::RoadHeader& GetXodrRoadFromMalidriveLane(const Lane* lane);
 const xodr::Lane& GetXodrLaneFromMalidriveLane(const Lane* lane);
 
 /// @returns The direction usage value of the target lane. It is one in the string set
-/// `{"AgainstS", "WithS", "Bidirectional", "Undefined"}`.
+/// `{"AgainstS", "WithS", "Bidirectional"}`.
 /// This method obtains the direction based on 3 different sources, in the priority detailed below:
 /// 1. If the userData is set as part of the lane description, it takes precedence.
 /// 2. If the lane has a direction attribute, the road::rule is used with the lane direction modifier.

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -182,7 +182,7 @@ class LaneTravelDirection {
   /// @endcode
   /// @returns A LaneTravelDirection.
   static LaneTravelDirection CreateFromLaneGroupDirection(
-      int lane_id, const std::optional<xodr::Lane::Direction>& hand_rule_traffic_direction,
+      int lane_id, const xodr::Lane::Direction& hand_traffic_rule_direction,
       const std::optional<xodr::RoadHeader::HandTrafficRule>& hand_traffic_rule);
 
   /// Constructs a LaneTravelDirection from a hand traffic rule.

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -207,7 +207,7 @@ class LaneTravelDirection {
   std::string GetMaliputTravelDir() const;
 
  private:
-  LaneTravelDirection(const Direction& direction) : travel_dir_(direction) {}
+  LaneTravelDirection(const Direction& direction);
 
   // Matches Direction with a string.
   // @param direction Is a string.

--- a/src/maliput_malidrive/builder/direction_usage_builder.cc
+++ b/src/maliput_malidrive/builder/direction_usage_builder.cc
@@ -76,7 +76,8 @@ DirectionUsageRule::State DirectionUsageBuilder::BuildDirectionUsageRuleStateFor
                                                                                  const Lane* lane) {
   MALIDRIVE_THROW_UNLESS(lane != nullptr);
   const DirectionUsageRule::State::Id state_id = GetDirectionUsageRuleStateId(rule_id);
-  const DirectionUsageRule::State::Type state_type = ParseStateType(GetDirectionUsageRuleStateType(lane));
+  const DirectionUsageRule::State::Type state_type = ParseStateType(
+      GetDirectionUsageRuleStateType(GetXodrRoadFromMalidriveLane(lane), GetXodrLaneFromMalidriveLane(lane)));
   return DirectionUsageRule::State(state_id, state_type, DirectionUsageRule::State::Severity::kStrict);
 }
 

--- a/src/maliput_malidrive/builder/road_rulebook_builder.cc
+++ b/src/maliput_malidrive/builder/road_rulebook_builder.cc
@@ -193,8 +193,9 @@ void RoadRuleBookBuilder::AddsDirectionUsageRulesToRulebook(const maliput::api::
     rulebook->AddRule(rule_registry->BuildDiscreteValueRule(
         GetRuleIdFrom(maliput::DirectionUsageRuleTypeId(), lane->id()), maliput::DirectionUsageRuleTypeId(),
         CreateLaneSRouteFor(lane),
-        {DiscreteValueRule::DiscreteValue{severity, empty_related_rules, empty_related_unique_ids,
-                                          GetDirectionUsageRuleStateType(lane)}}));
+        {DiscreteValueRule::DiscreteValue{
+            severity, empty_related_rules, empty_related_unique_ids,
+            GetDirectionUsageRuleStateType(GetXodrRoadFromMalidriveLane(lane), GetXodrLaneFromMalidriveLane(lane))}}));
   }
 }
 

--- a/src/maliput_malidrive/test_utilities/road_geometry_configuration_for_xodrs.cc
+++ b/src/maliput_malidrive/test_utilities/road_geometry_configuration_for_xodrs.cc
@@ -325,6 +325,18 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kSimplificationPolicy,
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes}},
+      {"StraightRoadMultipleLaneDirections.xodr",
+       builder::RoadGeometryConfiguration{
+           maliput::api::RoadGeometryId{"StraightRoadMultipleLaneDirections"},
+           {"StraightRoadMultipleLaneDirections.xodr"},
+           builder::RoadGeometryConfiguration::BuildTolerance{
+               1e-3 /* linear_tolerance */, 1e-3 /*max_linear_tolerance*/, 1e-3 /* angular_tolerance */},
+           constants::kScaleLength,
+           kZeroVector,
+           kBuildPolicy,
+           kSimplificationPolicy,
+           kStandardStrictnessPolicy,
+           kOmitNondrivableLanes}},
       {"SingleRoadComplexDescription.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadComplexDescription"},

--- a/src/maliput_malidrive/xodr/README.md
+++ b/src/maliput_malidrive/xodr/README.md
@@ -2,7 +2,7 @@
 
 ## OpenDRIVE format specification coverage
 
-The following table keeps track on the capabilities of the `maliput_malidrive`'s XODR parser according to the 1.5 version of OpenDRIVE format specification.
+The following table keeps track on the capabilities of the `maliput_malidrive`'s XODR parser according to the 1.8 version of OpenDRIVE format specification.
 
 Group | SubGroup | OpenDRIVE Record | Status
 :-:|:-:|:-:|:-:

--- a/src/maliput_malidrive/xodr/lane.h
+++ b/src/maliput_malidrive/xodr/lane.h
@@ -142,7 +142,9 @@ struct Lane {
     kBoth,
   };
 
-  /// Lane traffic direction.
+  /// Lane traffic direction modifier. This acts by modifying a specific lane direcion based on the containing road's
+  /// direction rule. See
+  /// https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/16_annexes/enumerations/map_uml_enumerations.html#top-EAID_BDEEA32B_3F22_4f2c_A327_04437D41CC3D
   enum class Direction {
     /// Direction is determined by the combination of <left> or <right> lane grouping and the values LHT or RHT of the
     /// @rule attribute of a road.

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -194,19 +194,19 @@ TEST_F(SolveLaneEndsInnerLaneSectionTest, TestMethod) {
 
 GTEST_TEST(LaneTravelDirection, NonCompleteXmlNode) {
   // Empty string.
-  EXPECT_EQ(LaneTravelDirection::CreateFromUserData("").GetXodrTravelDir(), LaneTravelDirection::Direction::kUndefined);
+  EXPECT_EQ(LaneTravelDirection::FromUserData("").GetXodrTravelDir(), LaneTravelDirection::Direction::kUndefined);
   // XML formatting error.
-  EXPECT_EQ(LaneTravelDirection::CreateFromUserData("Lorem Ipsum").GetXodrTravelDir(),
+  EXPECT_EQ(LaneTravelDirection::FromUserData("Lorem Ipsum").GetXodrTravelDir(),
             LaneTravelDirection::Direction::kUndefined);
   // Missing vectorLane node.
-  EXPECT_EQ(LaneTravelDirection::CreateFromUserData("<userData> <wrong node='true'/> </userData>").GetXodrTravelDir(),
+  EXPECT_EQ(LaneTravelDirection::FromUserData("<userData> <wrong node='true'/> </userData>").GetXodrTravelDir(),
             LaneTravelDirection::Direction::kUndefined);
   // Missing travelDir node.
-  EXPECT_EQ(LaneTravelDirection::CreateFromUserData("<userData> <vectorLane wrongAttribute='true'/> </userData>")
+  EXPECT_EQ(LaneTravelDirection::FromUserData("<userData> <vectorLane wrongAttribute='true'/> </userData>")
                 .GetXodrTravelDir(),
             LaneTravelDirection::Direction::kUndefined);
   // Direction value error.
-  EXPECT_THROW(LaneTravelDirection::CreateFromUserData("<userData> <vectorLane travelDir='wrongValue'/> </userData>"),
+  EXPECT_THROW(LaneTravelDirection::FromUserData("<userData> <vectorLane travelDir='wrongValue'/> </userData>"),
                maliput::common::assertion_error);
 }
 
@@ -217,9 +217,9 @@ GTEST_TEST(LaneTravelDirection, UserDataTravelDir) {
     </userData>
   )R";
   EXPECT_EQ(LaneTravelDirection::Direction::kBackward,
-            LaneTravelDirection::CreateFromUserData(kUserDataNode).GetXodrTravelDir());
+            LaneTravelDirection::FromUserData(kUserDataNode).GetXodrTravelDir());
   const std::string kExpectedMaliputValue{"AgainstS"};
-  EXPECT_EQ(kExpectedMaliputValue, LaneTravelDirection::CreateFromUserData(kUserDataNode).GetMaliputTravelDir());
+  EXPECT_EQ(kExpectedMaliputValue, LaneTravelDirection::FromUserData(kUserDataNode).GetMaliputTravelDir());
 }
 
 // Get a XML description that contains a XODR with 2 Lane nodes.
@@ -369,7 +369,7 @@ class LaneGroupDirectionTest : public ::testing::TestWithParam<LaneGroupDirectio
 TEST_P(LaneGroupDirectionTest, CreateDirectionTravelDirFromLaneGroup) {
   EXPECT_EQ(
       reference_value_.expected_direction,
-      LaneTravelDirection::CreateFromLaneGroupDirection(
+      LaneTravelDirection::FromLaneGroupDirection(
           reference_value_.lane_id, reference_value_.hand_traffic_rule_direction, reference_value_.hand_traffic_rule)
           .GetXodrTravelDir());
 }
@@ -406,7 +406,7 @@ class HandTrafficRuleTest : public ::testing::TestWithParam<HandTrafficRuleRefer
 
 TEST_P(HandTrafficRuleTest, CreateDirectionTravelDirFromHandTrafficRule) {
   EXPECT_EQ(reference_value_.expected_direction,
-            LaneTravelDirection::CreateFromHandTrafficRule(reference_value_.lane_id, reference_value_.hand_traffic_rule)
+            LaneTravelDirection::FromHandTrafficRule(reference_value_.lane_id, reference_value_.hand_traffic_rule)
                 .GetXodrTravelDir());
 }
 

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -260,7 +260,6 @@ class HandTrafficRuleTravelDirTest : public ::testing::Test {
   const maliput::api::LaneId kId{"dut"};
   const double kLinearTolerance{0.1};
   const int kXordTrack{1};
-  const int kXordTrackInvalid{-1};
   const int kXodrLanePositiveId{5};
   const int kXodrLaneNegativeId{-1};
   const maliput::api::HBounds kElevationBounds{0., 5.};
@@ -280,7 +279,7 @@ TEST_F(HandTrafficRuleTravelDirTest, HandTrafficRuleTravelDir) {
                                     MakeConstantCubicPolynomial(kWidth, kP0, kP1, kLinearTolerance),
                                     MakeConstantCubicPolynomial(kLaneOffset, kP0, kP1, kLinearTolerance), kP0, kP1,
                                     kRoadCurveOffsetIntegratorAccuracyMultiplier);
-  const Lane kLaneNegativeId = Lane(kId, kXordTrackInvalid, kXodrLaneNegativeId, kElevationBounds, road_curve_.get(),
+  const Lane kLaneNegativeId = Lane(kId, kXordTrack, kXodrLaneNegativeId, kElevationBounds, road_curve_.get(),
                                     MakeConstantCubicPolynomial(kWidth, kP0, kP1, kLinearTolerance),
                                     MakeConstantCubicPolynomial(kLaneOffset, kP0, kP1, kLinearTolerance), kP0, kP1,
                                     kRoadCurveOffsetIntegratorAccuracyMultiplier);

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -587,7 +587,7 @@ std::vector<DirectionUsageTruthTable> InstantiateDirectionUsageBuilderParameters
            {LaneId("1_2_3"), SRange(0., 33.4), "Bidirectional", strict_severity},
            {LaneId("1_2_2"), SRange(0., 33.4), "Bidirectional", strict_severity},
            {LaneId("1_2_1"), SRange(0., 33.4), "AgainstS", strict_severity},
-           {LaneId("1_2_-1"), SRange(0., 33.4), "Undefined", strict_severity},
+           {LaneId("1_2_-1"), SRange(0., 33.4), "WithS", strict_severity},
            {LaneId("1_2_-2"), SRange(0., 33.4), "Bidirectional", strict_severity},
            {LaneId("1_2_-3"), SRange(0., 33.4), "Bidirectional", strict_severity},
            {LaneId("1_2_-4"), SRange(0., 33.4), "Bidirectional", strict_severity},

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -625,6 +625,33 @@ std::vector<DirectionUsageTruthTable> InstantiateDirectionUsageBuilderParameters
            {LaneId("8_0_-1"), SRange(0., 9.0661910958999101), "WithS", strict_severity},
            {LaneId("9_0_-1"), SRange(0., 3.5587412868786292), "WithS", strict_severity},
        }},
+      {"StraightRoadMultipleLaneDirections.xodr",
+       {
+           {LaneId("1_0_4"), SRange(0., 10.), "Bidirectional", strict_severity},
+           {LaneId("1_0_3"), SRange(0., 10.), "WithS", strict_severity},
+           {LaneId("1_0_2"), SRange(0., 10.), "AgainstS", strict_severity},
+           {LaneId("1_0_1"), SRange(0., 10.), "WithS", strict_severity},
+           {LaneId("1_0_-1"), SRange(0., 10.), "Bidirectional", strict_severity},
+           {LaneId("1_0_-2"), SRange(0., 10.), "WithS", strict_severity},
+           {LaneId("1_0_-3"), SRange(0., 10.), "AgainstS", strict_severity},
+           {LaneId("1_0_-4"), SRange(0., 10.), "Bidirectional", strict_severity},
+           {LaneId("2_0_4"), SRange(0., 10.), "Bidirectional", strict_severity},
+           {LaneId("2_0_3"), SRange(0., 10.), "WithS", strict_severity},
+           {LaneId("2_0_2"), SRange(0., 10.), "WithS", strict_severity},
+           {LaneId("2_0_1"), SRange(0., 10.), "AgainstS", strict_severity},
+           {LaneId("2_0_-1"), SRange(0., 10.), "Bidirectional", strict_severity},
+           {LaneId("2_0_-2"), SRange(0., 10.), "AgainstS", strict_severity},
+           {LaneId("2_0_-3"), SRange(0., 10.), "AgainstS", strict_severity},
+           {LaneId("2_0_-4"), SRange(0., 10.), "Bidirectional", strict_severity},
+           {LaneId("3_0_4"), SRange(0., 10.), "Bidirectional", strict_severity},
+           {LaneId("3_0_3"), SRange(0., 10.), "WithS", strict_severity},
+           {LaneId("3_0_2"), SRange(0., 10.), "AgainstS", strict_severity},
+           {LaneId("3_0_1"), SRange(0., 10.), "WithS", strict_severity},
+           {LaneId("3_0_-1"), SRange(0., 10.), "Bidirectional", strict_severity},
+           {LaneId("3_0_-2"), SRange(0., 10.), "WithS", strict_severity},
+           {LaneId("3_0_-3"), SRange(0., 10.), "AgainstS", strict_severity},
+           {LaneId("3_0_-4"), SRange(0., 10.), "Bidirectional", strict_severity},
+       }},
   };
 }
 
@@ -640,7 +667,6 @@ TEST_P(DirectionUsageTest, DirectionUsageRuleTest) {
       {DirectionUsageRule::State::Type::kAgainstS, "AgainstS"},
       {DirectionUsageRule::State::Type::kBidirectional, "Bidirectional"},
       {DirectionUsageRule::State::Type::kWithS, "WithS"},
-      {DirectionUsageRule::State::Type::kUndefined, "Undefined"},
   };
   // Verify coverage of the lanes in the RoadNetwork by DirectionUsage rules.
   for (const auto lane : rn->road_geometry()->ById().GetLanes()) {

--- a/test/regression/builder/rule_registry_builder_test.cc
+++ b/test/regression/builder/rule_registry_builder_test.cc
@@ -164,7 +164,6 @@ class RuleRegistryBuilderTest : public ::testing::Test {
     TestRuleTypeDiscreteValue(direction_usage_states, "BidirectionalTurnOnly");
     TestRuleTypeDiscreteValue(direction_usage_states, "NoUse");
     TestRuleTypeDiscreteValue(direction_usage_states, "Parking");
-    TestRuleTypeDiscreteValue(direction_usage_states, "Undefined");
   }
 
   // Verifies possible states of Speed-Limit Rule Type which is registered by the RuleRegistryBuilder.


### PR DESCRIPTION
# 🎉 New feature

Closes #316 

## Summary
* **WARNING**: This PR modifies current behavior by mapping right lanes direction to `WithS` (RHT) when road direction rule is omitted, instead of leaving `Undefined`.
* Parse XODR road rule to determine if traffic follows `WithS` on the right or left lane.
* Parse XODR lane direction to override road rule.
  * Each lane can set if it follows the standard or reversed direction stated by the road rule, or even be bidirectional.
  * See [OpenDRIVE Lane direction](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/16_annexes/enumerations/map_uml_enumerations.html#top-EAID_BDEEA32B_3F22_4f2c_A327_04437D41CC3D) for more details.
* Get direction rules based on the following precedence:
  * 1. `userData` XODR node present within `lane` XODR node.
  * 2. `lane direction` modifier for road rule.
  * 3. Right hand traffic or left hand traffic based on `road rule`.
  * Default: Right hand traffic.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
