### PR TITLE
Allow OS Lane position conversions to off road r-coordinates.

### DIFF
--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -353,19 +353,6 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioLanePositionToMaliputRoadPo
   const double p = road_curve->PFromP(xodr_lane_position.s);
   const double roll_at_p = road_curve->superelevation()->f(p);
   const double r = xodr_lane_position.offset / std::cos(roll_at_p);
-  const double r_max = target_lane->lane_bounds(mali_lane_s).max();
-  const double r_min = target_lane->lane_bounds(mali_lane_s).min();
-  if (r_min > r || r_max < r) {
-    MALIDRIVE_THROW_MESSAGE(
-        "The lane offset is out of bounds for the given OpenSCENARIO lane position: "
-        "RoadID: " +
-        std::to_string(xodr_lane_position.road_id) + ", s: " + std::to_string(xodr_lane_position.s) +
-        ", LaneID: " + std::to_string(xodr_lane_position.lane_id) +
-        ", offset: " + std::to_string(xodr_lane_position.offset) + " | Maliput LaneID: " + target_lane->id().string() +
-        ", Maliput Lane's s-coordinate: " + std::to_string(mali_lane_s) + ", Maliput Lane's r-coordinate: " +
-        std::to_string(r) + ", Maliput Lane's r-coordinate bounds: [" + std::to_string(r_min) + ", " +
-        std::to_string(r_max) + "]" + ", Superelevation at s: " + std::to_string(roll_at_p));
-  }
   return maliput::api::RoadPosition{target_lane, maliput::api::LanePosition{mali_lane_s, r, 0.}};
 }
 

--- a/src/maliput_malidrive/base/road_geometry.h
+++ b/src/maliput_malidrive/base/road_geometry.h
@@ -124,7 +124,8 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   const road_curve::Function* GetReferenceLineOffset(const xodr::RoadHeader::Id& road_id) const;
 
   /// Converts an OpenScenario LanePosition to a maliput RoadPosition.
-  /// See
+  /// OS LanePosition's s-coordinate must be within the lane's length, but its offset can extend beyond the lane's
+  /// surface. See
   /// https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/LanePosition.html
   ///
   /// @param xodr_lane_position The lane position to get the maliput road position from.
@@ -192,7 +193,7 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
   /// @param d_lane The lane offset relative to the lane the reference.
   /// @param ds_lane The offset along the center line of the lane, where the reference entity is located.
   /// @param offset The lateral offset to the center line of the target lane (along the t-axis of the target lane center
-  /// line).
+  /// line). Offset may extend beyond the lane's surface.
   ///
   /// @returns A maliput RoadPosition.
   maliput::api::RoadPosition OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -310,6 +310,28 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioLanePosi
   EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
+TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioLanePositionToMaliputRoadPositionWithOffsetOffLane) {
+  // OpenScenario/OpenDrive parameters.
+  const double offset = 2.;  // 1 meter off the lane.
+  const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, offset};
+  // Maliput expected results.
+  const maliput::api::LaneId lane_id("1_0_-1");
+  const maliput::api::LanePosition expected_lane_position(51.25, 2., 0.);
+
+  auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+  const maliput::api::RoadPosition mali_road_pos =
+      rg->OpenScenarioLanePositionToMaliputRoadPosition(input_xodr_lane_position);
+  EXPECT_EQ(lane_id, mali_road_pos.lane->id());
+  EXPECT_TRUE(
+      AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
+      rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_lane_position.road_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
+}
+
 TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioRoadPositionToMaliputRoadPositionAtCenterline) {
   // OpenScenario/OpenDrive parameters.
   const RoadGeometry::OpenScenarioRoadPosition input_xodr_road_position{1, 50., 0.};
@@ -427,6 +449,31 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled,
        RoundTripOpenScenarioLanePositionToMaliputRoadPositionWithOffset) {
   // OpenScenario/OpenDrive parameters.
   const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, 0.5};
+  // Maliput expected results.
+  const maliput::api::LaneId lane_id("1_0_-1");
+  const double expected_s = road_network_->road_geometry()->ById().GetLane(lane_id)->length() / 2.;
+  const double expected_r = input_xodr_lane_position.offset / (std::sqrt(2.) / 2.);  // The road is rolled 45 degrees
+  const maliput::api::LanePosition expected_lane_position(expected_s, expected_r, 0.);
+
+  auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+  const maliput::api::RoadPosition mali_road_pos =
+      rg->OpenScenarioLanePositionToMaliputRoadPosition(input_xodr_lane_position);
+  EXPECT_EQ(lane_id, mali_road_pos.lane->id());
+  EXPECT_TRUE(
+      AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
+  const RoadGeometry::OpenScenarioLanePosition xodr_lane_pos =
+      rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+  EXPECT_EQ(input_xodr_lane_position.road_id, xodr_lane_pos.road_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.s - xodr_lane_pos.s) < constants::kLinearTolerance);
+  EXPECT_EQ(input_xodr_lane_position.lane_id, xodr_lane_pos.lane_id);
+  EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
+}
+
+TEST_F(RoadGeometryOpenScenarioConversionsArcLaneRolled,
+       RoundTripOpenScenarioLanePositionToMaliputRoadPositionWithOffsetOffLane) {
+  // OpenScenario/OpenDrive parameters.
+  const double offset = -5.;  // 4 meters off the lane.
+  const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, offset};
   // Maliput expected results.
   const maliput::api::LaneId lane_id("1_0_-1");
   const double expected_s = road_network_->road_geometry()->ById().GetLane(lane_id)->length() / 2.;

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -310,7 +310,8 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioLanePosi
   EXPECT_TRUE(std::abs(input_xodr_lane_position.offset - xodr_lane_pos.offset) < constants::kLinearTolerance);
 }
 
-TEST_F(RoadGeometryOpenScenarioConversionsArcLane, RoundTripOpenScenarioLanePositionToMaliputRoadPositionWithOffsetOffLane) {
+TEST_F(RoadGeometryOpenScenarioConversionsArcLane,
+       RoundTripOpenScenarioLanePositionToMaliputRoadPositionWithOffsetOffLane) {
   // OpenScenario/OpenDrive parameters.
   const double offset = 2.;  // 1 meter off the lane.
   const RoadGeometry::OpenScenarioLanePosition input_xodr_lane_position{1, 50., -1, offset};


### PR DESCRIPTION
# 🎉 New feature

Closes #325 

## Summary
* Removes check for r-coordinate bounds when converting OpenScenario `LanePosition`s into maliput `RoadPosition`s.
* Update docs.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
