### PR TITLE
Add custom error types to RangeValidator instances.

### DIFF
--- a/src/maliput_malidrive/base/lane.cc
+++ b/src/maliput_malidrive/base/lane.cc
@@ -94,8 +94,9 @@ Lane::Lane(const maliput::api::LaneId& id, int xodr_track, int xodr_lane_id,
     // functions of this class are in range with linear_tolerance and b) values
     // are adjusted to be in the open range (0, length_) with one-tenth of
     // linear_tolerance as the distance between closed and open range extrema.
-    s_range_validation_ = maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(
-        0., length_, road_curve_->linear_tolerance(), road_curve_->linear_tolerance() / 10.);
+    s_range_validation_ =
+        maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::GetAbsoluteEpsilonValidator(
+            0., length_, road_curve_->linear_tolerance(), road_curve_->linear_tolerance() / 10.);
   } else {
     maliput::log()->trace("Lane ", id.string(),
                           " is shorter than linear tolerance. Will not construct the RoadCurveOffset for it.");
@@ -109,8 +110,9 @@ Lane::Lane(const maliput::api::LaneId& id, int xodr_track, int xodr_lane_id,
     // There are no numerical integrations involved in p_from_s_ and s_from_p_
     // but to mimic the behavior, we will tolerate up to linear tolerance excess
     // in s range. Then, the s value will be saturated.
-    s_range_validation_ = maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(
-        0., length_, road_curve_->linear_tolerance(), /*epsilon*/ 0.);
+    s_range_validation_ =
+        maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::GetAbsoluteEpsilonValidator(
+            0., length_, road_curve_->linear_tolerance(), /*epsilon*/ 0.);
   }
   // @}
 }

--- a/src/maliput_malidrive/road_curve/arc_ground_curve.h
+++ b/src/maliput_malidrive/road_curve/arc_ground_curve.h
@@ -84,8 +84,8 @@ class ArcGroundCurve : public GroundCurve {
         d_theta_(arc_length * curvature),
         theta0_(start_heading - std::copysign(M_PI / 2., d_theta_)),
         center_(xy0_ - std::abs(radius_) * maliput::math::Vector2{std::cos(theta0_), std::sin(theta0_)}),
-        validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_,
-                                                                                 GroundCurve::kEpsilon)) {
+        validate_p_(maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::
+                        GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_, GroundCurve::kEpsilon)) {
     MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0, maliput::common::road_geometry_construction_error);
     MALIDRIVE_THROW_UNLESS(arc_length_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
     MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
@@ -158,7 +158,7 @@ class ArcGroundCurve : public GroundCurve {
   // curve.
   const maliput::math::Vector2 center_{};
   // Validates that p is within [p0, p1] with linear_tolerance.
-  const maliput::common::RangeValidator validate_p_;
+  const maliput::common::RangeValidator<maliput::common::road_geometry_construction_error> validate_p_;
 };
 
 }  // namespace road_curve

--- a/src/maliput_malidrive/road_curve/cubic_polynomial.h
+++ b/src/maliput_malidrive/road_curve/cubic_polynomial.h
@@ -66,10 +66,6 @@ class CubicPolynomial : public Function {
   ///         is less or equal to @p p0.
   /// @throws maliput::common::road_geometry_construction_error When @p linear_tolerance is not
   ///         positive.
-  // TODO(Santoi): Even so this method should throw a maliput::common::road_geometry_construction_error it
-  // actually throws a maliput::common::assertion_error coming from the RangeValidator called in the
-  // initialization list. After solving https://github.com/maliput/maliput/issues/666, we can make sure that
-  // it throws what we want it to throw.
   CubicPolynomial(double a, double b, double c, double d, double p0, double p1, double linear_tolerance)
       : a_(a),
         b_(b),
@@ -77,8 +73,8 @@ class CubicPolynomial : public Function {
         d_(d),
         p0_(p0),
         p1_(p1),
-        validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance,
-                                                                                 Function::kEpsilon)) {
+        validate_p_(maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::
+                        GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance, Function::kEpsilon)) {
     MALIDRIVE_THROW_UNLESS(p0_ >= 0, maliput::common::road_geometry_construction_error);
     MALIDRIVE_THROW_UNLESS(p1_ > p0_, maliput::common::road_geometry_construction_error);
     MALIDRIVE_THROW_UNLESS(linear_tolerance > 0., maliput::common::road_geometry_construction_error);
@@ -111,7 +107,7 @@ class CubicPolynomial : public Function {
   const double p0_{};
   const double p1_{};
   // Validates that p is within [p0_, p1_] with linear_tolerance.
-  const maliput::common::RangeValidator validate_p_;
+  const maliput::common::RangeValidator<maliput::common::road_geometry_construction_error> validate_p_;
 };
 
 }  // namespace road_curve

--- a/src/maliput_malidrive/road_curve/lane_offset.cc
+++ b/src/maliput_malidrive/road_curve/lane_offset.cc
@@ -48,8 +48,10 @@ LaneOffset::LaneOffset(const std::optional<AdjacentLaneFunctions>& adjacent_lane
       at_right_(at_right),
       p0_(p0),
       p1_(p1),
-      validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance,
-                                                                               Function::kEpsilon)) {
+      validate_p_(maliput::common::RangeValidator<
+                  maliput::common::road_geometry_construction_error>::GetAbsoluteEpsilonValidator(p0_, p1_,
+                                                                                                  linear_tolerance,
+                                                                                                  Function::kEpsilon)) {
   MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
   MALIDRIVE_THROW_UNLESS(p1_ > p0_, maliput::common::road_geometry_construction_error);
   MALIDRIVE_THROW_UNLESS(linear_tolerance > 0., maliput::common::road_geometry_construction_error);

--- a/src/maliput_malidrive/road_curve/lane_offset.h
+++ b/src/maliput_malidrive/road_curve/lane_offset.h
@@ -89,10 +89,6 @@ class LaneOffset : public Function {
   /// nullptr.
   /// @throws maliput::common::road_geometry_construction_error When @p adjacent_lane_functions 's width value is
   /// nullptr.
-  // TODO(Santoi): Even so this method should throw a maliput::common::road_geometry_construction_error it
-  // actually throws a maliput::common::assertion_error coming from the RangeValidator called in the
-  // initialization list. After solving https://github.com/maliput/maliput/issues/666, we can make sure that
-  // it throws what we want it to throw.
   LaneOffset(const std::optional<AdjacentLaneFunctions>& adjacent_lane_functions, const Function* lane_width,
              const Function* reference_line_offset, bool at_right, double p0, double p1, double linear_tolerance);
 
@@ -114,7 +110,7 @@ class LaneOffset : public Function {
   const double p0_{};
   const double p1_{};
   // Validates that p is within [p0_, p1_] with linear_tolerance.
-  const maliput::common::RangeValidator validate_p_;
+  const maliput::common::RangeValidator<maliput::common::road_geometry_construction_error> validate_p_;
 };
 
 }  // namespace road_curve

--- a/src/maliput_malidrive/road_curve/line_ground_curve.h
+++ b/src/maliput_malidrive/road_curve/line_ground_curve.h
@@ -63,10 +63,6 @@ class LineGroundCurve : public GroundCurve {
   /// @throws maliput::common::road_geometry_construction_error When the norm of @p dxy is too small.
   /// @throws maliput::common::road_geometry_construction_error When @p p0 is negative.
   /// @throws maliput::common::road_geometry_construction_error When @p p1 is not sufficiently larger than @p p0.
-  // TODO(Santoi): Even so this method should throw a maliput::common::road_geometry_construction_error it
-  // actually throws a maliput::common::assertion_error coming from the RangeValidator called in the
-  // initialization list. After solving https://github.com/maliput/maliput/issues/666, we can make sure that
-  // it throws what we want it to throw.
   LineGroundCurve(const double linear_tolerance, const maliput::math::Vector2& xy0, const maliput::math::Vector2& dxy,
                   double p0, double p1)
       : linear_tolerance_(linear_tolerance),
@@ -76,8 +72,8 @@ class LineGroundCurve : public GroundCurve {
         heading_(std::atan2(dxy.y(), dxy.x())),
         p0_(p0),
         p1_(p1),
-        validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_,
-                                                                                 GroundCurve::kEpsilon)) {
+        validate_p_(maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::
+                        GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_, GroundCurve::kEpsilon)) {
     MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0, maliput::common::road_geometry_construction_error);
     MALIDRIVE_THROW_UNLESS(arc_length_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
     MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
@@ -122,7 +118,7 @@ class LineGroundCurve : public GroundCurve {
   // The value of the p parameter at the end of the line.
   const double p1_{};
   // Validates that p is within [p0, p1] with linear_tolerance.
-  const maliput::common::RangeValidator validate_p_;
+  const maliput::common::RangeValidator<maliput::common::road_geometry_construction_error> validate_p_;
 };
 
 }  // namespace road_curve

--- a/src/maliput_malidrive/road_curve/piecewise_function.cc
+++ b/src/maliput_malidrive/road_curve/piecewise_function.cc
@@ -117,7 +117,8 @@ PiecewiseFunction::PiecewiseFunction(std::vector<std::unique_ptr<Function>> func
     : PiecewiseFunction(std::move(functions), tolerance, PiecewiseFunction::ContinuityCheck::kThrow) {}
 
 std::pair<const Function*, double> PiecewiseFunction::GetFunctionAndPAt(double p) const {
-  p = maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_, Function::kEpsilon)(p);
+  p = maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::GetAbsoluteEpsilonValidator(
+      p0_, p1_, linear_tolerance_, Function::kEpsilon)(p);
 
   auto search_it = interval_function_.find(FunctionInterval(p));
   if (search_it == interval_function_.end()) {
@@ -138,19 +139,22 @@ std::pair<const Function*, double> PiecewiseFunction::GetFunctionAndPAt(double p
 }
 
 double PiecewiseFunction::do_f(double p) const {
-  p = maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_, Function::kEpsilon)(p);
+  p = maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::GetAbsoluteEpsilonValidator(
+      p0_, p1_, linear_tolerance_, Function::kEpsilon)(p);
   const std::pair<const Function*, double> function_p = GetFunctionAndPAt(p);
   return function_p.first->f(function_p.second);
 }
 
 double PiecewiseFunction::do_f_dot(double p) const {
-  p = maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_, Function::kEpsilon)(p);
+  p = maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::GetAbsoluteEpsilonValidator(
+      p0_, p1_, linear_tolerance_, Function::kEpsilon)(p);
   const std::pair<const Function*, double> function_p = GetFunctionAndPAt(p);
   return function_p.first->f_dot(function_p.second);
 }
 
 double PiecewiseFunction::do_f_dot_dot(double p) const {
-  p = maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_, Function::kEpsilon)(p);
+  p = maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::GetAbsoluteEpsilonValidator(
+      p0_, p1_, linear_tolerance_, Function::kEpsilon)(p);
   const std::pair<const Function*, double> function_p = GetFunctionAndPAt(p);
   return function_p.first->f_dot_dot(function_p.second);
 }

--- a/src/maliput_malidrive/road_curve/piecewise_ground_curve.cc
+++ b/src/maliput_malidrive/road_curve/piecewise_ground_curve.cc
@@ -104,7 +104,9 @@ PiecewiseGroundCurve::PiecewiseGroundCurve(std::vector<std::unique_ptr<GroundCur
   p0_ = 0.;
   p1_ = cumulative_p;
   MALIDRIVE_THROW_UNLESS(p1_ - p0_ >= kEpsilon, maliput::common::road_geometry_construction_error);
-  validate_p_ = maliput::common::RangeValidator::GetRelativeEpsilonValidator(p0_, p1_, linear_tolerance_, kEpsilon);
+  validate_p_ =
+      maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::GetRelativeEpsilonValidator(
+          p0_, p1_, linear_tolerance_, kEpsilon);
 }
 
 std::pair<const GroundCurve*, double> PiecewiseGroundCurve::GetGroundCurveFromP(double p) const {

--- a/src/maliput_malidrive/road_curve/scaled_domain_function.h
+++ b/src/maliput_malidrive/road_curve/scaled_domain_function.h
@@ -65,8 +65,8 @@ class ScaledDomainFunction : public Function {
       : function_(std::move(function)),
         p0_(p0),
         p1_(p1),
-        validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance,
-                                                                                 Function::kEpsilon)) {
+        validate_p_(maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::
+                        GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance, Function::kEpsilon)) {
     MALIDRIVE_THROW_UNLESS(function_ != nullptr, maliput::common::road_geometry_construction_error);
     MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);
     MALIDRIVE_THROW_UNLESS(p1_ > p0_, maliput::common::road_geometry_construction_error);
@@ -106,7 +106,7 @@ class ScaledDomainFunction : public Function {
   double alpha_{};
   double beta_{};
   // Validates that p is within [p0, p1] with linear_tolerance.
-  const maliput::common::RangeValidator validate_p_;
+  const maliput::common::RangeValidator<maliput::common::road_geometry_construction_error> validate_p_;
 };
 
 }  // namespace road_curve

--- a/src/maliput_malidrive/road_curve/spiral_ground_curve.cc
+++ b/src/maliput_malidrive/road_curve/spiral_ground_curve.cc
@@ -128,8 +128,8 @@ SpiralGroundCurve::SpiralGroundCurve(double linear_tolerance, const maliput::mat
       heading0_spiral_(maliput::math::FresnelSpiralHeading(t0_ * norm_, k_dot_)),
       p0_(p0),
       p1_(p1),
-      validate_p_(maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_,
-                                                                               GroundCurve::kEpsilon)) {
+      validate_p_(maliput::common::RangeValidator<maliput::common::road_geometry_construction_error>::
+                      GetAbsoluteEpsilonValidator(p0_, p1_, linear_tolerance_, GroundCurve::kEpsilon)) {
   MALIDRIVE_THROW_UNLESS(linear_tolerance_ > 0, maliput::common::road_geometry_construction_error);
   MALIDRIVE_THROW_UNLESS(arc_length_ >= GroundCurve::kEpsilon, maliput::common::road_geometry_construction_error);
   MALIDRIVE_THROW_UNLESS(p0_ >= 0., maliput::common::road_geometry_construction_error);

--- a/src/maliput_malidrive/road_curve/spiral_ground_curve.h
+++ b/src/maliput_malidrive/road_curve/spiral_ground_curve.h
@@ -73,10 +73,6 @@ class SpiralGroundCurve : public GroundCurve {
   /// @throws maliput::common::road_geometry_construction_error When @p p0 is negative.
   /// @throws maliput::common::road_geometry_construction_error When @p p1 is not sufficiently
   ///         larger than @p p0.
-  // TODO(Santoi): Even so this method should throw a maliput::common::road_geometry_construction_error it
-  // actually throws a maliput::common::assertion_error coming from the RangeValidator called in the
-  // initialization list. After solving https://github.com/maliput/maliput/issues/666, we can make sure that
-  // it throws what we want it to throw.
   SpiralGroundCurve(double linear_tolerance, const maliput::math::Vector2& xy0, double heading0, double curvature0,
                     double curvature1, double arc_length, double p0, double p1);
 
@@ -130,7 +126,7 @@ class SpiralGroundCurve : public GroundCurve {
   // The value of the p parameter at the end of the spiral.
   const double p1_{};
   // Validates that p is within [p0, p1] with linear_tolerance.
-  const maliput::common::RangeValidator validate_p_;
+  const maliput::common::RangeValidator<maliput::common::road_geometry_construction_error> validate_p_;
 };
 
 }  // namespace road_curve

--- a/test/regression/builder/road_curve_factory_test.cc
+++ b/test/regression/builder/road_curve_factory_test.cc
@@ -413,10 +413,8 @@ TEST_F(RoadCurveFactoryMakeReferenceLineOffsetTest, DiscontinuousReferenceLineOf
   const std::vector<xodr::LaneOffset> kLaneOffsets{{0. /* s_0 */, 0. /* a */, 0.2 /* b */, 0. /* c */, 0. /* d */},
                                                    {10. /* s_0 */, 4. /* a */, 0. /* b */, 0. /* c */, 0. /* d */}};
 
-  // TODO(Santoi): This method throws because of RangeValidator. It should throw
-  // maliput::common::road_geometry_construction_error.
   EXPECT_THROW(road_curve_factory_->MakeReferenceLineOffset(kLaneOffsets, kP0, kP1, kEnsureContiguity),
-               maliput::common::assertion_error);
+               maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(RoadCurveFactoryMakeReferenceLineOffsetTest, DiscontinuousReferenceLineOffset) {

--- a/test/regression/road_curve/arc_ground_curve_test.cc
+++ b/test/regression/road_curve/arc_ground_curve_test.cc
@@ -54,11 +54,11 @@ TEST_F(ArcGroundCurveConstructorTest, CorrectlyConstructed) {
 }
 
 TEST_F(ArcGroundCurveConstructorTest, InvalidNegativeTolerance) {
-  EXPECT_THROW(ArcGroundCurve(-1., kZero, 0., 1., 1., 0., 1.), maliput::common::assertion_error);
+  EXPECT_THROW(ArcGroundCurve(-1., kZero, 0., 1., 1., 0., 1.), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(ArcGroundCurveConstructorTest, InvalidZeroTolerance) {
-  EXPECT_THROW(ArcGroundCurve(0., kZero, 0., 1., 1., 0., 1.), maliput::common::assertion_error);
+  EXPECT_THROW(ArcGroundCurve(0., kZero, 0., 1., 1., 0., 1.), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(ArcGroundCurveConstructorTest, InvalidPositiveCurvatureTooSmall) {
@@ -81,12 +81,12 @@ TEST_F(ArcGroundCurveConstructorTest, InvalidNegativeP0) {
 }
 
 TEST_F(ArcGroundCurveConstructorTest, InvalidP1SmallerThanP0) {
-  EXPECT_THROW(ArcGroundCurve(1.0, kZero, 0., 1., 1., 0., -0.01), maliput::common::assertion_error);
+  EXPECT_THROW(ArcGroundCurve(1.0, kZero, 0., 1., 1., 0., -0.01), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(ArcGroundCurveConstructorTest, InvalidP1NotSufficientlyLargerThanP0) {
   EXPECT_THROW(ArcGroundCurve(1.0, kZero, 0., 1., 1., 0., GroundCurve::kEpsilon / 2.),
-               maliput::common::assertion_error);
+               maliput::common::road_geometry_construction_error);
 }
 
 class ArcGroundCurveTest : public ::testing::Test {
@@ -286,14 +286,14 @@ TEST_F(ArcGroundCurveTest, G) {
 
   // Confirm that it throws when given p value outside of [p0, p1] by excess of
   // linear tolerance.
-  EXPECT_THROW(left_turn_90deg_dut_->G(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(left_turn_90deg_dut_->G(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(right_turn_90deg_dut_->G(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(right_turn_90deg_dut_->G(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(u_turn_quadrant1_dut_->G(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(u_turn_quadrant1_dut_->G(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(slight_right_turn_quadrant3_dut_->G(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(slight_right_turn_quadrant3_dut_->G(20.02), maliput::common::assertion_error);
+  EXPECT_THROW(left_turn_90deg_dut_->G(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(left_turn_90deg_dut_->G(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(right_turn_90deg_dut_->G(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(right_turn_90deg_dut_->G(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(u_turn_quadrant1_dut_->G(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(u_turn_quadrant1_dut_->G(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(slight_right_turn_quadrant3_dut_->G(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(slight_right_turn_quadrant3_dut_->G(20.02), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(ArcGroundCurveTest, GDot) {
@@ -328,14 +328,14 @@ TEST_F(ArcGroundCurveTest, GDot) {
 
   // Confirm that it throws when given p value outside of [p0, p1] by excess of
   // linear tolerance.
-  EXPECT_THROW(left_turn_90deg_dut_->GDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(left_turn_90deg_dut_->GDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(right_turn_90deg_dut_->GDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(right_turn_90deg_dut_->GDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(u_turn_quadrant1_dut_->GDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(u_turn_quadrant1_dut_->GDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(slight_right_turn_quadrant3_dut_->GDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(slight_right_turn_quadrant3_dut_->GDot(20.02), maliput::common::assertion_error);
+  EXPECT_THROW(left_turn_90deg_dut_->GDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(left_turn_90deg_dut_->GDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(right_turn_90deg_dut_->GDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(right_turn_90deg_dut_->GDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(u_turn_quadrant1_dut_->GDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(u_turn_quadrant1_dut_->GDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(slight_right_turn_quadrant3_dut_->GDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(slight_right_turn_quadrant3_dut_->GDot(20.02), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(ArcGroundCurveTest, Heading) {
@@ -361,14 +361,14 @@ TEST_F(ArcGroundCurveTest, Heading) {
 
   // Confirm that it throws when given p value outside of [p0, p1] by excess of
   // linear tolerance.
-  EXPECT_THROW(left_turn_90deg_dut_->Heading(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(left_turn_90deg_dut_->Heading(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(right_turn_90deg_dut_->Heading(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(right_turn_90deg_dut_->Heading(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(u_turn_quadrant1_dut_->Heading(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(u_turn_quadrant1_dut_->Heading(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(slight_right_turn_quadrant3_dut_->Heading(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(slight_right_turn_quadrant3_dut_->Heading(20.02), maliput::common::assertion_error);
+  EXPECT_THROW(left_turn_90deg_dut_->Heading(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(left_turn_90deg_dut_->Heading(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(right_turn_90deg_dut_->Heading(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(right_turn_90deg_dut_->Heading(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(u_turn_quadrant1_dut_->Heading(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(u_turn_quadrant1_dut_->Heading(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(slight_right_turn_quadrant3_dut_->Heading(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(slight_right_turn_quadrant3_dut_->Heading(20.02), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(ArcGroundCurveTest, HeadingDot) {
@@ -393,14 +393,14 @@ TEST_F(ArcGroundCurveTest, HeadingDot) {
               slight_right_turn_quadrant3_dut_->HeadingDot(/* kPMidpoint */ 15.), kTolerance);
 
   // Confirm that it throws when given p value outside of [p0, p1]
-  EXPECT_THROW(left_turn_90deg_dut_->HeadingDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(left_turn_90deg_dut_->HeadingDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(right_turn_90deg_dut_->HeadingDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(right_turn_90deg_dut_->HeadingDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(u_turn_quadrant1_dut_->HeadingDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(u_turn_quadrant1_dut_->HeadingDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(slight_right_turn_quadrant3_dut_->HeadingDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(slight_right_turn_quadrant3_dut_->HeadingDot(20.02), maliput::common::assertion_error);
+  EXPECT_THROW(left_turn_90deg_dut_->HeadingDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(left_turn_90deg_dut_->HeadingDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(right_turn_90deg_dut_->HeadingDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(right_turn_90deg_dut_->HeadingDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(u_turn_quadrant1_dut_->HeadingDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(u_turn_quadrant1_dut_->HeadingDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(slight_right_turn_quadrant3_dut_->HeadingDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(slight_right_turn_quadrant3_dut_->HeadingDot(20.02), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(ArcGroundCurveTest, GInverse) {

--- a/test/regression/road_curve/cubic_polynomial_test.cc
+++ b/test/regression/road_curve/cubic_polynomial_test.cc
@@ -56,7 +56,8 @@ GTEST_TEST(CubicPolynomial, Constructor) {
   // p1 < p0
   // TODO(Santoi): This method throws because of RangeValidator. It should throw
   // maliput::common::road_geometry_construction_error.
-  EXPECT_THROW(CubicPolynomial(kA, kB, kC, kD, kP1, kP0, kTolerance), maliput::common::assertion_error);
+  EXPECT_THROW(CubicPolynomial(kA, kB, kC, kD, kP1, kP0, kTolerance),
+               maliput::common::road_geometry_construction_error);
   // p0 is less than 0.
   EXPECT_THROW(CubicPolynomial(kA, kB, kC, kD, -kP1, kP0, kTolerance),
                maliput::common::road_geometry_construction_error);
@@ -112,9 +113,9 @@ GTEST_TEST(CubicPolynomial, FunctionApi) {
 GTEST_TEST(CubicPolynomial, Range) {
   const CubicPolynomial dut(kA, kB, kC, kD, kP0, kP1, kTolerance);
 
-  EXPECT_THROW(dut.f(kP1 + 1.), maliput::common::assertion_error);
-  EXPECT_THROW(dut.f_dot(kP1 + 1.), maliput::common::assertion_error);
-  EXPECT_THROW(dut.f_dot_dot(kP1 + 1.), maliput::common::assertion_error);
+  EXPECT_THROW(dut.f(kP1 + 1.), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(dut.f_dot(kP1 + 1.), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(dut.f_dot_dot(kP1 + 1.), maliput::common::road_geometry_construction_error);
 }
 
 GTEST_TEST(CubicPolynomial, IsG1Contiguous) {

--- a/test/regression/road_curve/lane_offset_test.cc
+++ b/test/regression/road_curve/lane_offset_test.cc
@@ -75,7 +75,7 @@ TEST_F(LaneOffsetTest, Constructor) {
   // maliput::common::road_geometry_construction_error.
   EXPECT_THROW(LaneOffset(kNoAdjacentLane, &kLaneWidth, &kReferenceLineOffset, LaneOffset::kAtLeftFromCenterLane, kP1,
                           kP0, kTolerance),
-               maliput::common::assertion_error);
+               maliput::common::road_geometry_construction_error);
   // p0 is less than 0.
   EXPECT_THROW(LaneOffset(kNoAdjacentLane, &kLaneWidth, &kReferenceLineOffset, LaneOffset::kAtLeftFromCenterLane, -kP1,
                           kP0, kTolerance),
@@ -302,9 +302,9 @@ TEST_F(LaneOffsetTest, Range) {
                        kP1,
                        kTolerance};
 
-  EXPECT_THROW(dut.f(kP1 + 1.), maliput::common::assertion_error);
-  EXPECT_THROW(dut.f_dot(kP1 + 1.), maliput::common::assertion_error);
-  EXPECT_THROW(dut.f_dot_dot(kP1 + 1.), maliput::common::assertion_error);
+  EXPECT_THROW(dut.f(kP1 + 1.), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(dut.f_dot(kP1 + 1.), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(dut.f_dot_dot(kP1 + 1.), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(LaneOffsetTest, IsG1Contiguous) {

--- a/test/regression/road_curve/line_ground_curve_test.cc
+++ b/test/regression/road_curve/line_ground_curve_test.cc
@@ -55,11 +55,11 @@ TEST_F(LineGroundCurveConstructorTest, CorrectlyConstructed) {
 }
 
 TEST_F(LineGroundCurveConstructorTest, InvalidNegativeTolerance) {
-  EXPECT_THROW(LineGroundCurve(-1., kZero, kUnitX, 0., 1.), maliput::common::assertion_error);
+  EXPECT_THROW(LineGroundCurve(-1., kZero, kUnitX, 0., 1.), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(LineGroundCurveConstructorTest, InvalidZeroTolerance) {
-  EXPECT_THROW(LineGroundCurve(0., kZero, kUnitX, 0., 1.), maliput::common::assertion_error);
+  EXPECT_THROW(LineGroundCurve(0., kZero, kUnitX, 0., 1.), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(LineGroundCurveConstructorTest, InvalidLineLengthTooSmall) {
@@ -74,13 +74,14 @@ TEST_F(LineGroundCurveConstructorTest, InvalidNegativeP0) {
 // TODO(Santoi): This method throws because of RangeValidator. It should throw
 // maliput::common::road_geometry_construction_error.
 TEST_F(LineGroundCurveConstructorTest, InvalidP1SmallerThanP0) {
-  EXPECT_THROW(LineGroundCurve(1.0, kZero, kUnitX, 0., -0.01), maliput::common::assertion_error);
+  EXPECT_THROW(LineGroundCurve(1.0, kZero, kUnitX, 0., -0.01), maliput::common::road_geometry_construction_error);
 }
 
 // TODO(Santoi): This method throws because of RangeValidator. It should throw
 // maliput::common::road_geometry_construction_error.
 TEST_F(LineGroundCurveConstructorTest, InvalidP1NotSufficientlyLargerThanP0) {
-  EXPECT_THROW(LineGroundCurve(1.0, kZero, kUnitX, 0., GroundCurve::kEpsilon / 2.), maliput::common::assertion_error);
+  EXPECT_THROW(LineGroundCurve(1.0, kZero, kUnitX, 0., GroundCurve::kEpsilon / 2.),
+               maliput::common::road_geometry_construction_error);
 }
 
 class LineGroundCurveTest : public ::testing::Test {
@@ -175,12 +176,12 @@ TEST_F(LineGroundCurveTest, G) {
 
   // Confirm that it throws when given p value outside of [p0, p1] by excess of
   // linear tolerance.
-  EXPECT_THROW(trivial_dut_->G(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(trivial_dut_->G(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant1_dut_->G(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant1_dut_->G(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant3_dut_->G(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant3_dut_->G(20.02), maliput::common::assertion_error);
+  EXPECT_THROW(trivial_dut_->G(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(trivial_dut_->G(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant1_dut_->G(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant1_dut_->G(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant3_dut_->G(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant3_dut_->G(20.02), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(LineGroundCurveTest, GDot) {
@@ -200,12 +201,12 @@ TEST_F(LineGroundCurveTest, GDot) {
 
   // Confirm that it throws when given p value outside of [p0, p1] by excess of
   // linear tolerance.
-  EXPECT_THROW(trivial_dut_->GDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(trivial_dut_->GDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant1_dut_->GDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant1_dut_->GDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant3_dut_->GDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant3_dut_->GDot(20.02), maliput::common::assertion_error);
+  EXPECT_THROW(trivial_dut_->GDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(trivial_dut_->GDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant1_dut_->GDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant1_dut_->GDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant3_dut_->GDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant3_dut_->GDot(20.02), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(LineGroundCurveTest, Heading) {
@@ -222,12 +223,12 @@ TEST_F(LineGroundCurveTest, Heading) {
 
   // Confirm that it throws when given p value outside of [p0, p1] by excess of
   // linear tolerance.
-  EXPECT_THROW(trivial_dut_->Heading(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(trivial_dut_->Heading(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant1_dut_->Heading(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant1_dut_->Heading(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant3_dut_->Heading(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant3_dut_->Heading(20.02), maliput::common::assertion_error);
+  EXPECT_THROW(trivial_dut_->Heading(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(trivial_dut_->Heading(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant1_dut_->Heading(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant1_dut_->Heading(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant3_dut_->Heading(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant3_dut_->Heading(20.02), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(LineGroundCurveTest, HeadingDot) {
@@ -244,12 +245,12 @@ TEST_F(LineGroundCurveTest, HeadingDot) {
 
   // Confirm that it throws when given p value outside of [p0, p1] by excess of
   // linear tolerance.
-  EXPECT_THROW(trivial_dut_->HeadingDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(trivial_dut_->HeadingDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant1_dut_->HeadingDot(9.988), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant1_dut_->HeadingDot(20.02), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant3_dut_->HeadingDot(9.98), maliput::common::assertion_error);
-  EXPECT_THROW(quadrant3_dut_->HeadingDot(20.02), maliput::common::assertion_error);
+  EXPECT_THROW(trivial_dut_->HeadingDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(trivial_dut_->HeadingDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant1_dut_->HeadingDot(9.988), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant1_dut_->HeadingDot(20.02), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant3_dut_->HeadingDot(9.98), maliput::common::road_geometry_construction_error);
+  EXPECT_THROW(quadrant3_dut_->HeadingDot(20.02), maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(LineGroundCurveTest, GInverse) {

--- a/test/regression/road_curve/spiral_ground_curve_test.cc
+++ b/test/regression/road_curve/spiral_ground_curve_test.cc
@@ -73,7 +73,7 @@ TEST_F(SpiralGroundCurveConstructorTest, NegativeLinearToleranceThrows) {
         SpiralGroundCurve(kNegativeTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kArcLength, kP0,
                           kP1);
       },
-      maliput::common::assertion_error);
+      maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(SpiralGroundCurveConstructorTest, SameCurvatureThrows) {
@@ -114,7 +114,7 @@ TEST_F(SpiralGroundCurveConstructorTest, NegativeP1Throws) {
         SpiralGroundCurve(kLinearTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kArcLength, kP0,
                           kNegativeP1);
       },
-      maliput::common::assertion_error);
+      maliput::common::road_geometry_construction_error);
 }
 
 TEST_F(SpiralGroundCurveConstructorTest, P0AndP1AreAlmostEqualThrows) {
@@ -124,7 +124,7 @@ TEST_F(SpiralGroundCurveConstructorTest, P0AndP1AreAlmostEqualThrows) {
         SpiralGroundCurve(kLinearTolerance, kXy0, kStartHeading, kStartCurvature, kEndCurvature, kArcLength, kP0,
                           kAlmostP0P1);
       },
-      maliput::common::assertion_error);
+      maliput::common::road_geometry_construction_error);
 }
 
 // Test class to validate the correct value retrieval of the accessors.
@@ -169,7 +169,7 @@ TEST_F(SpiralGroundCurveAccessorsTest, IsG1Contiguous) { EXPECT_TRUE(dut_.IsG1Co
 // @pre Given lower integration bound @p p0 is greater than or equal to 0.
 // @pre Given upper integration bound @p p1 is greater than or equal to the given lower integration bound @p p0.
 // @pre Given @p k_order for the linear approximation is a non-negative number.
-// @throws maliput::common::assertion_error if preconditions are not met.
+// @throws maliput::common::road_geometry_construction_error if preconditions are not met.
 double BruteForcePathLengthIntegral(const SpiralGroundCurve& dut, double p0, double p1, int k_order) {
   MALIDRIVE_IS_IN_RANGE(p0, dut.p0(), dut.p1());
   MALIDRIVE_IS_IN_RANGE(p1, dut.p0(), dut.p1());


### PR DESCRIPTION
# 🎉 New feature

Relates to https://github.com/maliput/maliput/issues/666

## Summary
`RangeValidator` now throws user defined error types, instead of always `assertion_error`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
