### PR TITLE
Add `RoadGeometryConfiguration` option to parse userData XODR node.

### DIFF
--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -190,11 +190,11 @@ static constexpr char const* kOmitNonDrivableLanes{"omit_nondrivable_lanes"};
 ///   - Default: @e "1.0"
 static constexpr char const* kIntegratorAccuracyMultiplier{"integrator_accuracy_multiplier"};
 
-/// True for supporting userData XODR tags within Lane XODR tags. If false, they will be ignored.
-/// userData are mostly used for traffic direction management, and will overwrite any other traffic direction
-/// configuration in the lane it is set for.
+/// True for supporting userData XODR nodes within Lane XODR nodes. If false, they will be ignored.
+/// userData are mostly used for traffic direction management, and will override any other traffic direction
+/// configuration in the lane it is added in.
 ///   - Default: @e "false"
-static constexpr char const* kSupportUserData{"support_user_data"};
+static constexpr char const* kUseUserDataTrafficDirection{"use_userdata_traffic_direction"};
 
 /// @}
 

--- a/src/maliput_malidrive/builder/road_geometry_configuration.cc
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.cc
@@ -172,9 +172,9 @@ RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(
     rg_config.integrator_accuracy_multiplier = std::stod(it->second);
   }
 
-  it = road_geometry_configuration.find(params::kSupportUserData);
+  it = road_geometry_configuration.find(params::kUseUserDataTrafficDirection);
   if (it != road_geometry_configuration.end()) {
-    rg_config.support_user_data = ParseBoolean(it->second);
+    rg_config.use_userdata_traffic_direction = ParseBoolean(it->second);
   }
   return rg_config;
 }
@@ -200,7 +200,7 @@ std::map<std::string, std::string> RoadGeometryConfiguration::ToStringMap() cons
     config_map.emplace(params::kNumThreads, std::to_string(build_policy.num_threads.value()));
   }
   config_map.emplace(params::kIntegratorAccuracyMultiplier, std::to_string(integrator_accuracy_multiplier));
-  config_map.emplace(params::kSupportUserData, support_user_data ? "true" : "false");
+  config_map.emplace(params::kUseUserDataTrafficDirection, use_userdata_traffic_direction ? "true" : "false");
   return config_map;
 }
 

--- a/src/maliput_malidrive/builder/road_geometry_configuration.h
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.h
@@ -183,7 +183,7 @@ struct RoadGeometryConfiguration {
   // lane 1, the lane 2 will have an incorrect lane offset function.
   bool omit_nondrivable_lanes{true};
   double integrator_accuracy_multiplier{1.0};
-  bool support_user_data{false};
+  bool use_userdata_traffic_direction{false};
   /// @}
 };
 

--- a/src/maliput_malidrive/builder/xodr_parser_configuration.cc
+++ b/src/maliput_malidrive/builder/xodr_parser_configuration.cc
@@ -41,7 +41,7 @@ xodr::ParserConfiguration XodrParserConfigurationFromRoadGeometryConfiguration(
           (rg_config.standard_strictness_policy &
            RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors) ==
               RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors,
-          rg_config.support_user_data};
+          rg_config.use_userdata_traffic_direction};
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/test_utilities/road_geometry_configuration_for_xodrs.cc
+++ b/src/maliput_malidrive/test_utilities/road_geometry_configuration_for_xodrs.cc
@@ -48,7 +48,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
       builder::RoadGeometryConfiguration::StandardStrictnessPolicy::kPermissive};
   const bool kOmitNondrivableLanes{false};
   const double kIntegratorAccuracyMultiplier{1.0};
-  const bool kSupportUserData{true};
+  const bool kUseUserDataTrafficDirection{true};
 
   const static std::unordered_map<std::string, builder::RoadGeometryConfiguration> kXodrConfigurations{
       {"SingleLane.xodr",
@@ -64,7 +64,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"ArcLane.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"ArcSingleLane"},
@@ -78,7 +78,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SpiralRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SpiralRoad"},
@@ -92,7 +92,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SmallTownRoads.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SmallTownRoads"},
@@ -106,7 +106,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"BikingLineLane.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"BikingLineLane"},
@@ -120,7 +120,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"DisconnectedRoadInJunction.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"DisconnectedRoadInJunction"},
@@ -134,7 +134,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SShapeRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SShapeRoad"},
@@ -148,7 +148,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"LShapeRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LShapeRoad"},
@@ -162,7 +162,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"LShapeRoadVariableLanes.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LShapeRoadVariableLanes"},
@@ -176,7 +176,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"LineMultipleSections.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineMultipleSections"},
@@ -190,7 +190,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"LineMultipleSectionsMoreCases.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineMultipleSectionsMoreCases"},
@@ -204,7 +204,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"LineMultipleSpeeds.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineMultipleSpeeds"},
@@ -218,7 +218,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"LineVariableOffset.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineVariableOffset"},
@@ -232,7 +232,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"LineVariableWidth.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LineVariableWidth"},
@@ -246,7 +246,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"LongRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"LongRoad"},
@@ -260,7 +260,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"ParkingGarageRamp.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"ParkingGarageRamp"},
@@ -274,7 +274,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"RRLongRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"RRLongRoad"},
@@ -288,7 +288,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SShapeSuperelevatedRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SShapeSuperelevatedRoad"},
@@ -302,7 +302,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"TShapeRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"TShapeRoad"},
@@ -316,7 +316,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"Highway.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"Highway"},
@@ -330,7 +330,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"Figure8.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"Figure8"},
@@ -344,7 +344,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"RRFigure8.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"RRFigure8"},
@@ -358,7 +358,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"StraightForward.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"StraightForward"},
@@ -372,7 +372,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"StraightRoadMultipleLaneDirections.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"StraightRoadMultipleLaneDirections"},
@@ -386,7 +386,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SingleRoadComplexDescription.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadComplexDescription"},
@@ -400,7 +400,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SingleRoadComplexDescription2.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadComplexDescription2"},
@@ -414,7 +414,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SingleRoadNanValues.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadNanValues"},
@@ -428,7 +428,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SingleRoadNegativeWidth.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadNegativeWidth"},
@@ -442,7 +442,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SingleRoadHighCoefficients.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadHighCoefficients"},
@@ -456,7 +456,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SingleRoadTinyGeometry.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadTinyGeometry"},
@@ -470,7 +470,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"SingleRoadTwoGeometries.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"SingleRoadTwoGeometries"},
@@ -484,7 +484,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"FlatTown01.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"FlatTown01"},
@@ -498,7 +498,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"Town01.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town01"},
                                                          {"Town01.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
@@ -511,7 +511,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes,
                                                          kIntegratorAccuracyMultiplier,
-                                                         kSupportUserData}},
+                                                         kUseUserDataTrafficDirection}},
       {"Town02.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town02"},
                                                          {"Town02.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
@@ -524,7 +524,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes,
                                                          kIntegratorAccuracyMultiplier,
-                                                         kSupportUserData}},
+                                                         kUseUserDataTrafficDirection}},
       {"Town03.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town03"},
                                                          {"Town03.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
@@ -537,7 +537,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes,
                                                          kIntegratorAccuracyMultiplier,
-                                                         kSupportUserData}},
+                                                         kUseUserDataTrafficDirection}},
       {"Town04.xodr",
        /* linear tolerance restricted by 0.052m elevation gap in Road 735 */
        builder::RoadGeometryConfiguration{
@@ -552,7 +552,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"Town05.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town05"},
                                                          {"Town05.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
@@ -565,7 +565,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes,
                                                          kIntegratorAccuracyMultiplier,
-                                                         kSupportUserData}},
+                                                         kUseUserDataTrafficDirection}},
       {"Town06.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town06"},
                                                          {"Town06.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
@@ -578,7 +578,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes,
                                                          kIntegratorAccuracyMultiplier,
-                                                         kSupportUserData}},
+                                                         kUseUserDataTrafficDirection}},
       {"Town07.xodr", builder::RoadGeometryConfiguration{maliput::api::RoadGeometryId{"Town07"},
                                                          {"Town07.xodr"},
                                                          builder::RoadGeometryConfiguration::BuildTolerance{
@@ -591,7 +591,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
                                                          kStandardStrictnessPolicy,
                                                          kOmitNondrivableLanes,
                                                          kIntegratorAccuracyMultiplier,
-                                                         kSupportUserData}},
+                                                         kUseUserDataTrafficDirection}},
       {"GapInElevationNonDrivableRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"GapInElevationNonDrivableRoad"},
@@ -605,7 +605,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"GapInSuperelevationNonDrivableRoad.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"GapInSuperelevationNonDrivableRoad"},
@@ -619,7 +619,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"GapInLaneWidthNonDrivableLane.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"GapInLaneWidthNonDrivableLane"},
@@ -633,7 +633,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
       {"GapInLaneWidthDrivableLane.xodr",
        builder::RoadGeometryConfiguration{
            maliput::api::RoadGeometryId{"GapInLaneWidthDrivableLane"},
@@ -647,7 +647,7 @@ std::optional<builder::RoadGeometryConfiguration> GetRoadGeometryConfigurationFo
            kStandardStrictnessPolicy,
            kOmitNondrivableLanes,
            kIntegratorAccuracyMultiplier,
-           kSupportUserData}},
+           kUseUserDataTrafficDirection}},
   };
   return kXodrConfigurations.find(xodr_file_name) != kXodrConfigurations.end()
              ? std::make_optional<builder::RoadGeometryConfiguration>(kXodrConfigurations.at(xodr_file_name))

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -645,7 +645,7 @@ Lane NodeParser::As() const {
 
   std::optional<std::string> user_data{std::nullopt};
   tinyxml2::XMLElement* user_data_element = nullptr;
-  if (parser_configuration_.support_user_data) {
+  if (parser_configuration_.use_userdata_traffic_direction) {
     user_data_element = element_->FirstChildElement(Lane::kUserData);
   }
   if (user_data_element != nullptr) {

--- a/src/maliput_malidrive/xodr/parser_configuration.h
+++ b/src/maliput_malidrive/xodr/parser_configuration.h
@@ -54,7 +54,7 @@ struct ParserConfiguration {
   bool allow_semantic_errors{true};
 
   /// When active, the parser will support userData XODR nodes.
-  bool support_user_data{false};
+  bool use_userdata_traffic_direction{false};
 };
 
 }  // namespace xodr

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -281,7 +281,7 @@ struct XodrDirectionUsageRuleReferenceValue {
   std::string right_lane_direction_modifier;
   std::string left_lane_direction_rule_state;
   std::string right_lane_direction_rule_state;
-  bool support_user_data;
+  bool use_userdata_traffic_direction;
 };
 
 std::vector<XodrDirectionUsageRuleReferenceValue> InstatiateDirectionUsageRuleStateTypeParametersSupportingUserData() {
@@ -324,7 +324,7 @@ class DirectionUsageRuleStateTypeTest : public ::testing::TestWithParam<XodrDire
  protected:
   void SetUp() override {
     reference_value_ = GetParam();
-    parser_configuration_.support_user_data = reference_value_.support_user_data;
+    parser_configuration_.use_userdata_traffic_direction = reference_value_.use_userdata_traffic_direction;
   }
   const std::optional<double> kParserSTolerance{std::nullopt};  // Disables the check because it is not needed.
   xodr::ParserConfiguration parser_configuration_{kParserSTolerance};

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -1314,7 +1314,7 @@ class RoadNetworkBuilderPopulationTest : public ::testing::Test {
       {params::kPhaseRingBook, phase_ring_book_path},
       {params::kIntersectionBook, intersection_book_path},
       {params::kOmitNonDrivableLanes, "false"},
-      {params::kSupportUserData, "false"},
+      {params::kUseUserDataTrafficDirection, "false"},
   })};
 };
 

--- a/test/regression/builder/road_rulebook_builder_test.cc
+++ b/test/regression/builder/road_rulebook_builder_test.cc
@@ -132,9 +132,10 @@ inline ::testing::AssertionResult IsEqual(const T& rule_a, const T& rule_b, doub
 class RoadRulebookBuilderTest : public ::testing::Test {
  public:
   void SetUp() override {
-    auto manager = xodr::LoadDataBaseFromFile(road_geometry_configuration_.opendrive_file,
-                                              {constants::kLinearTolerance, allow_schema_errors_,
-                                               allow_semantic_errors_, road_geometry_configuration_.support_user_data});
+    auto manager =
+        xodr::LoadDataBaseFromFile(road_geometry_configuration_.opendrive_file,
+                                   {constants::kLinearTolerance, allow_schema_errors_, allow_semantic_errors_,
+                                    road_geometry_configuration_.use_userdata_traffic_direction});
     road_geometry_ = RoadGeometryBuilder(std::move(manager), road_geometry_configuration_)();
     rule_registry_ = RuleRegistryBuilder(road_geometry_.get(), rule_registry_path)();
   }
@@ -149,7 +150,7 @@ class RoadRulebookBuilderTest : public ::testing::Test {
   const RoadGeometryConfiguration road_geometry_configuration_{RoadGeometryConfiguration::FromMap({
       {"opendrive_file", xodr_file_path},
       {"omit_nondrivable_lanes", "false"},
-      {"support_user_data", "true"},
+      {"use_userdata_traffic_direction", "true"},
   })};
   const bool allow_schema_errors_{true};
   const bool allow_semantic_errors_{true};

--- a/test/regression/xodr/db_manager_test.cc
+++ b/test/regression/xodr/db_manager_test.cc
@@ -105,7 +105,7 @@ constexpr bool kDontAllowSchemaErrors{false};
 // Flag to not allow semantic errors.
 constexpr bool kDontAllowSemanticErrors{false};
 // Flag to support user data.
-constexpr bool kSupportUserData{true};
+constexpr bool kUseUserDataTrafficDirection{true};
 
 // Tests the loading of a XODR description from a file.
 GTEST_TEST(DBManager, LoadFromFile) {
@@ -1694,7 +1694,7 @@ GTEST_TEST(DBManagerTest, Highway) {
 
   const std::unique_ptr<DBManager> dut = LoadDataBaseFromFile(
       utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder),
-      {kStrictParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors, kSupportUserData});
+      {kStrictParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors, kUseUserDataTrafficDirection});
 
   const std::map<RoadHeader::Id, RoadHeader> road_headers = dut->GetRoadHeaders();
   EXPECT_EQ(NumOfRoads, static_cast<int>(road_headers.size()));

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -69,7 +69,7 @@ class ParsingTests : public ::testing::Test {
   // Flag to allow schema errors.
   static constexpr bool kAllowSchemaErrors{true};
   // Flag to support userData XODR parsing.
-  static constexpr bool kSupportUserData{true};
+  static constexpr bool kUseUserDataTrafficDirection{true};
   // Flag to not support userData XODR parsing.
   static constexpr bool kDontSupportUserData{false};
 
@@ -956,8 +956,9 @@ TEST_F(ParsingTests, NodeParserLane) {
       kExpectedLane.dynamic_lane_type.value() ? "true" : "false", kExpectedLane.road_works.value() ? "true" : "false");
   std::cout << "XML description: " << xml_description << std::endl;
 
-  const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Lane::kLaneTag),
-                       {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors, kSupportUserData});
+  const NodeParser dut(
+      LoadXMLAndGetNodeByName(xml_description, Lane::kLaneTag),
+      {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors, kUseUserDataTrafficDirection});
   EXPECT_EQ(Lane::kLaneTag, dut.GetName());
   const Lane lane = dut.As<Lane>();
   EXPECT_EQ(kExpectedLane.id, lane.id);


### PR DESCRIPTION
# 🎉 New feature

Closes #345

## Summary
Adds a RoadGeometryConfiguration parameter to enable or disable `userData` parsing.

## Test it
Instructions in https://github.com/maliput/maliput_integration/pull/147

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
