### PR TITLE
Discarding superelevations outside road length

### DIFF
--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -175,7 +175,7 @@ static constexpr char const* kSimplificationPolicy{"simplification_policy"};
 ///      xodr lane offsets definitions are discontinuous, and yet the final road surface is continuous: This is not
 ///      forbidden by the OpenDRIVE specification. It is up to the user to ensure that the connecting
 ///      roads form a contiguous surface. See `maliput::API::RoadGeometry::CheckInvariants` method.
-///      - 6. Ignores XODR elevation elements that start after the road's length when parsing.
+///      - 6. Ignores XODR elevation and superelevation elements that start after the road's length when parsing.
 ///    - 4. @e "permissive": Allow all previous violations.
 ///   - Default: @e "permissive"
 static constexpr char const* kStandardStrictnessPolicy{"standard_strictness_policy"};

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -1540,17 +1540,17 @@ RoadHeader NodeParser::As() const {
   if (parser_configuration_.allow_semantic_errors) {
     auto& superelevations = road_header.reference_geometry.lateral_profile.superelevations;
     superelevations.erase(std::remove_if(superelevations.begin(), superelevations.end(),
-                                    [&road_header](const LateralProfile::Superelevation& e) {
-                                      if (e.s_0 > road_header.length) {
-                                        maliput::log()->warn(
-                                            "Road Id: ", road_header.id.string(),
-                                            " - Discarding superelevation with s_0=", std::to_string(e.s_0),
-                                            " that exceeds road length=", std::to_string(road_header.length));
-                                        return true;
-                                      }
-                                      return false;
-                                    }),
-                     superelevations.end());
+                                         [&road_header](const LateralProfile::Superelevation& e) {
+                                           if (e.s_0 > road_header.length) {
+                                             maliput::log()->warn(
+                                                 "Road Id: ", road_header.id.string(),
+                                                 " - Discarding superelevation with s_0=", std::to_string(e.s_0),
+                                                 " that exceeds road length=", std::to_string(road_header.length));
+                                             return true;
+                                           }
+                                           return false;
+                                         }),
+                          superelevations.end());
   }
   // @}
 

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -1536,6 +1536,22 @@ RoadHeader NodeParser::As() const {
     road_header.reference_geometry.lateral_profile =
         NodeParser(lateral_profile_element, parser_configuration_).As<LateralProfile>();
   }
+  // When semantic errors are allowed, discard superelevation entries whose s_0 exceeds the road's length.
+  if (parser_configuration_.allow_semantic_errors) {
+    auto& superelevations = road_header.reference_geometry.lateral_profile.superelevations;
+    superelevations.erase(std::remove_if(superelevations.begin(), superelevations.end(),
+                                    [&road_header](const LateralProfile::Superelevation& e) {
+                                      if (e.s_0 > road_header.length) {
+                                        maliput::log()->warn(
+                                            "Road Id: ", road_header.id.string(),
+                                            " - Discarding superelevation with s_0=", std::to_string(e.s_0),
+                                            " that exceeds road length=", std::to_string(road_header.length));
+                                        return true;
+                                      }
+                                      return false;
+                                    }),
+                     superelevations.end());
+  }
   // @}
 
   // Get Lanes.

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -1738,6 +1738,63 @@ TEST_F(ParsingTests, NodeParserRoadHeaderKeepsAllElevationsWhenNotAllowSemanticE
   EXPECT_DOUBLE_EQ(15., road_header.reference_geometry.elevation_profile.elevations[2].s_0);
 }
 
+// Template of a XML description that contains a XODR RoadHeader with superelevations
+// that exceed the road's length. The road length is 10.0 but contains superelevations at s=0, 5, 15 (exceeds).
+constexpr const char* kRoadHeaderWithOutOfRangeSuperelevations = R"R(
+<root>
+  <road name='TestRoad' length='10.0' id='1' junction='-1' rule='RHT'>
+    <planView>
+      <geometry s='0.' x='0.' y='0.' hdg='0.' length='10.'>
+          <line/>
+      </geometry>
+    </planView>
+    <lateralProfile>
+      <superelevation s='0.' a='1.' b='0.' c='0.' d='0.'/>
+      <superelevation s='5.' a='2.' b='0.' c='0.' d='0.'/>
+      <superelevation s='15.' a='3.' b='0.' c='0.' d='0.'/>
+    </lateralProfile>
+    <lanes>
+      <laneSection s='0.'>
+          <center>
+              <lane id='0' type='driving' level='0'>
+              </lane>
+          </center>
+          <right>
+              <lane id='-1' type='driving' level='0'>
+                  <width sOffset='0.' a='1.' b='0.' c='0.' d='0.'/>
+              </lane>
+          </right>
+      </laneSection>
+    </lanes>
+  </road>
+</root>
+)R";
+
+// Tests that superelevations with s_0 > road length are filtered out when allow_semantic_errors is true.
+TEST_F(ParsingTests, NodeParserRoadHeaderFiltersOutOfRangeSuperelevationsWhenAllowSemanticErrors) {
+  const NodeParser dut(LoadXMLAndGetNodeByName(kRoadHeaderWithOutOfRangeSuperelevations, RoadHeader::kRoadHeaderTag),
+                       {kNullParserSTolerance, kDontAllowSchemaErrors, kAllowSemanticErrors});
+  const RoadHeader road_header = dut.As<RoadHeader>();
+
+  // Superelevation at s=15 exceeds road length=10, so only superelevations at s=0 and s=5 should remain.
+  ASSERT_EQ(2u, road_header.reference_geometry.lateral_profile.superelevations.size());
+  EXPECT_DOUBLE_EQ(0., road_header.reference_geometry.lateral_profile.superelevations[0].s_0);
+  EXPECT_DOUBLE_EQ(5., road_header.reference_geometry.lateral_profile.superelevations[1].s_0);
+}
+
+// Tests that superelevations with s_0 > road length are NOT filtered when allow_semantic_errors is false.
+TEST_F(ParsingTests, NodeParserRoadHeaderKeepsAllSuperelevationsWhenNotAllowSemanticErrors) {
+  const NodeParser dut(LoadXMLAndGetNodeByName(kRoadHeaderWithOutOfRangeSuperelevations, RoadHeader::kRoadHeaderTag),
+                       {kNullParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors});
+  const RoadHeader road_header = dut.As<RoadHeader>();
+
+  // All three superelevations should be present (no filtering).
+  ASSERT_EQ(3u, road_header.reference_geometry.lateral_profile.superelevations.size());
+  EXPECT_DOUBLE_EQ(0., road_header.reference_geometry.lateral_profile.superelevations[0].s_0);
+  EXPECT_DOUBLE_EQ(5., road_header.reference_geometry.lateral_profile.superelevations[1].s_0);
+  EXPECT_DOUBLE_EQ(15., road_header.reference_geometry.lateral_profile.superelevations[2].s_0);
+}
+
 // Get a XML description that contains a XODR Signals.
 // @returns A string that contains a XML description of a XODR Signals.
 std::string GetSignals() {


### PR DESCRIPTION
# Feature request

Closes https://github.com/maliput/maliput_malidrive/issues/424

## Summary

Similar to elevations, ignores superelevations outside of road's length

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

