### PR TITLE
Move junction collection from unordered_map to map

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -37,4 +37,4 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          bazel test //...
+          bazel test //... --test_output=all

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -2,8 +2,6 @@ name: macOS Build
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     types: [labeled]
   workflow_dispatch:
@@ -35,3 +33,8 @@ jobs:
         shell: bash
         run: |
           bazel build //...
+
+      - name: Test
+        shell: bash
+        run: |
+          bazel test //...

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -2,6 +2,8 @@ name: macOS Build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [labeled]
   workflow_dispatch:

--- a/src/applications/xodr_query.cc
+++ b/src/applications/xodr_query.cc
@@ -186,8 +186,7 @@ class DBManagerQuery {
   /// @param junction_id The malidrive::xodr::Junction::Id of the junction to
   /// look for.
   void FindJunction(const malidrive::xodr::Junction::Id& junction_id) const {
-    const std::unordered_map<malidrive::xodr::Junction::Id, malidrive::xodr::Junction>& junctions =
-        db_manager_->GetJunctions();
+    const std::map<malidrive::xodr::Junction::Id, malidrive::xodr::Junction>& junctions = db_manager_->GetJunctions();
     const auto junction_it = junctions.find(junction_id);
     if (junction_it == junctions.end()) {
       (*out_) << "JunctionId: " << junction_id.string() << " could not be found." << std::endl;

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -147,7 +147,7 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsForConnectingRoad(
 std::vector<maliput::api::LaneEnd> SolveLaneEndsForJunction(
     const maliput::api::RoadGeometry* rg, const MalidriveXodrLaneProperties& xodr_lane_properties,
     const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers,
-    const std::unordered_map<xodr::Junction::Id, xodr::Junction>& junctions, XodrConnectionType connection_type) {
+    const std::map<xodr::Junction::Id, xodr::Junction>& junctions, XodrConnectionType connection_type) {
   MALIDRIVE_THROW_UNLESS(rg != nullptr, maliput::common::road_geometry_construction_error);
 
   std::vector<maliput::api::LaneEnd> connecting_lane_ends;

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -117,7 +117,7 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsForConnectingRoad(
 std::vector<maliput::api::LaneEnd> SolveLaneEndsForJunction(
     const maliput::api::RoadGeometry* rg, const MalidriveXodrLaneProperties& xodr_lane_properties,
     const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers,
-    const std::unordered_map<xodr::Junction::Id, xodr::Junction>& junctions, XodrConnectionType connection_type);
+    const std::map<xodr::Junction::Id, xodr::Junction>& junctions, XodrConnectionType connection_type);
 
 /// Searches which LaneEnds connect to `xodr_lane_properties.lane` in `connection_type` direction
 /// considering the LaneEnd belongs to an external interface. The XODR Road that contains the LaneEnd is

--- a/src/maliput_malidrive/xodr/db_manager.cc
+++ b/src/maliput_malidrive/xodr/db_manager.cc
@@ -141,7 +141,7 @@ class DBManager::Impl {
   const std::map<RoadHeader::Id, RoadHeader>& get_road_headers() const { return road_headers_; }
 
   // @returns A constant reference to junction map.
-  const std::unordered_map<Junction::Id, Junction>& get_junctions() const { return junctions_; }
+  const std::map<Junction::Id, Junction>& get_junctions() const { return junctions_; }
 
   // @returns Data from the shortest Geometry in the entire XODR description.
   const XodrGeometryLengthData& get_shortest_geometry() const { return shortest_geometry_; }
@@ -873,7 +873,7 @@ class DBManager::Impl {
   // Holds the RoadHeaders of the XODR map.
   std::map<RoadHeader::Id, RoadHeader> road_headers_{};
   // Holds the Junctions of the XODR map.
-  std::unordered_map<Junction::Id, Junction> junctions_{};
+  std::map<Junction::Id, Junction> junctions_{};
   // {@ Holds data of the shortest and largest geometries.
   XodrGeometryLengthData shortest_geometry_{RoadHeader::Id("none"), 0, std::numeric_limits<double>::infinity()};
   XodrGeometryLengthData largest_geometry_{RoadHeader::Id("none"), 0, 0.};
@@ -913,7 +913,7 @@ const Header& DBManager::GetXodrHeader() const { return impl_->get_header(); }
 
 const std::map<RoadHeader::Id, RoadHeader>& DBManager::GetRoadHeaders() const { return impl_->get_road_headers(); };
 
-const std::unordered_map<Junction::Id, Junction>& DBManager::GetJunctions() const { return impl_->get_junctions(); };
+const std::map<Junction::Id, Junction>& DBManager::GetJunctions() const { return impl_->get_junctions(); };
 
 const DBManager::XodrGeometryLengthData& DBManager::GetShortestGeometry() const {
   return impl_->get_shortest_geometry();

--- a/src/maliput_malidrive/xodr/db_manager.h
+++ b/src/maliput_malidrive/xodr/db_manager.h
@@ -31,7 +31,6 @@
 
 #include <map>
 #include <memory>
-#include <unordered_map>
 #include <utility>
 
 #include <tinyxml2.h>
@@ -144,7 +143,7 @@ class DBManager {
   const std::map<RoadHeader::Id, RoadHeader>& GetRoadHeaders() const;
 
   /// @returns A xodr::Junction map which contains all the junction information about the XODR description.
-  const std::unordered_map<Junction::Id, Junction>& GetJunctions() const;
+  const std::map<Junction::Id, Junction>& GetJunctions() const;
 
   /// @{ Xodr geometry introspection queries.
 

--- a/src/maliput_malidrive/xodr/junction.h
+++ b/src/maliput_malidrive/xodr/junction.h
@@ -31,7 +31,6 @@
 
 #include <optional>
 #include <ostream>
-#include <unordered_map>
 
 #include <maliput/api/type_specific_identifier.h>
 
@@ -91,7 +90,7 @@ struct Junction {
   /// Type of the junction, required for "virtual" junctions only.
   std::optional<Type> type{Type::kDefault};
   /// Connections within the junction.
-  std::unordered_map<Connection::Id, Connection> connections{};
+  std::map<Connection::Id, Connection> connections{};
 };
 
 /// Streams a string representation of @p junction into @p out. Returns

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -1098,7 +1098,7 @@ Junction NodeParser::As() const {
     }
     maliput::log()->debug(msg);
   }
-  std::unordered_map<Connection::Id, Connection> connections;
+  std::map<Connection::Id, Connection> connections;
   while (connection_element) {
     const auto connection = NodeParser(connection_element, parser_configuration_).As<Connection>();
     if (connections.find(connection.id) != connections.end()) {

--- a/test/regression/builder/road_geometry_builder_test.cc
+++ b/test/regression/builder/road_geometry_builder_test.cc
@@ -1387,7 +1387,7 @@ TEST_F(BranchPointDefaultTest, DefaultBranchPoint) {
   EXPECT_EQ(ongoing_branches->size(), 2);
   const auto default_lane_end = bp->GetDefaultBranch(lane_end);
   ASSERT_NE(default_lane_end, std::nullopt);
-  EXPECT_EQ(default_lane_end->lane->id(), LaneId("9_0_-1"));
+  EXPECT_EQ(default_lane_end->lane->id(), LaneId("5_0_-1"));
 }
 
 }  // namespace

--- a/test/regression/xodr/db_manager_test.cc
+++ b/test/regression/xodr/db_manager_test.cc
@@ -1380,7 +1380,7 @@ GTEST_TEST(DBManagerTest, GetJunctions) {
                                     {kConnection4.id, kConnection4},
                                     {kConnection5.id, kConnection5}} /* connections */};
 
-  const std::unordered_map<Junction::Id, Junction> kExpectedJunctions{{kExpectedJunction.id, kExpectedJunction}};
+  const std::map<Junction::Id, Junction> kExpectedJunctions{{kExpectedJunction.id, kExpectedJunction}};
   const std::string kXodrFile = "TShapeRoad.xodr";
   // If I decrease even more the tolerance, the TShapeRoad.xodr's geometries aren't contiguous in terms of the arc
   // length parameter.
@@ -1388,7 +1388,7 @@ GTEST_TEST(DBManagerTest, GetJunctions) {
   const std::unique_ptr<DBManager> dut =
       LoadDataBaseFromFile(utility::FindResourceInPath(kXodrFile, kMalidriveResourceFolder), {1e-6});
 
-  const std::unordered_map<Junction::Id, Junction> junctions = dut->GetJunctions();
+  const std::map<Junction::Id, Junction> junctions = dut->GetJunctions();
 
   EXPECT_EQ(kExpectedJunctions, junctions);
 }
@@ -1700,7 +1700,7 @@ GTEST_TEST(DBManagerTest, Highway) {
   EXPECT_EQ(NumOfRoads, static_cast<int>(road_headers.size()));
   EXPECT_EQ(kExpectedRoadHeader, road_headers.at(kExpectedRoadHeader.id));
 
-  const std::unordered_map<Junction::Id, Junction> junctions = dut->GetJunctions();
+  const std::map<Junction::Id, Junction> junctions = dut->GetJunctions();
   EXPECT_EQ(NumOfJunctions, static_cast<int>(junctions.size()));
   EXPECT_EQ(kExpectedJunction17, junctions.at(kExpectedJunction17.id));
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
 - This was causing the default branch lane end selection not to be robust.
 - It was noticed after compiling in clang compiler as well.


