### PR TITLE
Support unknown traffic signs in the database.

### DIFF
--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -130,10 +130,10 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   const auto& definition = definition_opt.value();
 
   const auto sign_type_opt = SignTypeStringToEnum(definition.sign_type);
+  const auto sign_type = sign_type_opt.value_or(maliput::api::rules::TrafficSignType::kUnknown);
   if (!sign_type_opt.has_value()) {
-    maliput::log()->warn("TrafficSignBuilder: unrecognized sign_type='", definition.sign_type, "' for signal id='",
-                         signal_.id.string(), "'. Skipping TrafficSign creation.");
-    return nullptr;
+    maliput::log()->debug("TrafficSignBuilder: unrecognized sign_type='", definition.sign_type, "' for signal id='",
+                          signal_.id.string(), "'. Defaulting to TrafficSignType::kUnknown.");
   }
 
   const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry_);
@@ -169,7 +169,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
                         "), related_lanes=", related_lanes.size(), ".");
 
   return std::make_unique<maliput::api::rules::TrafficSign>(maliput::api::rules::TrafficSign::Id(signal_.id.string()),
-                                                            *sign_type_opt, pos, orientation_road_network, signal_.text,
+                                                            sign_type, pos, orientation_road_network, signal_.text,
                                                             std::move(related_lanes), bounding_box);
 }
 

--- a/src/maliput_malidrive/traffic_signal/README.md
+++ b/src/maliput_malidrive/traffic_signal/README.md
@@ -47,6 +47,27 @@ Each YAML file in this directory should define a list of signal types under the 
 
 String field that identifies the signal variant. Defaults to `"traffic_light"` when not present in the YAML file. Use a different value (e.g., `"stop"`, `"yield"`, `"speed_limit"`) to identify static traffic signs.
 
+The supported `sign_type` values and their mapping to `maliput::api::rules::TrafficSignType` are:
+
+| `sign_type` value        | `TrafficSignType` enum      |
+|--------------------------|-----------------------------|
+| `"traffic_light"`        | *(handled as TrafficLight, not a TrafficSign)* |
+| `"stop"`                 | `kStop`                     |
+| `"yield"`                | `kYield`                    |
+| `"speed_limit"`          | `kSpeedLimit`               |
+| `"no_entry"`             | `kNoEntry`                  |
+| `"one_way"`              | `kOneWay`                   |
+| `"pedestrian_crossing"`  | `kPedestrianCrossing`       |
+| `"no_left_turn"`         | `kNoLeftTurn`               |
+| `"no_right_turn"`        | `kNoRightTurn`              |
+| `"no_u_turn"`            | `kNoUTurn`                  |
+| `"school_zone"`          | `kSchoolZone`               |
+| `"construction"`         | `kConstruction`             |
+| `"railroad_crossing"`    | `kRailroadCrossing`         |
+| *(any other value)*      | `kUnknown`                  |
+
+If `sign_type` is set to a value not listed above (and is not `"traffic_light"`), the builder will still create a `TrafficSign` with `TrafficSignType::kUnknown`. This allows the database to contain signal definitions for region-specific or non-standard sign types without requiring code changes.
+
 ### Bulbs
 
 Each signal type contains a list of `bulbs`:

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -110,16 +110,16 @@ TEST_F(TrafficSignBuilderFigure8Test, ConstructorThrows) {
   EXPECT_THROW(TrafficSignBuilder(signal_, xodr::RoadHeader::Id("44"), *loader_, nullptr), std::invalid_argument);
 }
 
-// Verifies that the builder returns nullptr when the signal's type maps to
-// sign_type "traffic_light" in the YAML database, since the TrafficSignBuilder
-// only handles static signs (non-"traffic_light" sign_type values).
-TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignReturnsNullForTrafficLightType) {
+// Verifies that the builder creates a TrafficSign with TrafficSignType::kUnknown
+// when the signal's type maps to an unrecognized sign_type in the YAML database.
+TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignReturnsUnknownForUnrecognizedSignType) {
   // The figure8 signal has type "1000001" which resolves to sign_type "traffic_light".
-  // SignTypeStringToEnum does not map "traffic_light" to any TrafficSignType,
-  // so the builder must return nullptr.
+  // "traffic_light" is not mapped to any TrafficSignType enum, so the builder
+  // should create a TrafficSign with TrafficSignType::kUnknown.
   TrafficSignBuilder builder(signal_, xodr::RoadHeader::Id("44"), *loader_, road_geometry_);
   auto traffic_sign = builder();
-  EXPECT_EQ(traffic_sign, nullptr);
+  ASSERT_NE(traffic_sign, nullptr);
+  EXPECT_EQ(maliput::api::rules::TrafficSignType::kUnknown, traffic_sign->type());
 }
 
 // Verifies that a TrafficSign is successfully created from a XODR signal whose


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/maliput/maliput/pull/738 
Closes #435 
Relates to https://github.com/maliput/maliput/issues/735

## Summary
* Support unknown traffic signs in the traffic signal database.
* Improve traffic signal database docs.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
