### PR TITLE
Add signalReference as part of Signals.

### DIFF
--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -1349,17 +1349,6 @@ signal::Signal NodeParser::As() const {
     references.push_back(reference);
     reference_element_xml = reference_element_xml->NextSiblingElement(signal::Reference::kReferenceTag);
   }
-  // signal::SignalReference elements
-  tinyxml2::XMLElement* signal_reference_element_xml =
-      element_->FirstChildElement(signal::SignalReference::kSignalReferenceTag);
-  std::vector<signal::SignalReference> signal_references;
-  while (signal_reference_element_xml) {
-    auto signal_reference =
-        NodeParser(signal_reference_element_xml, parser_configuration_).As<signal::SignalReference>();
-    signal_references.push_back(signal_reference);
-    signal_reference_element_xml =
-        signal_reference_element_xml->NextSiblingElement(signal::SignalReference::kSignalReferenceTag);
-  }
   // signal::Controller elements
   tinyxml2::XMLElement* controller_element_xml = element_->FirstChildElement(signal::Controller::kControllerTag);
   std::vector<signal::Controller> controllers;
@@ -1416,19 +1405,18 @@ signal::Signal NodeParser::As() const {
           validities,
           dependencies,
           references,
-          signal_references,
           controllers,
           static_boards,
           vms_boards,
           semantics};
 }
 
-// Specialization to parse `Signals`'s node.
+// Specialization to parse `signal::Signals`'s node.
 template <>
 signal::Signals NodeParser::As() const {
   const AttributeParser attribute_parser(element_, parser_configuration_);
 
-  // Signal elements.
+  // signal::Signal elements.
   tinyxml2::XMLElement* signals_element_xml = element_->FirstChildElement(signal::Signal::kSignalTag);
   std::vector<signal::Signal> signals;
   while (signals_element_xml) {
@@ -1436,8 +1424,19 @@ signal::Signals NodeParser::As() const {
     signals.push_back(signal);
     signals_element_xml = signals_element_xml->NextSiblingElement(signal::Signal::kSignalTag);
   }
+  // signal::SignalReference elements
+  tinyxml2::XMLElement* signal_reference_element_xml =
+      element_->FirstChildElement(signal::SignalReference::kSignalReferenceTag);
+  std::vector<signal::SignalReference> signal_references;
+  while (signal_reference_element_xml) {
+    auto signal_reference =
+        NodeParser(signal_reference_element_xml, parser_configuration_).As<signal::SignalReference>();
+    signal_references.push_back(signal_reference);
+    signal_reference_element_xml =
+        signal_reference_element_xml->NextSiblingElement(signal::SignalReference::kSignalReferenceTag);
+  }
 
-  return {signals};
+  return {signals, signal_references};
 }
 
 // Specialization to parse `Road`'s node.

--- a/src/maliput_malidrive/xodr/signal/signal.cc
+++ b/src/maliput_malidrive/xodr/signal/signal.cc
@@ -41,8 +41,8 @@ bool Signal::operator==(const Signal& other) const {
          value == other.value && height == other.height && width == other.width && h_offset == other.h_offset &&
          length == other.length && pitch == other.pitch && roll == other.roll && text == other.text &&
          validities == other.validities && dependencies == other.dependencies && references == other.references &&
-         signal_references == other.signal_references && controllers == other.controllers &&
-         static_boards == other.static_boards && vms_boards == other.vms_boards && semantics == other.semantics;
+         controllers == other.controllers && static_boards == other.static_boards && vms_boards == other.vms_boards &&
+         semantics == other.semantics;
 }
 
 bool Signal::operator!=(const Signal& other) const { return !(*this == other); }

--- a/src/maliput_malidrive/xodr/signal/signal.h
+++ b/src/maliput_malidrive/xodr/signal/signal.h
@@ -191,9 +191,6 @@ struct Signal {
   /// Reference elements.
   std::vector<Reference> references{};
 
-  /// SignalReference elements.
-  std::vector<SignalReference> signal_references{};
-
   /// Controller elements.
   std::vector<Controller> controllers{};
 
@@ -224,13 +221,18 @@ struct Signals {
   static constexpr const char* kSignalsTag = "signals";
 
   /// Equality operator.
-  bool operator==(const Signals& other) const { return signals == other.signals; }
+  bool operator==(const Signals& other) const {
+    return signals == other.signals && signal_references == other.signal_references;
+  }
 
   /// Inequality operator.
   bool operator!=(const Signals& other) const { return !(*this == other); }
 
   /// Holds all the `Signal`s in the road.
   std::vector<Signal> signals{};
+
+  /// SignalReference elements.
+  std::vector<SignalReference> signal_references{};
 };
 
 }  // namespace signal

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -53,6 +53,8 @@
 #include "maliput_malidrive/xodr/road_header.h"
 #include "maliput_malidrive/xodr/road_link.h"
 #include "maliput_malidrive/xodr/road_type.h"
+#include "maliput_malidrive/xodr/signal/signal.h"
+#include "maliput_malidrive/xodr/signal/signal_reference.h"
 #include "utility/resources.h"
 
 namespace malidrive {
@@ -1705,6 +1707,7 @@ std::string GetSignals() {
               roll="0.2"
               text="Sample Text">
           </signal>
+          <signalReference id="54321" s="10.e+1" t="1.5" orientation="-"/>
       </signals>
   )R";
   ss << "</root>";
@@ -1712,27 +1715,17 @@ std::string GetSignals() {
 }
 
 TEST_F(ParsingTests, NodeParserSignals) {
-  const signal::Signal kExpectedSignal{
-      100.10 /* s */,
-      -1.5 /* t */,
-      signal::Signal::Id("12345") /* id */,
-      "Test Signal" /* name */,
-      false /* dynamic */,
-      "+" /* orientation */,
-      2.22 /* z_offset */,
-      "DE" /* country */,
-      "2017" /* country_revision */,
-      "274" /* type */,
-      "100" /* subtype */,
-      signal::Signal::Value{100, "km/h"} /* value */,
-      0.5 /* height */,
-      1.0 /* width */,
-      0.5 /* h_offset */,
-      1.5 /* length */,
-      0.1 /* pitch */,
-      0.2 /* roll */,
-      "Sample Text" /* text */
-  };
+  const signal::Signals kExpectedSignals{
+      {signal::Signal{
+          100.10 /* s */, -1.5 /* t */, signal::Signal::Id("12345") /* id */, "Test Signal" /* name */,
+          false /* dynamic */, "+" /* orientation */, 2.22 /* z_offset */, "DE" /* country */,
+          "2017" /* country_revision */, "274" /* type */, "100" /* subtype */,
+          signal::Signal::Value{100, "km/h"} /* value */, 0.5 /* height */, 1.0 /* width */, 0.5 /* h_offset */,
+          1.5 /* length */, 0.1 /* pitch */, 0.2 /* roll */, "Sample Text" /* text */
+      }},
+      {signal::SignalReference{signal::SignalReference::SignalId("54321") /* id */,
+                               signal::SignalReference::Orientation::kAgainstS /* orientation */, 100 /* s */,
+                               1.5 /* t */}}};
 
   const std::string xml_description = GetSignals();
 
@@ -1740,8 +1733,7 @@ TEST_F(ParsingTests, NodeParserSignals) {
                        {kStrictParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
   EXPECT_EQ(signal::Signals::kSignalsTag, dut.GetName());
   const signal::Signals signals = dut.As<signal::Signals>();
-  ASSERT_EQ(1u, signals.signals.size());
-  EXPECT_EQ(kExpectedSignal, signals.signals[0]);
+  EXPECT_EQ(kExpectedSignals, signals);
 }
 
 // Get a XML description that contains a XODR Signal with a Value but without a Unit.

--- a/test/regression/xodr/signal/signal_parser_test.cc
+++ b/test/regression/xodr/signal/signal_parser_test.cc
@@ -518,7 +518,8 @@ std::string GetControllerMissingNameAndSequence() {
 TEST_F(SignalParsingTests, NodeParserControllerMissingNameAndSequence) {
   const Control kControl1{Control::SignalId("signal_1"), std::make_optional("control_type")};
   const Control kControl2{Control::SignalId("signal_2"), std::nullopt};
-  const Controller kExpectedController{Controller::Id("controller_1"), std::nullopt, std::nullopt, {{kControl1, kControl2}}};
+  const Controller kExpectedController{
+      Controller::Id("controller_1"), std::nullopt, std::nullopt, {{kControl1, kControl2}}};
 
   const std::string xml_description = GetControllerMissingNameAndSequence();
   const NodeParser dut(LoadXMLAndGetNodeByName(xml_description, Controller::kControllerTag),
@@ -846,8 +847,26 @@ std::string GetBasicSign() {
 // Tests `signal::Sign` parsing.
 TEST_F(SignalParsingTests, NodeParserSign) {
   const Validity kValidity{Validity::Id("1"), Validity::Id("2")};
-  const Signal kBaseSignal{100.10, -1.5, Signal::Id("12345"), std::make_optional("Test Signal"), false, "+", 2.22, std::make_optional("DE"),
-                      std::make_optional("2017"), "274", "100", signal::Signal::Value{100.0, "km/h"}, 0.5, 1.0, 0.5, 1.5, 0.1, 0.2, "Sample Text", {{kValidity}}};
+  const Signal kBaseSignal{100.10,
+                           -1.5,
+                           Signal::Id("12345"),
+                           std::make_optional("Test Signal"),
+                           false,
+                           "+",
+                           2.22,
+                           std::make_optional("DE"),
+                           std::make_optional("2017"),
+                           "274",
+                           "100",
+                           signal::Signal::Value{100.0, "km/h"},
+                           0.5,
+                           1.0,
+                           0.5,
+                           1.5,
+                           0.1,
+                           0.2,
+                           "Sample Text",
+                           {{kValidity}}};
   const Sign kExpectedSign{kBaseSignal, 0.5, 1.2};
 
   const std::string xml_description = GetBasicSign();


### PR DESCRIPTION
# 🎉 New feature

## Summary
`signalReference` should be part of the `signals` XODR element, as per the [docs](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/14_signals/14_05_multiple_roads.html) say.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
