### PR TITLE
Add tests for KDTree strategy FindRoadPositions with actual XODR.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.8.0")
+bazel_dep(name = "maliput", version = "1.8.1")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.8.1")
+bazel_dep(name = "maliput", version = "1.8.2")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -256,9 +256,11 @@ TEST_F(RoadGeometryFindRoadPositions, FindPositionsBetween2ParallelLanes) {
   maliput::geometry_base::KDTreeStrategy strategy(road_network_->road_geometry(), .05);
   std::vector<maliput::api::RoadPositionResult> results = strategy.FindRoadPositions(inertial_position, radius);
   EXPECT_EQ(static_cast<int>(results.size()), 2);
-  const maliput::api::LanePosition parallel_lane_position(lane->length() / 2, lane->lane_bounds(lane->length() / 2).max(), 0.);
+  const maliput::api::LanePosition parallel_lane_position(lane->length() / 2,
+                                                          lane->lane_bounds(lane->length() / 2).max(), 0.);
   const maliput::api::LaneId parallel_lane_id("0_0_-1");
-  EXPECT_TRUE(AssertCompare(IsLanePositionClose(parallel_lane_position, results[0].road_position.pos, constants::kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(
+      IsLanePositionClose(parallel_lane_position, results[0].road_position.pos, constants::kLinearTolerance)));
   EXPECT_EQ(results[0].road_position.lane->id(), parallel_lane_id);
   EXPECT_TRUE(AssertCompare(IsLanePositionClose(position, results[1].road_position.pos, constants::kLinearTolerance)));
   EXPECT_EQ(results[1].road_position.lane->id(), lane_id);

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -33,7 +33,9 @@
 
 #include <gtest/gtest.h>
 #include <maliput/api/compare.h>
+#include <maliput/api/lane_data.h>
 #include <maliput/common/error.h>
+#include <maliput/geometry_base/kd_tree_strategy.h>
 #include <maliput/math/compare.h>
 
 #include "assert_compare.h"
@@ -206,6 +208,43 @@ TEST_F(RoadGeometryFigure8Trafficlights, RoundTripPositionAtTheEnd) {
   auto result = road_network_->road_geometry()->ToRoadPosition(inertial_position);
   EXPECT_EQ(lane_id, result.road_position.lane->id());
   EXPECT_TRUE(AssertCompare(IsLanePositionClose(position, result.road_position.pos, constants::kLinearTolerance)));
+}
+
+class RoadGeometryFindRoadPositions : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    road_geometry_configuration_.id = maliput::api::RoadGeometryId("TShapeRoad");
+    road_geometry_configuration_.opendrive_file =
+        utility::FindResourceInPath("TShapeRoad.xodr", kMalidriveResourceFolder);
+    road_network_ =
+        ::malidrive::loader::Load<::malidrive::builder::RoadNetworkBuilder>(road_geometry_configuration_.ToStringMap());
+  }
+  builder::RoadGeometryConfiguration road_geometry_configuration_{};
+  std::unique_ptr<maliput::api::RoadNetwork> road_network_{nullptr};
+};
+
+TEST_F(RoadGeometryFindRoadPositions, FindSingleRoadPosition) {
+  const maliput::api::LaneId lane_id("0_0_1");
+  auto lane = road_network_->road_geometry()->ById().GetLane(lane_id);
+  const maliput::api::LanePosition position(lane->length() / 2, 0., 0.);
+  auto inertial_position = lane->ToInertialPosition(position);
+  double radius = 0.1;
+  maliput::geometry_base::KDTreeStrategy strategy(road_network_->road_geometry(), .05);
+  std::vector<maliput::api::RoadPositionResult> results = strategy.FindRoadPositions(inertial_position, radius);
+  EXPECT_EQ(static_cast<int>(results.size()), 1);
+  EXPECT_TRUE(AssertCompare(IsLanePositionClose(position, results[0].road_position.pos, constants::kLinearTolerance)));
+  EXPECT_EQ(results[0].road_position.lane->id(), lane_id);
+}
+
+TEST_F(RoadGeometryFindRoadPositions, FindAllRoadPosition) {
+  const maliput::api::LaneId lane_id("0_0_1");
+  auto lane = road_network_->road_geometry()->ById().GetLane(lane_id);
+  const maliput::api::LanePosition position(lane->length() / 2, 0., 0.);
+  auto inertial_position = lane->ToInertialPosition(position);
+  double radius = 1000.0;
+  maliput::geometry_base::KDTreeStrategy strategy(road_network_->road_geometry(), .05);
+  std::vector<maliput::api::RoadPositionResult> results = strategy.FindRoadPositions(inertial_position, radius);
+  EXPECT_EQ(static_cast<int>(results.size()), road_network_->road_geometry()->ById().GetLanes().size());
 }
 
 struct OpenScenarioLanePositionMaliputLane {


### PR DESCRIPTION
# 🎉 New feature

## Summary
* Test with input position in the middle of the road with a small radius returns one position in that road.
* Test with big radius returns all lanes.
* Test with input position between 2 lanes in the same segment returns both lanes.
* Test with input position at the end of road returns all branching roads (see pic below).
* Points to `maliput 1.8.1`.
<img width="1000" height="654" alt="image" src="https://github.com/user-attachments/assets/a92d6a32-5868-4665-b099-153a6ea37613" />


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
