### PR TITLE
Generalize error handling by passing custom error type to macros.

### DIFF
--- a/include/maliput_malidrive/common/macros.h
+++ b/include/maliput_malidrive/common/macros.h
@@ -59,33 +59,11 @@
 
 /// @def MALIDRIVE_THROW_UNLESS
 /// Used to declare a conditional throw.
-#define MALIDRIVE_THROW_UNLESS(condition) MALIPUT_THROW_UNLESS(condition)
+#define MALIDRIVE_THROW_UNLESS(...) MALIPUT_THROW_UNLESS(__VA_ARGS__)
 
 /// @def MALIDRIVE_THROW_MESSAGE
 /// Throws with `msg`.
-#define MALIDRIVE_THROW_MESSAGE(msg)                                              \
-  do {                                                                            \
-    const std::string message(msg);                                               \
-    MALIDRIVE_VALIDATE(false, maliput::common::assertion_error, message.c_str()); \
-  } while (0)
-
-/// @def MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS
-/// Throws a road_network_description_parser_error unless `condition` is true.
-#define MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(condition) \
-  MALIPUT_THROW_ROAD_NETWORK_DESCRIPTION_PARSER_UNLESS(condition)
-
-/// @def MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_MESSAGE
-/// Throws a road_network_description_parser_error with `msg`.
-#define MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_MESSAGE(msg) MALIPUT_THROW_ROAD_NETWORK_DESCRIPTION_PARSER_MESSAGE(msg)
-
-/// @def MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS
-/// Throws a road_geometry_construction_error unless `condition` is true.
-#define MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(condition) \
-  MALIPUT_THROW_ROAD_GEOMETRY_CONSTRUCTION_UNLESS(condition)
-
-/// @def MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE
-/// Throws a road_geometry_construction_error with `msg`.
-#define MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(msg) MALIPUT_THROW_ROAD_GEOMETRY_CONSTRUCTION_MESSAGE(msg)
+#define MALIDRIVE_THROW_MESSAGE(...) MALIPUT_THROW_MESSAGE(__VA_ARGS__)
 
 /// @def MALIDRIVE_NO_COPY_NO_MOVE_NO_ASSIGN
 /// Deletes the special member functions for copy-construction, copy-assignment,

--- a/src/maliput_malidrive/base/lane.cc
+++ b/src/maliput_malidrive/base/lane.cc
@@ -65,11 +65,11 @@ Lane::Lane(const maliput::api::LaneId& id, int xodr_track, int xodr_lane_id,
       road_curve_offset_(road_curve_, lane_offset.get(), p0, p1, integrator_accuracy_multiplier),
       lane_width_(std::move(lane_width)),
       lane_offset_(std::move(lane_offset)) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(xodr_track >= 0);
+  MALIDRIVE_THROW_UNLESS(xodr_track >= 0, maliput::common::road_geometry_construction_error);
 
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(road_curve_ != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_width_ != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_offset_ != nullptr);
+  MALIDRIVE_THROW_UNLESS(road_curve_ != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(lane_width_ != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(lane_offset_ != nullptr, maliput::common::road_geometry_construction_error);
 
   MALIDRIVE_IS_IN_RANGE(std::abs(lane_width_->p0() - p0), 0., road_curve_->linear_tolerance());
   MALIDRIVE_IS_IN_RANGE(std::abs(lane_width_->p1() - p1), 0., road_curve_->linear_tolerance());

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -94,7 +94,7 @@ const std::map<xodr::Lane::Type, XodrLaneProperties> kXodrLaneTypesToMaliputProp
 std::vector<maliput::api::LaneEnd> SolveLaneEndsForConnectingRoad(
     const maliput::api::RoadGeometry* rg, const MalidriveXodrLaneProperties& xodr_lane_properties,
     const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers, XodrConnectionType connection_type) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
 
   std::vector<maliput::api::LaneEnd> connecting_lane_ends;
 
@@ -148,7 +148,7 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsForJunction(
     const maliput::api::RoadGeometry* rg, const MalidriveXodrLaneProperties& xodr_lane_properties,
     const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers,
     const std::unordered_map<xodr::Junction::Id, xodr::Junction>& junctions, XodrConnectionType connection_type) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
 
   std::vector<maliput::api::LaneEnd> connecting_lane_ends;
 
@@ -214,7 +214,7 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsForJunction(
 std::vector<maliput::api::LaneEnd> SolveLaneEndsWithinJunction(
     const maliput::api::RoadGeometry* rg, const MalidriveXodrLaneProperties& xodr_lane_properties,
     const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers, XodrConnectionType connection_type) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
   // Successor / Predecessor is a road.
   const std::optional<xodr::RoadLink::LinkAttributes> road_link =
       connection_type == XodrConnectionType::kSuccessor ? xodr_lane_properties.road_header->road_link.successor
@@ -228,7 +228,8 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsWithinJunction(
     return {};
   }
   if (road_link->element_type == xodr::RoadLink::ElementType::kJunction) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE("Junctions connected to junctions are not supported.");
+    MALIDRIVE_THROW_MESSAGE("Junctions connected to junctions are not supported.",
+                            maliput::common::road_geometry_construction_error);
   }
   return SolveLaneEndsForConnectingRoad(rg, xodr_lane_properties, road_headers, connection_type);
 }
@@ -236,7 +237,7 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsWithinJunction(
 std::vector<maliput::api::LaneEnd> SolveLaneEndsForInnerLaneSection(
     const maliput::api::RoadGeometry* rg, const maliput::api::LaneEnd& lane_end,
     const MalidriveXodrLaneProperties& xodr_lane_properties) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
 
   std::vector<maliput::api::LaneEnd> connecting_lane_ends;
 

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -69,10 +69,10 @@ struct MalidriveXodrLaneProperties {
   MalidriveXodrLaneProperties(const xodr::RoadHeader* _road_header, const xodr::LaneSection* _lane_section,
                               int _lane_section_index, const xodr::Lane* _lane)
       : road_header(_road_header), lane(_lane), lane_section(_lane_section), lane_section_index(_lane_section_index) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(road_header != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_section != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_section_index >= 0);
+    MALIDRIVE_THROW_UNLESS(road_header != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(lane != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(lane_section != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(lane_section_index >= 0, maliput::common::road_geometry_construction_error);
   }
 
   const xodr::RoadHeader* road_header{};

--- a/src/maliput_malidrive/builder/direction_usage_builder.cc
+++ b/src/maliput_malidrive/builder/direction_usage_builder.cc
@@ -68,13 +68,15 @@ DirectionUsageRule::State::Type DirectionUsageBuilder::ParseStateType(const std:
       {"Undefined", DirectionUsageRule::State::Type::kUndefined},
   };
 
-  MALIDRIVE_THROW_UNLESS(string_to_state.find(state) != string_to_state.end());
+  MALIDRIVE_VALIDATE(string_to_state.find(state) != string_to_state.end(), maliput::common::state_provider_error,
+                     "State type `" + state + "` does not exist.");
   return string_to_state.at(state);
 }
 
 DirectionUsageRule::State DirectionUsageBuilder::BuildDirectionUsageRuleStateFor(const DirectionUsageRule::Id& rule_id,
                                                                                  const Lane* lane) {
-  MALIDRIVE_THROW_UNLESS(lane != nullptr);
+  MALIDRIVE_VALIDATE(lane != nullptr, maliput::common::state_provider_error,
+                     "Lane is null when building direction usage rule state.");
   const DirectionUsageRule::State::Id state_id = GetDirectionUsageRuleStateId(rule_id);
   const DirectionUsageRule::State::Type state_type = ParseStateType(
       GetDirectionUsageRuleStateType(GetXodrRoadFromMalidriveLane(lane), GetXodrLaneFromMalidriveLane(lane)));
@@ -83,7 +85,8 @@ DirectionUsageRule::State DirectionUsageBuilder::BuildDirectionUsageRuleStateFor
 
 DirectionUsageRule DirectionUsageBuilder::BuildDirectionUsageRuleFor(const maliput::api::Lane* lane) {
   const Lane* mali_lane = dynamic_cast<const Lane*>(lane);
-  MALIDRIVE_THROW_UNLESS(mali_lane != nullptr);
+  MALIDRIVE_VALIDATE(mali_lane != nullptr, maliput::common::rulebook_error,
+                     "Lane is null when building DirectionUseageRule.");
 
   const DirectionUsageRule::Id rule_id = GetDirectionUsageRuleId(mali_lane->id(), direction_usage_indexer_.new_id());
   const maliput::api::LaneSRange lane_s_range(mali_lane->id(), maliput::api::SRange(0., mali_lane->length()));

--- a/src/maliput_malidrive/builder/direction_usage_builder.cc
+++ b/src/maliput_malidrive/builder/direction_usage_builder.cc
@@ -68,14 +68,14 @@ DirectionUsageRule::State::Type DirectionUsageBuilder::ParseStateType(const std:
       {"Undefined", DirectionUsageRule::State::Type::kUndefined},
   };
 
-  MALIDRIVE_VALIDATE(string_to_state.find(state) != string_to_state.end(), maliput::common::state_provider_error,
+  MALIDRIVE_VALIDATE(string_to_state.find(state) != string_to_state.end(), maliput::common::rulebook_error,
                      "State type `" + state + "` does not exist.");
   return string_to_state.at(state);
 }
 
 DirectionUsageRule::State DirectionUsageBuilder::BuildDirectionUsageRuleStateFor(const DirectionUsageRule::Id& rule_id,
                                                                                  const Lane* lane) {
-  MALIDRIVE_VALIDATE(lane != nullptr, maliput::common::state_provider_error,
+  MALIDRIVE_VALIDATE(lane != nullptr, maliput::common::rulebook_error,
                      "Lane is null when building direction usage rule state.");
   const DirectionUsageRule::State::Id state_id = GetDirectionUsageRuleStateId(rule_id);
   const DirectionUsageRule::State::Type state_type = ParseStateType(

--- a/src/maliput_malidrive/builder/direction_usage_builder.h
+++ b/src/maliput_malidrive/builder/direction_usage_builder.h
@@ -77,7 +77,7 @@ class DirectionUsageBuilder {
   ///
   /// @param state is the maliput::api::rules::DirectionUsageRule::State::Type to be parsed.
   /// @return An optional of maliput::api::rules::DirectionUsageRule::State::Type with the parsed type.
-  /// @throws maliput::common::assertion_error When `state` is unrecognized.
+  /// @throws maliput::common::state_provider_error When `state` is unrecognized.
   maliput::api::rules::DirectionUsageRule::State::Type ParseStateType(const std::string& state) const;
 
   /// Builds a maliput::api::rules::DirectionUsageRule::State for a maliput::api::rules::DirectionUsageRule.
@@ -92,6 +92,7 @@ class DirectionUsageBuilder {
   /// @param rule_id is the ID of the DirectionUsageRule.
   /// @param lane is Lane pointer.  It must not be nullptr and its type
   ///        must be `malidrive::Lane`.
+  /// @throws maliput::common::state_provider_error when `lane` is null.
   maliput::api::rules::DirectionUsageRule::State BuildDirectionUsageRuleStateFor(
       const maliput::api::rules::DirectionUsageRule::Id& rule_id, const Lane* lane);
 
@@ -99,6 +100,7 @@ class DirectionUsageBuilder {
   ///
   /// @param lane is the Lane to inspect. It must not be nullptr and its type
   ///        must be `malidrive::Lane`.
+  /// @throws maliput::common::rulebook_error when `lane` is null.
   maliput::api::rules::DirectionUsageRule BuildDirectionUsageRuleFor(const maliput::api::Lane* lane);
 #pragma GCC diagnostic pop
 

--- a/src/maliput_malidrive/builder/direction_usage_builder.h
+++ b/src/maliput_malidrive/builder/direction_usage_builder.h
@@ -77,7 +77,7 @@ class DirectionUsageBuilder {
   ///
   /// @param state is the maliput::api::rules::DirectionUsageRule::State::Type to be parsed.
   /// @return An optional of maliput::api::rules::DirectionUsageRule::State::Type with the parsed type.
-  /// @throws maliput::common::state_provider_error When `state` is unrecognized.
+  /// @throws maliput::common::rulebook_error When `state` is unrecognized.
   maliput::api::rules::DirectionUsageRule::State::Type ParseStateType(const std::string& state) const;
 
   /// Builds a maliput::api::rules::DirectionUsageRule::State for a maliput::api::rules::DirectionUsageRule.
@@ -92,7 +92,7 @@ class DirectionUsageBuilder {
   /// @param rule_id is the ID of the DirectionUsageRule.
   /// @param lane is Lane pointer.  It must not be nullptr and its type
   ///        must be `malidrive::Lane`.
-  /// @throws maliput::common::state_provider_error when `lane` is null.
+  /// @throws maliput::common::rulebook_error when `lane` is null.
   maliput::api::rules::DirectionUsageRule::State BuildDirectionUsageRuleStateFor(
       const maliput::api::rules::DirectionUsageRule::Id& rule_id, const Lane* lane);
 

--- a/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.cc
+++ b/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.cc
@@ -38,11 +38,12 @@ namespace {
 // Sets to `state_provider` the first value in each
 // DiscreteValueRule::states() in `discrete_value_rules` as the default
 // state.
-// @throws maliput::common::assertion_error When `state_provider` is
+// @throws maliput::common::state_provider_error When `state_provider` is
 //         nullptr.
 void PopulateDiscreteValueRuleStates(const std::map<Rule::Id, DiscreteValueRule>& discrete_value_rules,
                                      maliput::PhasedDiscreteRuleStateProvider* state_provider) {
-  MALIDRIVE_THROW_UNLESS(state_provider != nullptr);
+  MALIDRIVE_VALIDATE(state_provider != nullptr, maliput::common::state_provider_error,
+                     "StateProvider is null when populating discrete value rule states.");
   for (const auto& rule_id_rule : discrete_value_rules) {
     state_provider->SetState(rule_id_rule.first, rule_id_rule.second.states().front(), std::nullopt, std::nullopt);
   }

--- a/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.h
+++ b/src/maliput_malidrive/builder/discrete_value_rule_state_provider_builder.h
@@ -56,15 +56,18 @@ class DiscreteValueRuleStateProviderBuilder {
   /// @param phase_provider A PhaseProvider to feed the
   ///        DiscreteValueRuleStateProvider. It must not be nullptr.
   ///
-  /// @throws maliput::common::assertion_error When `rulebook`,
+  /// @throws maliput::common::state_provider_error When `rulebook`,
   ///         `phase_ring_book` or `phase_provider` are nullptr.
   explicit DiscreteValueRuleStateProviderBuilder(const maliput::api::rules::RoadRulebook* rulebook,
                                                  const maliput::api::rules::PhaseRingBook* phase_ring_book,
                                                  const maliput::api::rules::PhaseProvider* phase_provider)
       : rulebook_(rulebook), phase_ring_book_(phase_ring_book), phase_provider_(phase_provider) {
-    MALIDRIVE_DEMAND(rulebook_ != nullptr);
-    MALIDRIVE_DEMAND(phase_ring_book_ != nullptr);
-    MALIDRIVE_DEMAND(phase_provider_ != nullptr);
+    MALIDRIVE_VALIDATE(rulebook_ != nullptr, maliput::common::state_provider_error,
+                       "Rulebook is null when building DiscreteValueRuleStateProvider.");
+    MALIDRIVE_VALIDATE(phase_ring_book_ != nullptr, maliput::common::state_provider_error,
+                       "PhaseRingBook is null when building DiscreteValueRuleStateProvider.");
+    MALIDRIVE_VALIDATE(phase_provider_ != nullptr, maliput::common::state_provider_error,
+                       "PhaseProvider is null when building DiscreteValueRuleStateProvider.");
   }
 
   /// Builds a maliput::PhasedDiscreteRuleStateProvider.

--- a/src/maliput_malidrive/builder/phase_provider_builder.h
+++ b/src/maliput_malidrive/builder/phase_provider_builder.h
@@ -47,10 +47,10 @@ class PhaseProviderBuilder {
   /// @param phase_ring_book A PhaseRingBook to feed the
   ///        PhaseProviderBuilder. It must not be nullptr.
   ///
-  /// @throws maliput::common::assertion_error When `phase_ring_book` is nullptr.
+  /// @throws maliput::common::phase_book_error When `phase_ring_book` is nullptr.
   explicit PhaseProviderBuilder(const maliput::api::rules::PhaseRingBook* phase_ring_book)
       : phase_ring_book_(phase_ring_book) {
-    MALIDRIVE_THROW_UNLESS(phase_ring_book_ != nullptr);
+    MALIDRIVE_VALIDATE(phase_ring_book_ != nullptr, maliput::common::phase_book_error, "PhaseRingBook is null.");
   }
 
   /// Builds a maliput::ManualPhaseProvider.

--- a/src/maliput_malidrive/builder/range_value_rule_state_provider_builder.cc
+++ b/src/maliput_malidrive/builder/range_value_rule_state_provider_builder.cc
@@ -37,11 +37,12 @@ namespace {
 
 // Sets to `state_provider` the first range in each
 // RangeValueRule::states() in `range_value_rules` as the default state.
-// @throws maliput::common::assertion_error When `state_provider` is
+// @throws maliput::common::state_provider_error When `state_provider` is
 //         nullptr.
 void PopulateRangeValueRuleStates(const std::map<Rule::Id, RangeValueRule>& range_value_rules,
                                   maliput::ManualRangeValueRuleStateProvider* state_provider) {
-  MALIDRIVE_THROW_UNLESS(state_provider != nullptr);
+  MALIDRIVE_VALIDATE(state_provider != nullptr, maliput::common::state_provider_error,
+                     "State provider is null when populating range value rule states.");
   for (const auto& rule_id_rule : range_value_rules) {
     state_provider->SetState(rule_id_rule.first, rule_id_rule.second.states().front(), std::nullopt, std::nullopt);
   }

--- a/src/maliput_malidrive/builder/range_value_rule_state_provider_builder.h
+++ b/src/maliput_malidrive/builder/range_value_rule_state_provider_builder.h
@@ -51,7 +51,7 @@ class RangeValueRuleStateProviderBuilder {
   /// @param rulebook A RoadRulebook to feed the RangeValueRuleStateProvider.
   ///        It must not be nullptr.
   ///
-  /// @throws maliput::common::assertion_error When `rulebook` is nullptr.
+  /// @throws maliput::common::state_provider_error When `rulebook` is nullptr.
   explicit RangeValueRuleStateProviderBuilder(const maliput::api::rules::RoadRulebook* rulebook) : rulebook_(rulebook) {
     MALIDRIVE_DEMAND(rulebook_ != nullptr);
   }

--- a/src/maliput_malidrive/builder/road_curve_factory.cc
+++ b/src/maliput_malidrive/builder/road_curve_factory.cc
@@ -78,8 +78,8 @@ constexpr const char* TypeName() {
   } else if (std::is_same<T, xodr::LaneOffset>::value) {
     return "LaneOffset";
   } else {
-    // MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE macro can't be used within a constexpr function.
-    throw maliput::common::assertion_error(
+    // MALIDRIVE_THROW_MESSAGE macro can't be used within a constexpr function.
+    throw maliput::common::road_geometry_construction_error(
         "Only xodr::ElevationProfile::Elevation, xodr::LateralProfile::Superelevation and xodr::LaneOffset types are "
         "allowed by this function. ");
   }
@@ -118,8 +118,8 @@ std::unique_ptr<road_curve::Function> RoadCurveFactory::MakeCubicPolynomial(doub
 // @endcode
 std::unique_ptr<road_curve::Function> RoadCurveFactory::MakeCubicPolynomial(double p0, double p1, double y,
                                                                             double dy) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 >= 0);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1 > p0);
+  MALIDRIVE_THROW_UNLESS(p0 >= 0, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1 > p0, maliput::common::road_geometry_construction_error);
   const double cubic_p0 = p0 * p0 * p0;
   const double quad_p0 = p0 * p0;
   const double cubic_p1 = p1 * p1 * p1;
@@ -154,7 +154,8 @@ xodr::LaneWidth RoadCurveFactory::AdaptCubicPolynomial(const xodr::LaneWidth& a,
 
 std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakeArcGroundCurve(
     const xodr::Geometry& arc_geometry) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(arc_geometry.type == xodr::Geometry::Type::kArc);
+  MALIDRIVE_THROW_UNLESS(arc_geometry.type == xodr::Geometry::Type::kArc,
+                         maliput::common::road_geometry_construction_error);
   const double p0{arc_geometry.s_0};
   const double p1{arc_geometry.s_0 + arc_geometry.length};
   MALIDRIVE_VALIDATE(p1 - p0 > road_curve::GroundCurve::kEpsilon, maliput::common::assertion_error,
@@ -168,7 +169,8 @@ std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakeArcGroundCurve(
 
 std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakeLineGroundCurve(
     const xodr::Geometry& line_geometry) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(line_geometry.type == xodr::Geometry::Type::kLine);
+  MALIDRIVE_THROW_UNLESS(line_geometry.type == xodr::Geometry::Type::kLine,
+                         maliput::common::road_geometry_construction_error);
   const double p0{line_geometry.s_0};
   const double p1{line_geometry.s_0 + line_geometry.length};
   MALIDRIVE_VALIDATE(p1 - p0 > road_curve::GroundCurve::kEpsilon, maliput::common::assertion_error,
@@ -182,7 +184,8 @@ std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakeLineGroundCurve(
 
 std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakeSpiralGroundCurve(
     const xodr::Geometry& spiral_geometry) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(spiral_geometry.type == xodr::Geometry::Type::kSpiral);
+  MALIDRIVE_THROW_UNLESS(spiral_geometry.type == xodr::Geometry::Type::kSpiral,
+                         maliput::common::road_geometry_construction_error);
   const double p0{spiral_geometry.s_0};
   const double p1{spiral_geometry.s_0 + spiral_geometry.length};
   MALIDRIVE_VALIDATE(p1 - p0 > road_curve::GroundCurve::kEpsilon, maliput::common::assertion_error,
@@ -197,7 +200,7 @@ std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakeSpiralGroundCurve
 
 std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakePiecewiseGroundCurve(
     const std::vector<xodr::Geometry>& geometries) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(!geometries.empty());
+  MALIDRIVE_THROW_UNLESS(!geometries.empty(), maliput::common::road_geometry_construction_error);
 
   std::vector<std::unique_ptr<road_curve::GroundCurve>> ground_curves;
   for (const xodr::Geometry& geometry : geometries) {
@@ -216,20 +219,20 @@ std::unique_ptr<road_curve::GroundCurve> RoadCurveFactory::MakePiecewiseGroundCu
         ground_curves.emplace_back(MakeSpiralGroundCurve(geometry));
         break;
       default:
-        MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(
-            "Geometries contain a xodr::Geometry whose type is not in {kLine, kArc}.");
+        MALIDRIVE_THROW_MESSAGE("Geometries contain a xodr::Geometry whose type is not in {kLine, kArc}.",
+                                maliput::common::road_geometry_construction_error);
         break;
     }
   }
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(!ground_curves.empty());
+  MALIDRIVE_THROW_UNLESS(!ground_curves.empty(), maliput::common::road_geometry_construction_error);
   return std::make_unique<road_curve::PiecewiseGroundCurve>(std::move(ground_curves), linear_tolerance(),
                                                             angular_tolerance());
 }
 
 std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeElevation(
     const xodr::ElevationProfile& elevation_profile, double p0, double p1, bool assert_continuity) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1 > p0);
+  MALIDRIVE_THROW_UNLESS(p0 >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1 > p0, maliput::common::road_geometry_construction_error);
   return MakeCubicFromXodr<xodr::ElevationProfile::Elevation>(elevation_profile.elevations, p0, p1,
                                                               FillingGapPolicy::kEnsureContiguity,
                                                               FromBoolToContiguityCheck(assert_continuity));
@@ -237,8 +240,8 @@ std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeElevation
 
 std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeSuperelevation(
     const xodr::LateralProfile& lateral_profile, double p0, double p1, bool assert_continuity) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1 > p0);
+  MALIDRIVE_THROW_UNLESS(p0 >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1 > p0, maliput::common::road_geometry_construction_error);
   return MakeCubicFromXodr<xodr::LateralProfile::Superelevation>(lateral_profile.superelevations, p0, p1,
                                                                  FillingGapPolicy::kEnsureContiguity,
                                                                  FromBoolToContiguityCheck(assert_continuity));
@@ -262,13 +265,14 @@ std::vector<std::unique_ptr<malidrive::road_curve::Function>> RoadCurveFactory::
     // the same road_curve::Function::kEpsilon which value is zero. So it makes sense to match the same behavior.
     if (p0_i - p1_i >= road_curve::Function::kEpsilon) {
       if (!end) {
-        MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE("Invalid range for the laneWidth's function in position " +
-                                                      std::to_string(i) + ": p0_i: " + std::to_string(p0_i) +
-                                                      " | p1_i: " + std::to_string(p1_i));
+        MALIDRIVE_THROW_MESSAGE("Invalid range for the laneWidth's function in position " + std::to_string(i) +
+                                    ": p0_i: " + std::to_string(p0_i) + " | p1_i: " + std::to_string(p1_i),
+                                maliput::common::road_geometry_construction_error);
       } else {
         if (p0_i != p1_i) {
-          MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE("Last laneWidth's function has invalid length: p0_i: " +
-                                                        std::to_string(p0_i) + " | p1_i: " + std::to_string(p1_i));
+          MALIDRIVE_THROW_MESSAGE("Last laneWidth's function has invalid length: p0_i: " + std::to_string(p0_i) +
+                                      " | p1_i: " + std::to_string(p1_i),
+                                  maliput::common::road_geometry_construction_error);
         } else {
           maliput::log()->debug("Last laneWidth's function has null length: p0_i = p1_1 = ", p1_i);
           continue;
@@ -302,11 +306,11 @@ bool RoadCurveFactory::AreLaneWidthsContinuous(const xodr::LaneWidth& a, const x
 std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeLaneWidth(
     const std::vector<xodr::LaneWidth>& lane_widths, double p0, double p1, bool assert_continuity,
     bool adapt_lane_widths) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1 > p0);
+  MALIDRIVE_THROW_UNLESS(p0 >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1 > p0, maliput::common::road_geometry_construction_error);
   const int num_polynomials = static_cast<int>(lane_widths.size());
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(num_polynomials > 0);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_widths[0].s_0 == 0);
+  MALIDRIVE_THROW_UNLESS(num_polynomials > 0, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(lane_widths[0].s_0 == 0, maliput::common::road_geometry_construction_error);
   std::vector<std::unique_ptr<road_curve::Function>> polynomials;
 
   std::vector<xodr::LaneWidth> adapted_lane_widths;
@@ -333,8 +337,8 @@ std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeLaneWidth
 
 std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeReferenceLineOffset(
     const std::vector<xodr::LaneOffset>& reference_offsets, double p0, double p1, bool assert_continuity) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1 > p0);
+  MALIDRIVE_THROW_UNLESS(p0 >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1 > p0, maliput::common::road_geometry_construction_error);
   return MakeCubicFromXodr<xodr::LaneOffset>(reference_offsets, p0, p1, FillingGapPolicy::kZero,
                                              FromBoolToContiguityCheck(assert_continuity));
 }
@@ -350,8 +354,8 @@ template <class T>
 std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeCubicFromXodr(
     const std::vector<T>& xodr_data, double p0, double p1, FillingGapPolicy policy,
     road_curve::PiecewiseFunction::ContinuityCheck continuity_check) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1 > p0);
+  MALIDRIVE_THROW_UNLESS(p0 >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1 > p0, maliput::common::road_geometry_construction_error);
   const std::string xodr_data_type{TypeName<T>()};
   const int num_polynomials = static_cast<int>(xodr_data.size());
   std::vector<std::unique_ptr<road_curve::Function>> polynomials;
@@ -372,14 +376,15 @@ std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeCubicFrom
     // the same epsilon(Function::kEpsilon) which value is zero. So it makes sense to match the same behavior.
     if (p0_i - p1_i >= road_curve::Function::kEpsilon) {
       if (!end) {
-        MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(
-            "Invalid range for the " + xodr_data_type + "'s function in position " + std::to_string(i) +
-            ": p0_i: " + std::to_string(p0_i) + " | p1_i: " + std::to_string(p1_i));
+        MALIDRIVE_THROW_MESSAGE("Invalid range for the " + xodr_data_type + "'s function in position " +
+                                    std::to_string(i) + ": p0_i: " + std::to_string(p0_i) +
+                                    " | p1_i: " + std::to_string(p1_i),
+                                maliput::common::road_geometry_construction_error);
       } else {
         if (p0_i != p1_i) {
-          MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(
-              "Last " + xodr_data_type + "'s function has invalid length: p0_i: " + std::to_string(p0_i) +
-              " | p1_i: " + std::to_string(p1_i));
+          MALIDRIVE_THROW_MESSAGE("Last " + xodr_data_type + "'s function has invalid length: p0_i: " +
+                                      std::to_string(p0_i) + " | p1_i: " + std::to_string(p1_i),
+                                  maliput::common::road_geometry_construction_error);
         } else {
           maliput::log()->debug("Last function that compounds ", xodr_data_type,
                                 " has null length: p0_i = p1_1 = ", p1_i);
@@ -413,7 +418,7 @@ std::unique_ptr<malidrive::road_curve::Function> RoadCurveFactory::MakeCubicFrom
                                                 polynomials[0]->f_dot(xodr_cubic->s_0)));
         break;
       default:
-        MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE("Unknown FillingGapPolicy value.");
+        MALIDRIVE_THROW_MESSAGE("Unknown FillingGapPolicy value.", maliput::common::road_geometry_construction_error);
     }
   }
 

--- a/src/maliput_malidrive/builder/road_curve_factory.h
+++ b/src/maliput_malidrive/builder/road_curve_factory.h
@@ -72,9 +72,9 @@ class RoadCurveFactoryBase {
   ///         positive.
   RoadCurveFactoryBase(double linear_tolerance, double scale_length, double angular_tolerance)
       : linear_tolerance_(linear_tolerance), scale_length_(scale_length), angular_tolerance_(angular_tolerance) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(linear_tolerance_ > 0.);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(scale_length_ > 0.);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(angular_tolerance_ > 0.);
+    MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0., maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(scale_length_ > 0., maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(angular_tolerance_ > 0., maliput::common::road_geometry_construction_error);
   }
 
   virtual ~RoadCurveFactoryBase() = default;

--- a/src/maliput_malidrive/builder/road_geometry_builder.cc
+++ b/src/maliput_malidrive/builder/road_geometry_builder.cc
@@ -106,8 +106,8 @@ double ComputeKdTreeSamplingStep(const maliput::api::RoadGeometry* rg) {
 RoadGeometryBuilder::RoadGeometryBuilder(std::unique_ptr<xodr::DBManager> manager,
                                          const RoadGeometryConfiguration& road_geometry_configuration)
     : rg_config_(road_geometry_configuration), manager_(std::move(manager)) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(manager_.get());
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg_config_.scale_length >= 0.);
+  MALIDRIVE_THROW_UNLESS(manager_.get(), maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(rg_config_.scale_length >= 0., maliput::common::road_geometry_construction_error);
   MALIDRIVE_VALIDATE(rg_config_.tolerances.angular_tolerance >= 0, maliput::common::road_geometry_construction_error,
                      std::string("angular tolerance should be non-negative: ") +
                          std::to_string(rg_config_.tolerances.angular_tolerance));
@@ -215,7 +215,7 @@ void RoadGeometryBuilder::VerifyNonNegativeLaneWidth(const std::vector<xodr::Lan
                             "] with a width value of: " + std::to_string(f_p0)};
       maliput::log()->debug(msg);
       if (!allow_negative_width) {
-        MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(msg);
+        MALIDRIVE_THROW_MESSAGE(msg, maliput::common::road_geometry_construction_error);
       }
     }
     if (f_p1 < -linear_tolerance / 2.) {
@@ -227,7 +227,7 @@ void RoadGeometryBuilder::VerifyNonNegativeLaneWidth(const std::vector<xodr::Lan
                             "] with a width value of: " + std::to_string(f_p1)};
       maliput::log()->debug(msg);
       if (!allow_negative_width) {
-        MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(msg);
+        MALIDRIVE_THROW_MESSAGE(msg, maliput::common::road_geometry_construction_error);
       }
     }
     if (non_negative_limits) {
@@ -248,7 +248,7 @@ void RoadGeometryBuilder::VerifyNonNegativeLaneWidth(const std::vector<xodr::Lan
                                 " | lane_s = " + std::to_string(p_local_min.value() + lane_widths[i].s_0) + "]"};
           maliput::log()->debug(msg);
           if (!allow_negative_width) {
-            MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(msg);
+            MALIDRIVE_THROW_MESSAGE(msg, maliput::common::road_geometry_construction_error);
           }
         }
       }
@@ -260,15 +260,15 @@ RoadGeometryBuilder::LaneConstructionResult RoadGeometryBuilder::BuildLane(
     const xodr::Lane* lane, const xodr::RoadHeader* road_header, const xodr::LaneSection* lane_section,
     int xodr_lane_section_index, const RoadCurveFactoryBase* factory, const RoadGeometryConfiguration& rg_config,
     Segment* segment, road_curve::LaneOffset::AdjacentLaneFunctions* adjacent_lane_functions) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(road_header != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_section != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(xodr_lane_section_index >= 0);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(factory != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(segment != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(xodr_lane_section_index >= 0);
+  MALIDRIVE_THROW_UNLESS(lane != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(road_header != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(lane_section != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(xodr_lane_section_index >= 0, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(factory != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(segment != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(xodr_lane_section_index >= 0, maliput::common::road_geometry_construction_error);
   const int xodr_track_id = std::stoi(road_header->id.string());
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(xodr_track_id >= 0);
+  MALIDRIVE_THROW_UNLESS(xodr_track_id >= 0, maliput::common::road_geometry_construction_error);
   const int xodr_lane_id = std::stoi(lane->id.string());
   // Build a maliput::api::LaneId.
   const maliput::api::LaneId lane_id = GetLaneId(xodr_track_id, xodr_lane_section_index, xodr_lane_id);
@@ -331,8 +331,8 @@ RoadGeometryBuilder::LaneConstructionResult RoadGeometryBuilder::BuildLane(
 
 std::vector<RoadGeometryBuilder::LaneConstructionResult> RoadGeometryBuilder::LanesBuilderParallelPolicy(
     std::size_t num_of_threads, RoadGeometry* rg) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(num_of_threads > 0);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(num_of_threads > 0, maliput::common::road_geometry_construction_error);
   maliput::utility::ThreadPool task_executor(num_of_threads);
 
   // Queue all the tasks in the thread pool. Each task will build all the lanes of a junction.
@@ -385,7 +385,7 @@ std::vector<RoadGeometryBuilder::LaneConstructionResult> RoadGeometryBuilder::La
 }
 
 void RoadGeometryBuilder::FillSegmentsWithLanes(RoadGeometry* rg) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
   std::vector<LaneConstructionResult> built_lanes_result =
       rg_config_.build_policy.type == malidrive::builder::BuildPolicy::Type::kParallel
           ? LanesBuilderParallelPolicy(GetEffectiveNumberOfThreads(rg_config_.build_policy), rg)
@@ -393,7 +393,7 @@ void RoadGeometryBuilder::FillSegmentsWithLanes(RoadGeometry* rg) {
   for (auto& built_lane : built_lanes_result) {
     const auto result = lane_xodr_lane_properties_.insert(
         {built_lane.lane->id(), {built_lane.lane.get(), built_lane.xodr_lane_properties}});
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(result.second == true);
+    MALIDRIVE_THROW_UNLESS(result.second == true, maliput::common::road_geometry_construction_error);
 
     const bool hide_lane =
         rg_config_.omit_nondrivable_lanes && !is_driveable_lane(*built_lane.xodr_lane_properties.lane);
@@ -482,9 +482,10 @@ std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryBuilder::operator(
       "Used linear tolerances are in the range [" + std::to_string(linear_tolerances[0]) + ", " +
       std::to_string(linear_tolerances.back()) + "] with an increasing step of " +
       std::to_string(static_cast<int>((constants::kToleranceStepMultiplier - 1) * 100)) + "% per iteration.";
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE("None of the tolerances(" + std::to_string(linear_tolerances.size()) +
-                                                ") worked to build a RoadGeometry " + file_description + ".\n\t" +
-                                                linear_tolerance_description);
+  MALIDRIVE_THROW_MESSAGE("None of the tolerances(" + std::to_string(linear_tolerances.size()) +
+                              ") worked to build a RoadGeometry " + file_description + ".\n\t" +
+                              linear_tolerance_description,
+                          maliput::common::road_geometry_construction_error);
   // @}
 }
 
@@ -492,9 +493,11 @@ void RoadGeometryBuilder::Reset(double linear_tolerance, double angular_toleranc
   rg_config_.tolerances.linear_tolerance = linear_tolerance;
   rg_config_.tolerances.angular_tolerance = angular_tolerance;
   rg_config_.scale_length = scale_length;
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg_config_.tolerances.linear_tolerance.value() >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg_config_.tolerances.angular_tolerance >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg_config_.scale_length >= 0.);
+  MALIDRIVE_THROW_UNLESS(rg_config_.tolerances.linear_tolerance.value() >= 0.,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(rg_config_.tolerances.angular_tolerance >= 0.,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(rg_config_.scale_length >= 0., maliput::common::road_geometry_construction_error);
   // TODO(#12): It goes against dependency injection. Should use a provider instead.
   factory_ = std::make_unique<builder::RoadCurveFactory>(linear_tolerance, scale_length, angular_tolerance);
 
@@ -603,11 +606,12 @@ std::unique_ptr<road_curve::RoadCurve> RoadGeometryBuilder::BuildRoadCurve(
   const auto& start_geometry = road_header.reference_geometry.plan_view.geometries.begin();
   const auto start_lane_section = road_header.lanes.lanes_section.begin();
   if (std::abs(start_geometry->s_0 - start_lane_section->s_0) >= rg_config_.tolerances.linear_tolerance) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(
+    MALIDRIVE_THROW_MESSAGE(
         std::string("Start geometry differs more than linear_tolerance from the start lane section s coordinate.") +
-        std::string("RoadId: ") + road_header.id.string() + std::string(", geometry.s0: ") +
-        std::to_string(start_geometry->s_0) + std::string(", start lane section s0: ") +
-        std::to_string(start_lane_section->s_0));
+            std::string("RoadId: ") + road_header.id.string() + std::string(", geometry.s0: ") +
+            std::to_string(start_geometry->s_0) + std::string(", start lane section s0: ") +
+            std::to_string(start_lane_section->s_0),
+        maliput::common::road_geometry_construction_error);
   }
   const auto& geometries{road_header.reference_geometry.plan_view.geometries};
   maliput::log()->trace("Creating GroundCurve for road id ", road_header.id.string());
@@ -639,11 +643,11 @@ std::vector<RoadGeometryBuilder::LaneConstructionResult> RoadGeometryBuilder::Bu
     const xodr::RoadHeader* road_header, const xodr::LaneSection* lane_section, int xodr_lane_section_index,
     const RoadCurveFactoryBase* factory, const RoadGeometryConfiguration& rg_config, RoadGeometry* rg,
     Segment* segment) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_section != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(road_header != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(segment != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(factory != nullptr);
+  MALIDRIVE_THROW_UNLESS(lane_section != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(road_header != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(segment != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(factory != nullptr, maliput::common::road_geometry_construction_error);
 
   std::vector<RoadGeometryBuilder::LaneConstructionResult> built_lanes_result;
   road_curve::LaneOffset::AdjacentLaneFunctions adjacent_lane_functions{nullptr, nullptr};
@@ -677,22 +681,22 @@ std::vector<RoadGeometryBuilder::LaneConstructionResult> RoadGeometryBuilder::Bu
 std::unique_ptr<maliput::geometry_base::Junction> RoadGeometryBuilder::BuildJunction(const std::string& xodr_track_id,
                                                                                      int lane_section_index) {
   const int xodr_track = std::stoi(xodr_track_id);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(xodr_track >= 0);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_section_index >= 0);
+  MALIDRIVE_THROW_UNLESS(xodr_track >= 0, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(lane_section_index >= 0, maliput::common::road_geometry_construction_error);
   return std::make_unique<maliput::geometry_base::Junction>(GetJunctionId(xodr_track, lane_section_index));
 }
 
 std::unique_ptr<maliput::geometry_base::Junction> RoadGeometryBuilder::BuildJunction(
     const std::string& xodr_junction_id) {
   const int xodr_junction = std::stoi(xodr_junction_id);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(xodr_junction >= 0);
+  MALIDRIVE_THROW_UNLESS(xodr_junction >= 0, maliput::common::road_geometry_construction_error);
   return std::make_unique<maliput::geometry_base::Junction>(GetJunctionId(xodr_junction));
 }
 
 std::unique_ptr<malidrive::road_curve::GroundCurve> RoadGeometryBuilder::MakeGroundCurve(
     const std::vector<xodr::Geometry>& geometries,
     const std::vector<xodr::DBManager::XodrGeometriesToSimplify>& geometries_to_simplify) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(!geometries.empty());
+  MALIDRIVE_THROW_UNLESS(!geometries.empty(), maliput::common::road_geometry_construction_error);
 
   if (!geometries_to_simplify.empty()) {
     maliput::log()->trace("Simplifying XODR Road ", geometries_to_simplify.front().road_header_id.string(), ".");
@@ -708,15 +712,15 @@ std::unique_ptr<malidrive::road_curve::GroundCurve> RoadGeometryBuilder::MakeGro
       case xodr::Geometry::Type::kSpiral:
         return factory_->MakeSpiralGroundCurve(*start_geometry);
       default:
-        MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE("Geometry " + xodr::Geometry::type_to_str(start_geometry->type) +
-                                                      " cannot be built");
+        MALIDRIVE_THROW_MESSAGE("Geometry " + xodr::Geometry::type_to_str(start_geometry->type) + " cannot be built",
+                                maliput::common::road_geometry_construction_error);
     }
   }
   return factory_->MakePiecewiseGroundCurve(SimplifyGeometries(geometries, geometries_to_simplify));
 }
 
 void RoadGeometryBuilder::BuildBranchPointsForLanes(RoadGeometry* rg) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
   maliput::log()->trace("Building BranchPoints for Lanes...");
 
   for (auto& lane_xodr_lane_properties : lane_xodr_lane_properties_) {
@@ -730,8 +734,8 @@ void RoadGeometryBuilder::BuildBranchPointsForLanes(RoadGeometry* rg) {
 
 void RoadGeometryBuilder::FindOrCreateBranchPointFor(const MalidriveXodrLaneProperties& xodr_lane_properties,
                                                      Lane* lane, RoadGeometry* rg) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane != nullptr);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(lane != nullptr, maliput::common::road_geometry_construction_error);
 
   std::vector<maliput::api::LaneEnd> connecting_lane_ends;
   // Start BP
@@ -753,7 +757,7 @@ void RoadGeometryBuilder::FindOrCreateBranchPointFor(const MalidriveXodrLaneProp
 
 std::vector<maliput::api::LaneEnd> RoadGeometryBuilder::FindConnectingLaneEndsForLaneEnd(
     const maliput::api::LaneEnd& lane_end, const MalidriveXodrLaneProperties& xodr_lane_properties, RoadGeometry* rg) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
+  MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
 
   // Checks if the LaneSection is an inner LaneSection or not. When it is
   // inner, the Lane end look up is simplified as it connects to lanes which
@@ -859,7 +863,7 @@ void RoadGeometryBuilder::SetDefaultsToBranchPoints() {
     const maliput::api::LaneEndSet* a_side_set = bps_[i]->GetASide();
     const maliput::api::LaneEndSet* b_side_set = bps_[i]->GetBSide();
     // We expect to have at least one in A side.
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(a_side_set->size() > 0);
+    MALIDRIVE_THROW_UNLESS(a_side_set->size() > 0, maliput::common::road_geometry_construction_error);
     for (int j = 0; j < b_side_set->size(); ++j) {
       bps_[i]->SetDefault(b_side_set->get(j), a_side_set->get(0));
     }
@@ -877,7 +881,7 @@ maliput::api::BranchPointId RoadGeometryBuilder::GetNewBranchPointId() {
 
 bool RoadGeometryBuilder::IsLaneEndOnABSide(const maliput::api::BranchPoint* bp, const maliput::api::LaneEnd& lane_end,
                                             BranchPointSide bp_side) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(bp != nullptr);
+  MALIDRIVE_THROW_UNLESS(bp != nullptr, maliput::common::road_geometry_construction_error);
 
   auto equiv = [](const maliput::api::LaneEnd& lane_end_a, const maliput::api::LaneEnd& lane_end_b) {
     return lane_end_a.lane == lane_end_b.lane && lane_end_a.end == lane_end_b.end;

--- a/src/maliput_malidrive/builder/road_geometry_builder.h
+++ b/src/maliput_malidrive/builder/road_geometry_builder.h
@@ -204,8 +204,8 @@ class RoadGeometryBuilder {
           factory(factory_in),
           rg_config(rg_config_in),
           rg(rg_in) {
-      MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(rg != nullptr);
-      MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(factory != nullptr);
+      MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
+      MALIDRIVE_THROW_UNLESS(factory != nullptr, maliput::common::road_geometry_construction_error);
     }
 
     // Returns A vector containing all the created Lanes and its properties.

--- a/src/maliput_malidrive/builder/road_rulebook_builder.h
+++ b/src/maliput_malidrive/builder/road_rulebook_builder.h
@@ -82,7 +82,7 @@ class RoadRuleBookBuilder {
   /// @param rg is the pointer to the RoadGeometry. It must not be nullptr.
   /// @param rule_registry is the pointer to the RuleRegistry. It must not be nullptr.
   /// @param road_rulebook_file_path to the yaml file to load the RoadRulebook.
-  /// @throw maliput::assertion_error When `rg` or `rule_registry` are nullptr.
+  /// @throw maliput::rulebook_error When `rg` or `rule_registry` are nullptr.
   RoadRuleBookBuilder(const maliput::api::RoadGeometry* rg, const maliput::api::rules::RuleRegistry* rule_registry,
                       const std::optional<std::string>& road_rulebook_file_path);
 
@@ -120,13 +120,13 @@ class RoadRuleBookBuilder {
   // @param rulebook The RoadRulebook to which to add the rules.
   //        It must not be nullptr.
   //
-  // @throws maliput::common::assertion_error When `rg` is nullptr.
-  // @throws maliput::common::assertion_error When `rule_registry` is nullptr.
-  // @throws maliput::common::assertion_error When `rulebook` is nullptr.
-  // @throws maliput::common::assertion_error When
+  // @throws maliput::common::rulebook_error When `rg` is nullptr.
+  // @throws maliput::common::rulebook_error When `rule_registry` is nullptr.
+  // @throws maliput::common::rulebook_error When `rulebook` is nullptr.
+  // @throws maliput::common::rulebook_error When
   // maliput::api::rules::RuleRegistry has no type equal to
   // maliput::SpeedLimitRuleTypeId().
-  // @throws maliput::common::assertion_error When a Lane in the RoadGeometry
+  // @throws maliput::common::rulebook_error When a Lane in the RoadGeometry
   // has a max speed limit that does not match any range in
   // maliput::SpeedLimitRuleTypeId() rule type.
   static void AddsSpeedLimitRulesToRulebook(const maliput::api::RoadGeometry* rg,
@@ -143,13 +143,13 @@ class RoadRuleBookBuilder {
   // @param rulebook The RoadRulebook to add the rules.
   //        It must not be nullptr.
   //
-  // @throws maliput::common::assertion_error When `rulebook` is nullptr.
+  // @throws maliput::common::rulebook_error When `rulebook` is nullptr.
   static void AddsDirectionUsageRulesToRulebook(const maliput::api::RoadGeometry* rg,
                                                 const maliput::api::rules::RuleRegistry* rule_registry,
                                                 maliput::ManualRulebook* rulebook);
 
   // @returns A LaneSRoute that covers `lane.`
-  // @throws maliput::common::assertion_error When `lane` is nullptr.
+  // @throws maliput::common::rulebook_error When `lane` is nullptr.
   static maliput::api::LaneSRoute CreateLaneSRouteFor(const Lane* lane);
 
   const maliput::api::RoadGeometry* rg_{};

--- a/src/maliput_malidrive/builder/road_rulebook_builder_old_rules.cc
+++ b/src/maliput_malidrive/builder/road_rulebook_builder_old_rules.cc
@@ -58,8 +58,10 @@ RoadRuleBookBuilderOldRules::RoadRuleBookBuilderOldRules(
       road_rulebook_file_path_(road_rulebook_file_path),
       direction_usage_rules_(direction_usage_rules),
       speed_limit_rules_(speed_limit_rules) {
-  MALIDRIVE_THROW_UNLESS(rg_ != nullptr);
-  MALIDRIVE_THROW_UNLESS(rule_registry_ != nullptr);
+  MALIDRIVE_VALIDATE(rg_ != nullptr, maliput::common::rulebook_error,
+                     "RoadGeometry is null when building RoadRulebook (old rules).");
+  MALIDRIVE_VALIDATE(rule_registry_ != nullptr, maliput::common::rulebook_error,
+                     "RuleRegistry is null when building RoadRulebook (old rules).");
 }
 #pragma GCC diagnostic pop
 
@@ -74,7 +76,7 @@ std::unique_ptr<const maliput::api::rules::RoadRulebook> RoadRuleBookBuilderOldR
                       : std::make_unique<maliput::ManualRulebook>();
 
   maliput::ManualRulebook* rulebook_ptr = dynamic_cast<maliput::ManualRulebook*>(rulebook.get());
-  MALIDRIVE_THROW_UNLESS(rulebook_ptr != nullptr);
+  MALIDRIVE_VALIDATE(rulebook_ptr != nullptr, maliput::common::rulebook_error, "Rulebook is null (old rules).");
 
   // Adds rules based on RuleRegistry.
   RoadRuleBookBuilder::AddsXODRBasedRulesToRulebook(rg_, rule_registry_, rulebook_ptr);

--- a/src/maliput_malidrive/builder/road_rulebook_builder_old_rules.h
+++ b/src/maliput_malidrive/builder/road_rulebook_builder_old_rules.h
@@ -81,7 +81,7 @@ class RoadRuleBookBuilderOldRules {
   /// @param road_rulebook_file_path to the yaml file to load the RoadRulebook.
   /// @param direction_usage_rules is a vector of DirectionUsageRules.
   /// @param speed_limit_rules is a vector of SpeedLimitRules.
-  /// @throw maliput::assertion_error When `rg` or `rule_registry` are nullptr.
+  /// @throw maliput::rulebook_error When `rg` or `rule_registry` are nullptr.
   RoadRuleBookBuilderOldRules(const maliput::api::RoadGeometry* rg,
                               const maliput::api::rules::RuleRegistry* rule_registry,
                               const std::optional<std::string>& road_rulebook_file_path,

--- a/src/maliput_malidrive/builder/rule_registry_builder.cc
+++ b/src/maliput_malidrive/builder/rule_registry_builder.cc
@@ -44,7 +44,8 @@ using maliput::api::rules::Rule;
 RuleRegistryBuilder::RuleRegistryBuilder(const maliput::api::RoadGeometry* rg,
                                          const std::optional<std::string>& rule_registry_file_path)
     : rg_{rg}, rule_registry_file_path_{rule_registry_file_path} {
-  MALIDRIVE_THROW_UNLESS(rg_ != nullptr);
+  MALIDRIVE_VALIDATE(rg_ != nullptr, maliput::common::rule_registry_error,
+                     "RoadGeometry is null when building RuleRegistry.");
 }
 
 std::unique_ptr<maliput::api::rules::RuleRegistry> RuleRegistryBuilder::operator()() {
@@ -61,7 +62,8 @@ std::unique_ptr<maliput::api::rules::RuleRegistry> RuleRegistryBuilder::operator
 }
 
 void RuleRegistryBuilder::AddDiscreteValueRuleTypes(maliput::api::rules::RuleRegistry* rule_registry) const {
-  MALIDRIVE_THROW_UNLESS(rule_registry != nullptr);
+  MALIDRIVE_VALIDATE(rule_registry != nullptr, maliput::common::rule_registry_error,
+                     "RuleRegistry is null when adding discrete value rule type.");
 
   const Rule::RelatedRules empty_related_rules{};
   const Rule::RelatedUniqueIds empty_related_unique_ids{};
@@ -107,7 +109,8 @@ std::unordered_map<DiscreteValueRule::TypeId, std::vector<std::string>> RuleRegi
 }
 
 void RuleRegistryBuilder::AddSpeedLimitRuleType(maliput::api::rules::RuleRegistry* rule_registry) const {
-  MALIDRIVE_THROW_UNLESS(rule_registry != nullptr);
+  MALIDRIVE_VALIDATE(rule_registry != nullptr, maliput::common::rule_registry_error,
+                     "RuleRegistry is null when adding speed limit rule type.");
 
   const Rule::RelatedRules empty_related_rules{};
   const Rule::RelatedUniqueIds empty_related_unique_ids{};

--- a/src/maliput_malidrive/builder/rule_registry_builder.h
+++ b/src/maliput_malidrive/builder/rule_registry_builder.h
@@ -80,7 +80,7 @@ class RuleRegistryBuilder {
   // maliput::api::rules::Rule::State::kStrict severity.
   // Direction usage rule type are included to the rule registry.
   //
-  // @throws maliput::common::assertion_error When `rule_registry` is nullptr.
+  // @throws maliput::common::rule_registry_error When `rule_registry` is nullptr.
   void AddDiscreteValueRuleTypes(maliput::api::rules::RuleRegistry* rule_registry) const;
 
   // @returns An unordered map of DiscreteValueRule::TypeId and possible rule states.
@@ -101,7 +101,7 @@ class RuleRegistryBuilder {
   // All built ranges will have a minimum speed constants::kDefaultMaxSpeedLimit.
   // When no maximum speed is set, constants::kDefaultMaxSpeedLimit is used.
   //
-  // @throws maliput::common::assertion_error When `rule_registry` is nullptr.
+  // @throws maliput::common::rule_registry_error When `rule_registry` is nullptr.
   void AddSpeedLimitRuleType(maliput::api::rules::RuleRegistry* rule_registry) const;
 
   const maliput::api::RoadGeometry* rg_{};

--- a/src/maliput_malidrive/builder/speed_limit_builder.cc
+++ b/src/maliput_malidrive/builder/speed_limit_builder.cc
@@ -61,7 +61,8 @@ std::vector<SpeedLimitRule> SpeedLimitBuilder::operator()() {
 
 std::vector<maliput::api::rules::SpeedLimitRule> SpeedLimitBuilder::BuildSpeedLimitFor(
     const maliput::api::Segment* segment) {
-  MALIDRIVE_THROW_UNLESS(segment != nullptr);
+  MALIDRIVE_VALIDATE(segment != nullptr, maliput::common::rulebook_error,
+                     "Segment is null when building SpeedLimit rule.");
 
   const double kDefaultMinSpeedLimit{constants::kDefaultMinSpeedLimit};
   const SpeedLimitRule::Severity kDefaultSeverity{SpeedLimitRule::Severity::kStrict};

--- a/src/maliput_malidrive/road_curve/arc_ground_curve.cc
+++ b/src/maliput_malidrive/road_curve/arc_ground_curve.cc
@@ -58,9 +58,9 @@ double wrap(double theta) {
 // involves the extra step picking the 'closest' interval to saturate
 // within.
 double saturate_on_wrapped_bounds(double theta, double theta_min, double theta_max) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(-M_PI <= theta);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(theta <= M_PI);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(theta_min <= theta_max);
+  MALIDRIVE_THROW_UNLESS(-M_PI <= theta, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(theta <= M_PI, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(theta_min <= theta_max, maliput::common::road_geometry_construction_error);
 
   if (theta_max >= theta_min + 2. * M_PI) return theta;
 
@@ -90,7 +90,7 @@ double ArcGroundCurve::DoGInverse(const maliput::math::Vector2& xy) const {
   const maliput::math::Vector2 center_to_xy = xy - center_;
 
   // throw if test point is to close to the center of curvature
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(center_to_xy.norm() >= linear_tolerance_);
+  MALIDRIVE_THROW_UNLESS(center_to_xy.norm() >= linear_tolerance_, maliput::common::road_geometry_construction_error);
 
   // compute theta angle
   const double theta = std::atan2(center_to_xy.y(), center_to_xy.x());

--- a/src/maliput_malidrive/road_curve/arc_ground_curve.h
+++ b/src/maliput_malidrive/road_curve/arc_ground_curve.h
@@ -86,11 +86,12 @@ class ArcGroundCurve : public GroundCurve {
         center_(xy0_ - std::abs(radius_) * maliput::math::Vector2{std::cos(theta0_), std::sin(theta0_)}),
         validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_,
                                                                                  GroundCurve::kEpsilon)) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(linear_tolerance_ > 0);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(arc_length_ >= GroundCurve::kEpsilon);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0_ >= 0.);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1_ - p0_ >= GroundCurve::kEpsilon);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(curvature) >= GroundCurve::kEpsilon);
+    MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(arc_length_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p1_ - p0_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(std::abs(curvature) >= GroundCurve::kEpsilon,
+                           maliput::common::road_geometry_construction_error);
   }
 
  private:

--- a/src/maliput_malidrive/road_curve/cubic_polynomial.h
+++ b/src/maliput_malidrive/road_curve/cubic_polynomial.h
@@ -79,9 +79,9 @@ class CubicPolynomial : public Function {
         p1_(p1),
         validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance,
                                                                                  Function::kEpsilon)) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0_ >= 0);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1_ > p0_);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(linear_tolerance > 0.);
+    MALIDRIVE_THROW_UNLESS(p0_ >= 0, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p1_ > p0_, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(linear_tolerance > 0., maliput::common::road_geometry_construction_error);
   }
 
  private:

--- a/src/maliput_malidrive/road_curve/lane_offset.cc
+++ b/src/maliput_malidrive/road_curve/lane_offset.cc
@@ -50,26 +50,32 @@ LaneOffset::LaneOffset(const std::optional<AdjacentLaneFunctions>& adjacent_lane
       p1_(p1),
       validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance,
                                                                                Function::kEpsilon)) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0_ >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1_ > p0_);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(linear_tolerance > 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_width_ != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(reference_line_offset_ != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(lane_width_->p0() - p0_) <= linear_tolerance);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(lane_width_->p1() - p1_) <= linear_tolerance);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(reference_line_offset_->p0() <= p0 + linear_tolerance);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(reference_line_offset_->p1() >= p1_ - linear_tolerance);
+  MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1_ > p0_, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(linear_tolerance > 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(lane_width_ != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(reference_line_offset_ != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(std::abs(lane_width_->p0() - p0_) <= linear_tolerance,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(std::abs(lane_width_->p1() - p1_) <= linear_tolerance,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(reference_line_offset_->p0() <= p0 + linear_tolerance,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(reference_line_offset_->p1() >= p1_ - linear_tolerance,
+                         maliput::common::road_geometry_construction_error);
   if (adjacent_lane_functions_.has_value()) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(adjacent_lane_functions_->offset != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(adjacent_lane_functions_->width != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(adjacent_lane_functions_->offset->p0() - p0_) <=
-                                                 linear_tolerance);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(adjacent_lane_functions_->offset->p1() - p1_) <=
-                                                 linear_tolerance);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(adjacent_lane_functions_->width->p0() - p0_) <=
-                                                 linear_tolerance);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(adjacent_lane_functions_->width->p1() - p1_) <=
-                                                 linear_tolerance);
+    MALIDRIVE_THROW_UNLESS(adjacent_lane_functions_->offset != nullptr,
+                           maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(adjacent_lane_functions_->width != nullptr,
+                           maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(std::abs(adjacent_lane_functions_->offset->p0() - p0_) <= linear_tolerance,
+                           maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(std::abs(adjacent_lane_functions_->offset->p1() - p1_) <= linear_tolerance,
+                           maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(std::abs(adjacent_lane_functions_->width->p0() - p0_) <= linear_tolerance,
+                           maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(std::abs(adjacent_lane_functions_->width->p1() - p1_) <= linear_tolerance,
+                           maliput::common::road_geometry_construction_error);
   }
 }
 

--- a/src/maliput_malidrive/road_curve/line_ground_curve.h
+++ b/src/maliput_malidrive/road_curve/line_ground_curve.h
@@ -78,10 +78,10 @@ class LineGroundCurve : public GroundCurve {
         p1_(p1),
         validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_,
                                                                                  GroundCurve::kEpsilon)) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(linear_tolerance_ > 0);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(arc_length_ >= GroundCurve::kEpsilon);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0_ >= 0.);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1_ - p0_ >= GroundCurve::kEpsilon);
+    MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(arc_length_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p1_ - p0_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
   }
 
  private:

--- a/src/maliput_malidrive/road_curve/piecewise_function.cc
+++ b/src/maliput_malidrive/road_curve/piecewise_function.cc
@@ -43,7 +43,7 @@ struct ContinuityChecker {
 
   ContinuityChecker(double tolerance_in, const PiecewiseFunction::ContinuityCheck& continuity_check_in)
       : tolerance(tolerance_in), continuity_check(continuity_check_in) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(tolerance > 0.);
+    MALIDRIVE_THROW_UNLESS(tolerance > 0., maliput::common::road_geometry_construction_error);
   }
 
   // Evaluates whether `lhs` is C1 continuous with `rhs` according to the contiguity strictness.
@@ -89,17 +89,17 @@ struct ContinuityChecker {
 PiecewiseFunction::PiecewiseFunction(std::vector<std::unique_ptr<Function>> functions, double tolerance,
                                      const PiecewiseFunction::ContinuityCheck& continuity_check)
     : functions_(std::move(functions)), linear_tolerance_(tolerance) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(linear_tolerance_ > 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(!functions_.empty());
+  MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(!functions_.empty(), maliput::common::road_geometry_construction_error);
 
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(functions_[0].get() != nullptr);
+  MALIDRIVE_THROW_UNLESS(functions_[0].get() != nullptr, maliput::common::road_geometry_construction_error);
   p0_ = functions_[0]->p0();
   double p = p0_;
   Function* previous_function{nullptr};
   const ContinuityChecker checker(linear_tolerance_, continuity_check);
   for (const auto& function : functions_) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(function.get() != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(function->IsG1Contiguous());
+    MALIDRIVE_THROW_UNLESS(function.get() != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(function->IsG1Contiguous(), maliput::common::road_geometry_construction_error);
     if (previous_function != nullptr) {
       if (!checker(previous_function, function.get())) {
         is_g1_contiguous = false;
@@ -122,8 +122,9 @@ std::pair<const Function*, double> PiecewiseFunction::GetFunctionAndPAt(double p
   auto search_it = interval_function_.find(FunctionInterval(p));
   if (search_it == interval_function_.end()) {
     if (p != p1_) {
-      MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_MESSAGE(std::string("p = ") + std::to_string(p) +
-                                                    std::string(" doesn't match with any Function interval."));
+      MALIDRIVE_THROW_MESSAGE(
+          std::string("p = ") + std::to_string(p) + std::string(" doesn't match with any Function interval."),
+          maliput::common::road_geometry_construction_error);
     } else {
       search_it = --interval_function_.end();
     }

--- a/src/maliput_malidrive/road_curve/piecewise_function.h
+++ b/src/maliput_malidrive/road_curve/piecewise_function.h
@@ -88,7 +88,7 @@ class PiecewiseFunction : public Function {
     // @throws maliput::common::road_geometry_construction_error When `max_in` is not greater
     //         than `min_in`.
     FunctionInterval(double min_in, double max_in) : min(min_in), max(max_in) {
-      MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(max >= min);
+      MALIDRIVE_THROW_UNLESS(max >= min, maliput::common::road_geometry_construction_error);
     }
 
     // Constructs a range @f$ [`x`, `x`) @f$.

--- a/src/maliput_malidrive/road_curve/piecewise_ground_curve.h
+++ b/src/maliput_malidrive/road_curve/piecewise_ground_curve.h
@@ -75,7 +75,7 @@ class PiecewiseGroundCurve : public GroundCurve {
     // @param max_in Is the maximum value of the interval.
     // @throw maliput::common::road_geometry_construction_error When `min_in` is greater than `max_in`.
     RoadCurveInterval(double min_in, double max_in) : min(min_in), max(max_in) {
-      MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(min_in <= max_in);
+      MALIDRIVE_THROW_UNLESS(min_in <= max_in, maliput::common::road_geometry_construction_error);
     }
 
     // Creates a RoadCurveInterval where

--- a/src/maliput_malidrive/road_curve/road_curve.cc
+++ b/src/maliput_malidrive/road_curve/road_curve.cc
@@ -49,27 +49,31 @@ RoadCurve::RoadCurve(double linear_tolerance, double scale_length, std::unique_p
       elevation_(std::move(elevation)),
       superelevation_(std::move(superelevation)) {
   // Non negative quantities check.
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(linear_tolerance_ >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(scale_length_ >= 0.);
+  MALIDRIVE_THROW_UNLESS(linear_tolerance_ >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(scale_length_ >= 0., maliput::common::road_geometry_construction_error);
   // nullptr check.
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(ground_curve_ != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(elevation_ != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(superelevation_ != nullptr);
+  MALIDRIVE_THROW_UNLESS(ground_curve_ != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(elevation_ != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(superelevation_ != nullptr, maliput::common::road_geometry_construction_error);
   // Contiguity check.
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(ground_curve_->IsG1Contiguous());
+  MALIDRIVE_THROW_UNLESS(ground_curve_->IsG1Contiguous(), maliput::common::road_geometry_construction_error);
   if (assert_contiguity) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(elevation_->IsG1Contiguous());
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(superelevation_->IsG1Contiguous());
+    MALIDRIVE_THROW_UNLESS(elevation_->IsG1Contiguous(), maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(superelevation_->IsG1Contiguous(), maliput::common::road_geometry_construction_error);
   }
   // Range checks.
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(ground_curve_->p0() - elevation_->p0()) <= linear_tolerance_);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(ground_curve_->p0() - superelevation_->p0()) <=
-                                               linear_tolerance_);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(elevation_->p0() - superelevation_->p0()) <= linear_tolerance_);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(ground_curve_->p1() - elevation_->p1()) <= linear_tolerance_);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(ground_curve_->p1() - superelevation_->p1()) <=
-                                               linear_tolerance_);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(elevation_->p1() - superelevation_->p1()) <= linear_tolerance_);
+  MALIDRIVE_THROW_UNLESS(std::abs(ground_curve_->p0() - elevation_->p0()) <= linear_tolerance_,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(std::abs(ground_curve_->p0() - superelevation_->p0()) <= linear_tolerance_,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(std::abs(elevation_->p0() - superelevation_->p0()) <= linear_tolerance_,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(std::abs(ground_curve_->p1() - elevation_->p1()) <= linear_tolerance_,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(std::abs(ground_curve_->p1() - superelevation_->p1()) <= linear_tolerance_,
+                         maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(std::abs(elevation_->p1() - superelevation_->p1()) <= linear_tolerance_,
+                         maliput::common::road_geometry_construction_error);
 }
 
 maliput::math::Vector3 RoadCurve::W(const maliput::math::Vector3& prh) const {
@@ -92,7 +96,7 @@ maliput::math::Vector3 RoadCurve::WDot(const maliput::math::Vector3& prh) const 
 }
 
 maliput::math::Vector3 RoadCurve::WDot(const maliput::math::Vector3& prh, const Function* lane_offset) const {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_offset != nullptr);
+  MALIDRIVE_THROW_UNLESS(lane_offset != nullptr, maliput::common::road_geometry_construction_error);
   MALIDRIVE_IS_IN_RANGE(prh.x(), ground_curve_->p0() - ground_curve_->linear_tolerance(),
                         ground_curve_->p1() + ground_curve_->linear_tolerance());
   MALIDRIVE_IS_IN_RANGE(lane_offset->p0(), ground_curve_->p0() - ground_curve_->linear_tolerance(),
@@ -139,7 +143,7 @@ maliput::math::RollPitchYaw RoadCurve::Orientation(const maliput::math::Vector3&
 maliput::math::RollPitchYaw RoadCurve::Orientation(const maliput::math::Vector3& prh,
                                                    const Function* lane_offset) const {
   MALIDRIVE_IS_IN_RANGE(prh.x(), ground_curve_->p0(), ground_curve_->p1());
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_offset != nullptr);
+  MALIDRIVE_THROW_UNLESS(lane_offset != nullptr, maliput::common::road_geometry_construction_error);
   const double p = maliput::math::saturate(prh.x(), ground_curve_->p0(), ground_curve_->p1());
 
   // Calculate s,r basis vectors at (s,r,h).
@@ -216,13 +220,13 @@ maliput::math::Vector3 RoadCurve::RHat(const maliput::math::Vector3& prh) const 
 
 maliput::math::Vector3 RoadCurve::SHat(const maliput::math::Vector3& prh, const Function* lane_offset) const {
   MALIDRIVE_IS_IN_RANGE(prh.x(), ground_curve_->p0(), ground_curve_->p1());
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_offset != nullptr);
+  MALIDRIVE_THROW_UNLESS(lane_offset != nullptr, maliput::common::road_geometry_construction_error);
   return WDot(prh, lane_offset).normalized();
 }
 
 maliput::math::Vector3 RoadCurve::RHat(const maliput::math::Vector3& prh, const Function* lane_offset) const {
   MALIDRIVE_IS_IN_RANGE(prh.x(), ground_curve_->p0(), ground_curve_->p1());
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_offset != nullptr);
+  MALIDRIVE_THROW_UNLESS(lane_offset != nullptr, maliput::common::road_geometry_construction_error);
   const maliput::math::Vector3 s_hat = SHat(prh, lane_offset);
   const maliput::math::Vector3 h_hat = HHat(prh.x(), s_hat);
   return h_hat.cross(s_hat);

--- a/src/maliput_malidrive/road_curve/road_curve_offset.cc
+++ b/src/maliput_malidrive/road_curve/road_curve_offset.cc
@@ -63,10 +63,10 @@ struct ArcLengthDerivativeFunction {
   // @throws maliput::common::road_geometry_construction_error When `road_curve` or `lane_offset` is nullptr.
   ArcLengthDerivativeFunction(const RoadCurve* road_curve, const Function* lane_offset, double p0, double p1)
       : road_curve_(road_curve), lane_offset_(lane_offset), p0_(p0), p1_(p1) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(road_curve_ != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_offset_ != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0_ >= 0.);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1_ >= p0_);
+    MALIDRIVE_THROW_UNLESS(road_curve_ != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(lane_offset_ != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p1_ >= p0_, maliput::common::road_geometry_construction_error);
   }
 
   // Computes the arc length derivative for the RoadCurve specified
@@ -116,10 +116,10 @@ struct InverseArcLengthODEFunction {
   // @throws maliput::common::road_geometry_construction_error When `road_curve` or `lane_offset` is nullptr.
   InverseArcLengthODEFunction(const RoadCurve* road_curve, const Function* lane_offset, double p0, double p1)
       : road_curve_(road_curve), lane_offset_(lane_offset), p0_(p0), p1_(p1) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(road_curve_ != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_offset_ != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0_ >= 0.);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1_ >= p0_);
+    MALIDRIVE_THROW_UNLESS(road_curve_ != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(lane_offset_ != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p1_ >= p0_, maliput::common::road_geometry_construction_error);
   }
 
   // Computes the inverse arc length derivative for the RoadCurve
@@ -163,11 +163,11 @@ struct InverseArcLengthODEFunction {
 RoadCurveOffset::RoadCurveOffset(const RoadCurve* road_curve, const Function* lane_offset, double p0, double p1,
                                  double integrator_accuracy_multiplier)
     : road_curve_(road_curve), lane_offset_(lane_offset), p0_(p0), p1_(p1) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(road_curve_ != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(lane_offset_ != nullptr);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 <= p1);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(integrator_accuracy_multiplier > 0.);
+  MALIDRIVE_THROW_UNLESS(road_curve_ != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(lane_offset_ != nullptr, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p0 >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p0 <= p1, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(integrator_accuracy_multiplier > 0., maliput::common::road_geometry_construction_error);
 
   maliput::log()->trace("Creating RoadCurveOffset with p0: ", p0, " and p1: ", p1);
 

--- a/src/maliput_malidrive/road_curve/scaled_domain_function.h
+++ b/src/maliput_malidrive/road_curve/scaled_domain_function.h
@@ -67,9 +67,9 @@ class ScaledDomainFunction : public Function {
         p1_(p1),
         validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance,
                                                                                  Function::kEpsilon)) {
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(function_ != nullptr);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0_ >= 0.);
-    MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1_ > p0_);
+    MALIDRIVE_THROW_UNLESS(function_ != nullptr, maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
+    MALIDRIVE_THROW_UNLESS(p1_ > p0_, maliput::common::road_geometry_construction_error);
 
     alpha_ = (function_->p1() - function_->p0()) / (p1_ - p0_);
     beta_ = function_->p0() - alpha_ * p0_;

--- a/src/maliput_malidrive/road_curve/spiral_ground_curve.cc
+++ b/src/maliput_malidrive/road_curve/spiral_ground_curve.cc
@@ -69,10 +69,10 @@ inline maliput::math::Vector2 ConditionalShiftYComponent(const maliput::math::Ve
 // @return The p parameter value that minimizes the distance against @p point.
 double FindBestPParameter(const SpiralGroundCurve& curve, const maliput::math::Vector2& point, double p0, double p1,
                           size_t partitions, double tolerance) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0 >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1 - p0 >= GroundCurve::kEpsilon);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(partitions >= 2u);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(tolerance >= 0.);
+  MALIDRIVE_THROW_UNLESS(p0 >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1 - p0 >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(partitions >= 2u, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(tolerance >= 0., maliput::common::road_geometry_construction_error);
 
   const size_t kIterations{2u * static_cast<size_t>(std::ceil(std::log(partitions))) + 1u};
   // Initialize the list of p values.
@@ -130,11 +130,12 @@ SpiralGroundCurve::SpiralGroundCurve(double linear_tolerance, const maliput::mat
       p1_(p1),
       validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_,
                                                                                GroundCurve::kEpsilon)) {
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(linear_tolerance_ > 0);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(arc_length_ >= GroundCurve::kEpsilon);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p0_ >= 0.);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(p1_ - p0_ >= GroundCurve::kEpsilon);
-  MALIDRIVE_THROW_ROAD_GEOMETRY_BUILDER_UNLESS(std::abs(curvature1_ - curvature0_) >= GroundCurve::kEpsilon);
+  MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(arc_length_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(p1_ - p0_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
+  MALIDRIVE_THROW_UNLESS(std::abs(curvature1_ - curvature0_) >= GroundCurve::kEpsilon,
+                         maliput::common::road_geometry_construction_error);
 }
 
 maliput::math::Vector2 SpiralGroundCurve::DoG(double p) const {

--- a/src/maliput_malidrive/xodr/road_header.cc
+++ b/src/maliput_malidrive/xodr/road_header.cc
@@ -48,14 +48,15 @@ std::string RoadHeader::hand_traffic_rule_to_str(RoadHeader::HandTrafficRule rul
 }
 
 RoadHeader::HandTrafficRule RoadHeader::str_to_hand_traffic_rule(const std::string& rule) {
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(str_to_hand_traffic_rule_map.find(rule) !=
-                                                  str_to_hand_traffic_rule_map.end());
+  MALIDRIVE_THROW_UNLESS(str_to_hand_traffic_rule_map.find(rule) != str_to_hand_traffic_rule_map.end(),
+                         maliput::common::road_network_description_parser_error);
   return str_to_hand_traffic_rule_map.at(rule);
 }
 
 double RoadHeader::GetLaneSectionLength(int index) const {
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(index >= 0);
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(index < static_cast<int>(lanes.lanes_section.size()));
+  MALIDRIVE_THROW_UNLESS(index >= 0, maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(index < static_cast<int>(lanes.lanes_section.size()),
+                         maliput::common::road_network_description_parser_error);
   if (index == static_cast<int>(lanes.lanes_section.size()) - 1) {
     return length - (lanes.lanes_section[index].s_0 - lanes.lanes_section[0].s_0);
   } else {
@@ -71,14 +72,15 @@ int RoadHeader::GetLaneSectionIndex(double s) const {
       return index;
     }
   }
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_MESSAGE(std::string("Coordinate s: ") + std::to_string(s) +
-                                                   std::string(" is not part of any LaneSection of Road Id: ") +
-                                                   id.string());
+  MALIDRIVE_THROW_MESSAGE(std::string("Coordinate s: ") + std::to_string(s) +
+                              std::string(" is not part of any LaneSection of Road Id: ") + id.string(),
+                          maliput::common::road_network_description_parser_error);
 }
 
 double RoadHeader::GetRoadTypeLength(int index) const {
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(index >= 0);
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(index < static_cast<int>(road_types.size()));
+  MALIDRIVE_THROW_UNLESS(index >= 0, maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(index < static_cast<int>(road_types.size()),
+                         maliput::common::road_network_description_parser_error);
   if (index == static_cast<int>(road_types.size()) - 1) {
     return length - (road_types[index].s_0 - road_types[0].s_0);
   } else {
@@ -97,14 +99,14 @@ const RoadType* RoadHeader::GetRoadType(double s) const {
       return &road_types[index];
     }
   }
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_MESSAGE(std::string("Coordinate s: ") + std::to_string(s) +
-                                                   std::string(" is not part of any RoadType of Road Id: ") +
-                                                   id.string());
+  MALIDRIVE_THROW_MESSAGE(std::string("Coordinate s: ") + std::to_string(s) +
+                              std::string(" is not part of any RoadType of Road Id: ") + id.string(),
+                          maliput::common::road_network_description_parser_error);
 }
 
 std::vector<const RoadType*> RoadHeader::GetRoadTypesInRange(double s_start, double s_end) const {
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(s_start < s_end);
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(s_start >= 0.);
+  MALIDRIVE_THROW_UNLESS(s_start < s_end, maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(s_start >= 0., maliput::common::road_network_description_parser_error);
   // TODO(#567): Verify that `s_end` is not greater than road's length.
   //             Tolerance is needed.
   std::vector<const RoadType*> road_types_in_range;

--- a/test/regression/builder/phase_provider_builder_test.cc
+++ b/test/regression/builder/phase_provider_builder_test.cc
@@ -101,7 +101,7 @@ class PhaseProviderBuilderTest : public ::testing::Test {
 
 TEST_F(PhaseProviderBuilderTest, Constructor) {
   // Throws because PhaseRingBook pointer is null.
-  EXPECT_THROW(PhaseProviderBuilder(nullptr)(), maliput::common::assertion_error);
+  EXPECT_THROW(PhaseProviderBuilder(nullptr)(), maliput::common::phase_book_error);
   // Correct contruction.
   EXPECT_NO_THROW(PhaseProviderBuilder(phase_ring_book_.get())());
 }

--- a/test/regression/builder/road_rulebook_builder_test.cc
+++ b/test/regression/builder/road_rulebook_builder_test.cc
@@ -158,10 +158,10 @@ class RoadRulebookBuilderTest : public ::testing::Test {
 TEST_F(RoadRulebookBuilderTest, Constructor) {
   // Throws because RoadGeometry pointer is null.
   EXPECT_THROW(RoadRuleBookBuilder(nullptr, rule_registry_.get(), road_rulebook_path)(),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
   // Throws because RuleRegistry pointer is null.
   EXPECT_THROW(RoadRuleBookBuilder(road_geometry_.get(), nullptr, road_rulebook_path)(),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
   // Correct construction with RoadRulebook's yaml path is empty.
   EXPECT_NO_THROW(RoadRuleBookBuilder(road_geometry_.get(), rule_registry_.get(), std::nullopt)());
   // Correct contruction.

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -70,11 +70,12 @@ class ParsingTests : public ::testing::Test {
   static constexpr bool kAllowSchemaErrors{true};
 
   tinyxml2::XMLElement* LoadXMLAndGetNodeByName(const std::string& xml_str, const std::string& node_name) {
-    MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(xml_doc_.Parse(xml_str.c_str()) == tinyxml2::XML_SUCCESS);
+    MALIDRIVE_THROW_UNLESS(xml_doc_.Parse(xml_str.c_str()) == tinyxml2::XML_SUCCESS,
+                           maliput::common::road_network_description_parser_error);
     tinyxml2::XMLElement* p_xml = xml_doc_.FirstChildElement();
-    MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(p_xml != nullptr);
+    MALIDRIVE_THROW_UNLESS(p_xml != nullptr, maliput::common::road_network_description_parser_error);
     tinyxml2::XMLElement* p_elem = p_xml->FirstChildElement(node_name.c_str());
-    MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(p_elem != nullptr);
+    MALIDRIVE_THROW_UNLESS(p_elem != nullptr, maliput::common::road_network_description_parser_error);
     return p_elem;
   }
   const std::optional<double> kNullParserSTolerance{std::nullopt};  // Disables the check because it is not needed.
@@ -1527,7 +1528,8 @@ GTEST_TEST(XMLToText, ConvertXMLNodeToText) {
 )R";
 
   tinyxml2::XMLDocument xml_doc;
-  MALIDRIVE_THROW_ROAD_NETWORK_XODR_PARSER_UNLESS(xml_doc.Parse(kArbitraryXMLDescription) == tinyxml2::XML_SUCCESS);
+  MALIDRIVE_THROW_UNLESS(xml_doc.Parse(kArbitraryXMLDescription) == tinyxml2::XML_SUCCESS,
+                         maliput::common::road_network_description_parser_error);
   const std::string str_xml = ConvertXMLNodeToText(xml_doc.FirstChildElement());
   EXPECT_EQ(kArbitraryXMLDescription, str_xml);
 }


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput-rs/issues/183

## Summary
* Replaces specific error macros in favor of generic ones that receive a runtime error type to throw, defined in `maliput/common/error.h`.
* Replaces all throws of `assertion_error` in rule-related features within malidrive with:
  * `rulebook_error`
  * `rule_registry_error`
  * `phase_book_error`
  * `traffic_lights_error`
  * `state_provider_error`
* Improves some of the thrown errors by adding a helpful message for the user to debug.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
