### PR TITLE
Treat XODR roadMark objects as stopLines if their name state so.

### DIFF
--- a/resources/RoadWithStopLine.xodr
+++ b/resources/RoadWithStopLine.xodr
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2026, Woven by Toyota. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ Test XODR file for stop-line RoadObject tests.
+ Road 1: 100 m straight road at x=[0,100], y=0, hdg=0.
+ Contains two objects:
+   - obj_stop_line:   roadMark with name "stopLine" → should map to kStopLine
+   - obj_road_mark:   roadMark without stop-line indicators → should map to kRoadMark
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="1" name="RoadWithStopLine" version="1.00" date="Thu Apr 17 12:00:00 2026" north="0.0" south="0.0" east="0.0" west="0.0" maxRoad="1" maxJunc="0" maxPrg="0">
+    </header>
+    <road name="TestRoad1" length="100.0" id="1" junction="-1">
+        <link>
+        </link>
+        <planView>
+            <geometry s="0.0" x="0.0" y="0.0" hdg="0.0" length="100.0">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0">
+                <left>
+                    <lane id="1" type="driving" level="0">
+                        <link>
+                        </link>
+                        <width sOffset="0.0" a="3.5" b="0.0" c="0.0" d="0.0"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="driving" level="0">
+                        <link>
+                        </link>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="0">
+                        <link>
+                        </link>
+                        <width sOffset="0.0" a="3.5" b="0.0" c="0.0" d="0.0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+            <!-- Stop line: roadMark with name "stopLine" → should become kStopLine. -->
+            <object id="obj_stop_line" name="stopLine" type="roadMark"
+                    s="50.0" t="0.0" zOffset="0.0"
+                    length="7.0" width="0.3" height="0.01"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="1"/>
+            </object>
+
+            <!-- Regular road mark: arrow marking → should remain kRoadMark. -->
+            <object id="obj_road_mark" name="TurnArrow" type="roadMark"
+                    s="30.0" t="-1.75" zOffset="0.0"
+                    length="2.0" width="1.0" height="0.01"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="-1"/>
+            </object>
+        </objects>
+    </road>
+</OpenDRIVE>

--- a/resources/RoadWithStopLine.xodr
+++ b/resources/RoadWithStopLine.xodr
@@ -31,8 +31,9 @@
 
  Test XODR file for stop-line RoadObject tests.
  Road 1: 100 m straight road at x=[0,100], y=0, hdg=0.
- Contains two objects:
-   - obj_stop_line:   roadMark with name "stopLine" → should map to kStopLine
+ Contains three objects:
+   - obj_stop_line_name:   roadMark with name "stopLine" → should map to kStopLine
+   - obj_stop_line_subtype:   roadMark with subtype "stopLine" → should map to kStopLine
    - obj_road_mark:   roadMark without stop-line indicators → should map to kRoadMark
 -->
 <OpenDRIVE>

--- a/resources/RoadWithStopLine.xodr
+++ b/resources/RoadWithStopLine.xodr
@@ -76,8 +76,16 @@
         </lanes>
         <objects>
             <!-- Stop line: roadMark with name "stopLine" → should become kStopLine. -->
-            <object id="obj_stop_line" name="stopLine" type="roadMark"
+            <object id="obj_stop_line_name" name="stopLine" type="roadMark"
                     s="50.0" t="0.0" zOffset="0.0"
+                    length="7.0" width="0.3" height="0.01"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="1"/>
+            </object>
+
+            <!-- Stop line: roadMark with subtype "stopLine" → should become kStopLine. -->
+            <object id="obj_stop_line_subtype" subtype="stopLine" type="roadMark"
+                    s="80.0" t="0.0" zOffset="0.0"
                     length="7.0" width="0.3" height="0.01"
                     hdg="0.0" orientation="+" dynamic="no">
                 <validity fromLane="-1" toLane="1"/>

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -181,7 +181,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
   // --- Type ---
-  const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object_.type);
+  const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object_.type, object_.name, object_.subtype);
 
   // --- Related lanes ---
   auto related_lanes = ResolveLaneIds(road_id_, object_s, object_.validities, road_geometry_);

--- a/src/maliput_malidrive/builder/road_object_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.cc
@@ -32,7 +32,8 @@ namespace malidrive {
 namespace builder {
 
 maliput::api::objects::RoadObjectType MapXodrObjectType(
-    const std::optional<xodr::object::Object::ObjectType>& xodr_type) {
+    const std::optional<xodr::object::Object::ObjectType>& xodr_type, const std::optional<std::string>& name,
+    const std::optional<std::string>& subtype) {
   using XodrType = xodr::object::Object::ObjectType;
   using MaliputType = maliput::api::objects::RoadObjectType;
 
@@ -60,6 +61,9 @@ maliput::api::objects::RoadObjectType MapXodrObjectType(
     case XodrType::kStreetLamp:
       return MaliputType::kPole;
     case XodrType::kRoadMark:
+      if ((name.has_value() && name.value() == "stopLine") || (subtype.has_value() && subtype.value() == "stopLine")) {
+        return MaliputType::kStopLine;
+      }
       return MaliputType::kRoadMark;
     case XodrType::kRoadSurface:
     case XodrType::kPatch:

--- a/src/maliput_malidrive/builder/road_object_type_mapper.h
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <optional>
+#include <string>
 
 #include <maliput/api/objects/road_object.h>
 
@@ -46,10 +47,16 @@ namespace builder {
 /// kStreetLamp/kWind → kPole, kRailing/kSoundBarrier → kBarrier, kPatch → kRoadSurface.
 /// A std::nullopt input maps to kUnknown.
 ///
+/// When @p xodr_type is kRoadMark and @p name or @p subtype equals
+/// "stopLine", the result is kStopLine instead of kRoadMark.
+///
 /// @param xodr_type The optional XODR object type to map.
+/// @param name The optional object name.
+/// @param subtype The optional object subtype.
 /// @returns The corresponding maliput RoadObjectType.
 maliput::api::objects::RoadObjectType MapXodrObjectType(
-    const std::optional<xodr::object::Object::ObjectType>& xodr_type);
+    const std::optional<xodr::object::Object::ObjectType>& xodr_type,
+    const std::optional<std::string>& name = std::nullopt, const std::optional<std::string>& subtype = std::nullopt);
 
 }  // namespace builder
 }  // namespace malidrive

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -90,6 +90,25 @@ TEST_F(RoadObjectTypeMapperTest, CloseMappings) {
   EXPECT_EQ(MaliputType::kRoadSurface, MapXodrObjectType(XodrType::kPatch));
 }
 
+TEST_F(RoadObjectTypeMapperTest, StopLineMappings) {
+  using XodrType = xodr::object::Object::ObjectType;
+  using MaliputType = maliput::api::objects::RoadObjectType;
+
+  // roadMark with name "stopLine" → kStopLine.
+  EXPECT_EQ(MaliputType::kStopLine, MapXodrObjectType(XodrType::kRoadMark, std::string("stopLine"), std::nullopt));
+  // roadMark with subtype "stopLine" → kStopLine.
+  EXPECT_EQ(MaliputType::kStopLine, MapXodrObjectType(XodrType::kRoadMark, std::nullopt, std::string("stopLine")));
+  // roadMark with both name and subtype "stopLine" → kStopLine.
+  EXPECT_EQ(MaliputType::kStopLine,
+            MapXodrObjectType(XodrType::kRoadMark, std::string("stopLine"), std::string("stopLine")));
+  // roadMark without stop-line indicators → kRoadMark.
+  EXPECT_EQ(MaliputType::kRoadMark, MapXodrObjectType(XodrType::kRoadMark, std::nullopt, std::nullopt));
+  EXPECT_EQ(MaliputType::kRoadMark,
+            MapXodrObjectType(XodrType::kRoadMark, std::string("arrow"), std::string("turnLeft")));
+  // Non-roadMark type with "stopLine" name → still maps by type, not to kStopLine.
+  EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kBarrier, std::string("stopLine"), std::nullopt));
+}
+
 TEST_F(RoadObjectTypeMapperTest, UnknownMappings) {
   using XodrType = xodr::object::Object::ObjectType;
   using MaliputType = maliput::api::objects::RoadObjectType;
@@ -440,6 +459,83 @@ TEST_F(RoadObjectBuilderTest, FindInRadius) {
   // Search far from any object should return empty.
   const auto far_away = road_object_book_->FindInRadius(maliput::api::InertialPosition(500.0, 500.0, 0.0), 1.0);
   EXPECT_TRUE(far_away.empty());
+}
+
+// ---------------------------------------------------------------------------
+// StopLine integration tests.
+// Uses the RoadWithStopLine.xodr resource.
+// ---------------------------------------------------------------------------
+
+class StopLineBuilderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path = utility::FindResourceInPath("RoadWithStopLine.xodr", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(
+        RoadNetworkConfiguration::FromMap({
+                                              {params::kOpendriveFile, xodr_file_path},
+                                              {params::kOmitNonDrivableLanes, "false"},
+                                              {params::kLinearTolerance, std::to_string(kLinearTolerance)},
+                                          })
+            .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_object_book_ = road_network_->road_object_book();
+    ASSERT_NE(road_object_book_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::objects::RoadObjectBook* road_object_book_{};
+  constexpr static double kLinearTolerance = 1e-5;
+};
+
+TEST_F(StopLineBuilderTest, RoadObjectBookIsPopulated) {
+  const auto all_objects = road_object_book_->RoadObjects();
+  EXPECT_EQ(2u, all_objects.size());
+}
+
+TEST_F(StopLineBuilderTest, StopLineObject) {
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line"));
+  ASSERT_NE(road_object, nullptr);
+
+  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_stop_line"));
+  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kStopLine);
+  EXPECT_EQ(road_object->name(), "stopLine");
+  EXPECT_FALSE(road_object->is_dynamic());
+
+  // Position: straight road at hdg=0, s=50, t=0 → inertial x≈50, y≈0.
+  const auto& pos = road_object->position().inertial_position();
+  EXPECT_NEAR(pos.x(), 50.0, 0.5);
+  EXPECT_NEAR(pos.y(), 0.0, 0.5);
+
+  // Bounding box: length=7, width=0.3, height=0.01.
+  const auto& bb = road_object->bounding_box();
+  EXPECT_NEAR(bb.box_size().x(), 7.0, 1e-3);
+  EXPECT_NEAR(bb.box_size().y(), 0.3, 1e-3);
+  EXPECT_NEAR(bb.box_size().z(), 0.01, 1e-3);
+
+  // Related lanes: spans both lanes via validity.
+  EXPECT_GE(road_object->related_lanes().size(), 2u);
+}
+
+TEST_F(StopLineBuilderTest, RegularRoadMarkObject) {
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_road_mark"));
+  ASSERT_NE(road_object, nullptr);
+
+  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_road_mark"));
+  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kRoadMark);
+  EXPECT_EQ(road_object->name(), "TurnArrow");
+}
+
+TEST_F(StopLineBuilderTest, FindByTypeStopLine) {
+  const auto stop_lines = road_object_book_->FindByType(maliput::api::objects::RoadObjectType::kStopLine);
+  ASSERT_EQ(1u, stop_lines.size());
+  EXPECT_EQ(stop_lines[0]->id(), maliput::api::objects::RoadObject::Id("obj_stop_line"));
+}
+
+TEST_F(StopLineBuilderTest, FindByTypeRoadMark) {
+  const auto road_marks = road_object_book_->FindByType(maliput::api::objects::RoadObjectType::kRoadMark);
+  ASSERT_EQ(1u, road_marks.size());
+  EXPECT_EQ(road_marks[0]->id(), maliput::api::objects::RoadObject::Id("obj_road_mark"));
 }
 
 }  // namespace

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/builder/road_object_builder.h"
 
+#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <string>
@@ -490,14 +491,14 @@ class StopLineBuilderTest : public ::testing::Test {
 
 TEST_F(StopLineBuilderTest, RoadObjectBookIsPopulated) {
   const auto all_objects = road_object_book_->RoadObjects();
-  EXPECT_EQ(2u, all_objects.size());
+  EXPECT_EQ(3u, all_objects.size());
 }
 
-TEST_F(StopLineBuilderTest, StopLineObject) {
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line"));
+TEST_F(StopLineBuilderTest, StopLineObjectFromName) {
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line_name"));
   ASSERT_NE(road_object, nullptr);
 
-  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_stop_line"));
+  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_stop_line_name"));
   EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kStopLine);
   EXPECT_EQ(road_object->name(), "stopLine");
   EXPECT_FALSE(road_object->is_dynamic());
@@ -505,6 +506,30 @@ TEST_F(StopLineBuilderTest, StopLineObject) {
   // Position: straight road at hdg=0, s=50, t=0 → inertial x≈50, y≈0.
   const auto& pos = road_object->position().inertial_position();
   EXPECT_NEAR(pos.x(), 50.0, 0.5);
+  EXPECT_NEAR(pos.y(), 0.0, 0.5);
+
+  // Bounding box: length=7, width=0.3, height=0.01.
+  const auto& bb = road_object->bounding_box();
+  EXPECT_NEAR(bb.box_size().x(), 7.0, 1e-3);
+  EXPECT_NEAR(bb.box_size().y(), 0.3, 1e-3);
+  EXPECT_NEAR(bb.box_size().z(), 0.01, 1e-3);
+
+  // Related lanes: spans both lanes via validity.
+  EXPECT_GE(road_object->related_lanes().size(), 2u);
+}
+
+TEST_F(StopLineBuilderTest, StopLineObjectFromSubtype) {
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line_subtype"));
+  ASSERT_NE(road_object, nullptr);
+
+  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_stop_line_subtype"));
+  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kStopLine);
+  EXPECT_EQ(road_object->subtype(), "stopLine");
+  EXPECT_FALSE(road_object->is_dynamic());
+
+  // Position: straight road at hdg=0, s=80, t=0 → inertial x≈80, y≈0.
+  const auto& pos = road_object->position().inertial_position();
+  EXPECT_NEAR(pos.x(), 80.0, 0.5);
   EXPECT_NEAR(pos.y(), 0.0, 0.5);
 
   // Bounding box: length=7, width=0.3, height=0.01.
@@ -528,8 +553,13 @@ TEST_F(StopLineBuilderTest, RegularRoadMarkObject) {
 
 TEST_F(StopLineBuilderTest, FindByTypeStopLine) {
   const auto stop_lines = road_object_book_->FindByType(maliput::api::objects::RoadObjectType::kStopLine);
-  ASSERT_EQ(1u, stop_lines.size());
-  EXPECT_EQ(stop_lines[0]->id(), maliput::api::objects::RoadObject::Id("obj_stop_line"));
+  ASSERT_EQ(2u, stop_lines.size());
+  const auto has_id = [&](const std::string& id) {
+    return std::any_of(stop_lines.begin(), stop_lines.end(),
+                       [&](const auto* obj) { return obj->id() == maliput::api::objects::RoadObject::Id(id); });
+  };
+  EXPECT_TRUE(has_id("obj_stop_line_name"));
+  EXPECT_TRUE(has_id("obj_stop_line_subtype"));
 }
 
 TEST_F(StopLineBuilderTest, FindByTypeRoadMark) {

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -495,7 +495,8 @@ TEST_F(StopLineBuilderTest, RoadObjectBookIsPopulated) {
 }
 
 TEST_F(StopLineBuilderTest, StopLineObjectFromName) {
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line_name"));
+  const auto* road_object =
+      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line_name"));
   ASSERT_NE(road_object, nullptr);
 
   EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_stop_line_name"));
@@ -519,7 +520,8 @@ TEST_F(StopLineBuilderTest, StopLineObjectFromName) {
 }
 
 TEST_F(StopLineBuilderTest, StopLineObjectFromSubtype) {
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line_subtype"));
+  const auto* road_object =
+      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line_subtype"));
   ASSERT_NE(road_object, nullptr);
 
   EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_stop_line_subtype"));


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/maliput/maliput/pull/740
Closes #439 

## Summary
RoadObjectTypeMapper now returns a RoadObjectType::kStopLine if:
* XODR Object is of type `roadMark` AND at least one of the below is true:
  * Its `name` is set to `stopLine`
  * Its `subtype` is set to `stopLine`


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
