### PR TITLE
Allow schema error: Contact point in junction.

### DIFF
--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -158,6 +158,7 @@ static constexpr char const* kSimplificationPolicy{"simplification_policy"};
 ///      - 3. Allows having functions with NaN values. It is only accepted when there is a function that starts at
 ///      the same 's' so the function with NaN values can be discarded.
 ///      - 4. Allows having junction nodes without any connection.
+///      - 5. Allows having RoadLink to Junction with contactPoint attribute defined.
 ///    - 3. @e "allow_semantic_errors" : Allow semantic errors.
 ///      - 1. At a XODR level it allows having non reciprocal Road-linkage and Lane-linkage within a Road.
 ///      - 2. Allows having lane width descriptions that are negative in certain range.

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -404,10 +404,20 @@ RoadLink::LinkAttributes NodeParser::As() const {
   const auto contact_point = attribute_parser.As<RoadLink::ContactPoint>(RoadLink::LinkAttributes::kContactPoint);
   switch (*element_type) {
     case RoadLink::ElementType::kRoad:
-      MALIDRIVE_THROW_UNLESS(contact_point != std::nullopt, maliput::common::road_network_description_parser_error);
+      if (contact_point == std::nullopt) {
+        const std::string msg = "RoadLink to Road demands contactPoint attribute.";
+        maliput::log()->debug(msg);
+        MALIDRIVE_THROW_MESSAGE(msg, maliput::common::road_network_description_parser_error);
+      }
       break;
     case RoadLink::ElementType::kJunction:
-      MALIDRIVE_THROW_UNLESS(contact_point == std::nullopt, maliput::common::road_network_description_parser_error);
+      if (contact_point != std::nullopt) {
+        const std::string msg = "RoadLink to Junction does not support contactPoint attribute.";
+        maliput::log()->debug(msg);
+        if (!parser_configuration_.allow_schema_errors) {
+          MALIDRIVE_THROW_MESSAGE(msg, maliput::common::road_network_description_parser_error);
+        }
+      }
       break;
     default:
       MALIDRIVE_THROW_MESSAGE("Invalid elementType value for RoadLink's description.",


### PR DESCRIPTION
# 🎉 New feature

Closes #<NUMBER>

## Summary
Allow defining a contactPoint attribute for the roadLink when the element is a junction.
 - This is flagged under the `allow_schema_error` parameter.
 - When enabled, the parser will allow the attribute to be defined however it won't be used.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

