### PR TITLE
Refactor traffic sign mapper while adding new sign type no_overtaking.

### DIFF
--- a/src/maliput_malidrive/builder/CMakeLists.txt
+++ b/src/maliput_malidrive/builder/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(builder
   speed_limit_builder.cc
   traffic_light_builder.cc
   traffic_sign_builder.cc
+  traffic_sign_type_mapper.cc
   traffic_signal_books_builder.cc
   xodr_parser_configuration.cc
 )

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -29,23 +29,21 @@
 #include "maliput_malidrive/builder/traffic_sign_builder.h"
 
 #include <algorithm>
-#include <cctype>
 #include <cmath>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <maliput/api/lane_data.h>
 #include <maliput/api/rules/traffic_sign.h>
 #include <maliput/common/logger.h>
-#include <maliput/common/maliput_hash.h>
 #include <maliput/math/bounding_box.h>
 #include <maliput/math/roll_pitch_yaw.h>
 #include <maliput/math/vector.h>
 
 #include "maliput_malidrive/base/road_geometry.h"
 #include "maliput_malidrive/builder/builder_tools.h"
+#include "maliput_malidrive/builder/traffic_sign_type_mapper.h"
 #include "maliput_malidrive/common/macros.h"
 #include "maliput_malidrive/traffic_signal/parser.h"
 #include "maliput_malidrive/xodr/signal/orientation.h"
@@ -66,37 +64,6 @@ std::optional<std::string> NormalizeSubtype(const std::string& subtype) {
     return std::nullopt;
   }
   return subtype;
-}
-
-std::unordered_map<std::string, maliput::api::rules::TrafficSignType, maliput::common::DefaultHash>
-YamlToTrafficSignTypeMapper() {
-  std::unordered_map<std::string, maliput::api::rules::TrafficSignType, maliput::common::DefaultHash> result;
-  result.emplace("stop", maliput::api::rules::TrafficSignType::kStop);
-  result.emplace("yield", maliput::api::rules::TrafficSignType::kYield);
-  result.emplace("speed_limit", maliput::api::rules::TrafficSignType::kSpeedLimit);
-  result.emplace("no_entry", maliput::api::rules::TrafficSignType::kNoEntry);
-  result.emplace("one_way", maliput::api::rules::TrafficSignType::kOneWay);
-  result.emplace("pedestrian_crossing", maliput::api::rules::TrafficSignType::kPedestrianCrossing);
-  result.emplace("no_left_turn", maliput::api::rules::TrafficSignType::kNoLeftTurn);
-  result.emplace("no_right_turn", maliput::api::rules::TrafficSignType::kNoRightTurn);
-  result.emplace("no_u_turn", maliput::api::rules::TrafficSignType::kNoUTurn);
-  result.emplace("school_zone", maliput::api::rules::TrafficSignType::kSchoolZone);
-  result.emplace("construction", maliput::api::rules::TrafficSignType::kConstruction);
-  result.emplace("railroad_crossing", maliput::api::rules::TrafficSignType::kRailroadCrossing);
-  return result;
-}
-
-/// Maps a sign_type string from the YAML database to a maliput TrafficSignType enum.
-///
-/// The lookup is built once from YamlToTrafficSignTypeMapper().
-/// Returns std::nullopt if @p sign_type_str does not match any known type.
-std::optional<maliput::api::rules::TrafficSignType> SignTypeStringToEnum(const std::string& sign_type_str) {
-  const auto mapper = YamlToTrafficSignTypeMapper();
-  const auto it = mapper.find(sign_type_str);
-  if (it == mapper.end()) {
-    return std::nullopt;
-  }
-  return it->second;
 }
 
 }  // namespace
@@ -129,9 +96,8 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   }
   const auto& definition = definition_opt.value();
 
-  const auto sign_type_opt = SignTypeStringToEnum(definition.sign_type);
-  const auto sign_type = sign_type_opt.value_or(maliput::api::rules::TrafficSignType::kUnknown);
-  if (!sign_type_opt.has_value()) {
+  const auto sign_type = MapSignTypeString(definition.sign_type);
+  if (sign_type == maliput::api::rules::TrafficSignType::kUnknown) {
     maliput::log()->debug("TrafficSignBuilder: unrecognized sign_type='", definition.sign_type, "' for signal id='",
                           signal_.id.string(), "'. Defaulting to TrafficSignType::kUnknown.");
   }

--- a/src/maliput_malidrive/builder/traffic_sign_type_mapper.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_type_mapper.cc
@@ -1,0 +1,63 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/builder/traffic_sign_type_mapper.h"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include <maliput/common/maliput_hash.h>
+
+namespace malidrive {
+namespace builder {
+
+maliput::api::rules::TrafficSignType MapSignTypeString(const std::string& sign_type_str) {
+  using T = maliput::api::rules::TrafficSignType;
+  static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper{
+      {"stop", T::kStop},
+      {"yield", T::kYield},
+      {"speed_limit", T::kSpeedLimit},
+      {"no_entry", T::kNoEntry},
+      {"one_way", T::kOneWay},
+      {"pedestrian_crossing", T::kPedestrianCrossing},
+      {"no_left_turn", T::kNoLeftTurn},
+      {"no_right_turn", T::kNoRightTurn},
+      {"no_u_turn", T::kNoUTurn},
+      {"school_zone", T::kSchoolZone},
+      {"construction", T::kConstruction},
+      {"railroad_crossing", T::kRailroadCrossing},
+      {"no_overtaking", T::kNoOvertaking},
+  };
+  std::string lower = sign_type_str;
+  std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+  const auto it = kMapper.find(lower);
+  return it != kMapper.end() ? it->second : T::kUnknown;
+}
+
+}  // namespace builder
+}  // namespace malidrive

--- a/src/maliput_malidrive/builder/traffic_sign_type_mapper.h
+++ b/src/maliput_malidrive/builder/traffic_sign_type_mapper.h
@@ -1,0 +1,51 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+
+#include <maliput/api/rules/traffic_sign.h>
+
+namespace malidrive {
+namespace builder {
+
+/// Maps a sign_type string from the YAML traffic signal database to a
+/// @ref maliput::api::rules::TrafficSignType enum.
+///
+/// The comparison is case-insensitive: "Stop", "STOP", and "stop" all
+/// map to TrafficSignType::kStop.
+///
+/// Any unrecognized string (including "traffic_light") maps to kUnknown.
+///
+/// @param sign_type_str The sign_type value from the YAML database.
+/// @returns The corresponding TrafficSignType, or kUnknown if not recognized.
+maliput::api::rules::TrafficSignType MapSignTypeString(const std::string& sign_type_str);
+
+}  // namespace builder
+}  // namespace malidrive

--- a/src/maliput_malidrive/traffic_signal/README.md
+++ b/src/maliput_malidrive/traffic_signal/README.md
@@ -64,9 +64,12 @@ The supported `sign_type` values and their mapping to `maliput::api::rules::Traf
 | `"school_zone"`          | `kSchoolZone`               |
 | `"construction"`         | `kConstruction`             |
 | `"railroad_crossing"`    | `kRailroadCrossing`         |
+| `"no_overtaking"`        | `kNoOvertaking`             |
 | *(any other value)*      | `kUnknown`                  |
 
 If `sign_type` is set to a value not listed above (and is not `"traffic_light"`), the builder will still create a `TrafficSign` with `TrafficSignType::kUnknown`. This allows the database to contain signal definitions for region-specific or non-standard sign types without requiring code changes.
+
+The `sign_type` matching is **case-insensitive**: `"No_Entry"`, `"NO_ENTRY"`, and `"no_entry"` are all equivalent.
 
 ### Bulbs
 

--- a/test/regression/builder/CMakeLists.txt
+++ b/test/regression/builder/CMakeLists.txt
@@ -27,6 +27,7 @@ set(UNIT_BUILDER_TEST_SOURCES
   simplify_geometries_test.cc
   traffic_light_builder_test.cc
   traffic_sign_builder_test.cc
+  traffic_sign_type_mapper_test.cc
 )
 
 maliput_malidrive_build_tests(${UNIT_BUILDER_TEST_SOURCES})

--- a/test/regression/builder/traffic_sign_type_mapper_test.cc
+++ b/test/regression/builder/traffic_sign_type_mapper_test.cc
@@ -1,0 +1,93 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/builder/traffic_sign_type_mapper.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <maliput/api/rules/traffic_sign.h>
+
+namespace malidrive {
+namespace builder {
+namespace test {
+namespace {
+
+using maliput::api::rules::TrafficSignType;
+
+struct MapSignTypeStringTestCase {
+  std::string input;
+  TrafficSignType expected;
+};
+
+class MapSignTypeStringTest : public ::testing::TestWithParam<MapSignTypeStringTestCase> {};
+
+TEST_P(MapSignTypeStringTest, MapsCorrectly) {
+  const auto& test_case = GetParam();
+  EXPECT_EQ(test_case.expected, MapSignTypeString(test_case.input));
+}
+
+INSTANTIATE_TEST_CASE_P(AllKnownTypes, MapSignTypeStringTest,
+                         ::testing::Values(
+                             // Known mappings.
+                             MapSignTypeStringTestCase{"stop", TrafficSignType::kStop},
+                             MapSignTypeStringTestCase{"yield", TrafficSignType::kYield},
+                             MapSignTypeStringTestCase{"speed_limit", TrafficSignType::kSpeedLimit},
+                             MapSignTypeStringTestCase{"no_entry", TrafficSignType::kNoEntry},
+                             MapSignTypeStringTestCase{"one_way", TrafficSignType::kOneWay},
+                             MapSignTypeStringTestCase{"pedestrian_crossing", TrafficSignType::kPedestrianCrossing},
+                             MapSignTypeStringTestCase{"no_left_turn", TrafficSignType::kNoLeftTurn},
+                             MapSignTypeStringTestCase{"no_right_turn", TrafficSignType::kNoRightTurn},
+                             MapSignTypeStringTestCase{"no_u_turn", TrafficSignType::kNoUTurn},
+                             MapSignTypeStringTestCase{"school_zone", TrafficSignType::kSchoolZone},
+                             MapSignTypeStringTestCase{"construction", TrafficSignType::kConstruction},
+                             MapSignTypeStringTestCase{"railroad_crossing", TrafficSignType::kRailroadCrossing},
+                             MapSignTypeStringTestCase{"no_overtaking", TrafficSignType::kNoOvertaking}));
+
+INSTANTIATE_TEST_CASE_P(UnknownTypes, MapSignTypeStringTest,
+                         ::testing::Values(
+                             // Unrecognized strings map to kUnknown.
+                             MapSignTypeStringTestCase{"traffic_light", TrafficSignType::kUnknown},
+                             MapSignTypeStringTestCase{"", TrafficSignType::kUnknown},
+                             MapSignTypeStringTestCase{"unknown_value", TrafficSignType::kUnknown}));
+
+INSTANTIATE_TEST_CASE_P(CaseInsensitive, MapSignTypeStringTest,
+                         ::testing::Values(
+                             // Case-insensitive matching.
+                             MapSignTypeStringTestCase{"Stop", TrafficSignType::kStop},
+                             MapSignTypeStringTestCase{"STOP", TrafficSignType::kStop},
+                             MapSignTypeStringTestCase{"Yield", TrafficSignType::kYield},
+                             MapSignTypeStringTestCase{"SPEED_LIMIT", TrafficSignType::kSpeedLimit},
+                             MapSignTypeStringTestCase{"No_Overtaking", TrafficSignType::kNoOvertaking}));
+
+}  // namespace
+}  // namespace test
+}  // namespace builder
+}  // namespace malidrive

--- a/test/regression/builder/traffic_sign_type_mapper_test.cc
+++ b/test/regression/builder/traffic_sign_type_mapper_test.cc
@@ -55,37 +55,37 @@ TEST_P(MapSignTypeStringTest, MapsCorrectly) {
 }
 
 INSTANTIATE_TEST_CASE_P(AllKnownTypes, MapSignTypeStringTest,
-                         ::testing::Values(
-                             // Known mappings.
-                             MapSignTypeStringTestCase{"stop", TrafficSignType::kStop},
-                             MapSignTypeStringTestCase{"yield", TrafficSignType::kYield},
-                             MapSignTypeStringTestCase{"speed_limit", TrafficSignType::kSpeedLimit},
-                             MapSignTypeStringTestCase{"no_entry", TrafficSignType::kNoEntry},
-                             MapSignTypeStringTestCase{"one_way", TrafficSignType::kOneWay},
-                             MapSignTypeStringTestCase{"pedestrian_crossing", TrafficSignType::kPedestrianCrossing},
-                             MapSignTypeStringTestCase{"no_left_turn", TrafficSignType::kNoLeftTurn},
-                             MapSignTypeStringTestCase{"no_right_turn", TrafficSignType::kNoRightTurn},
-                             MapSignTypeStringTestCase{"no_u_turn", TrafficSignType::kNoUTurn},
-                             MapSignTypeStringTestCase{"school_zone", TrafficSignType::kSchoolZone},
-                             MapSignTypeStringTestCase{"construction", TrafficSignType::kConstruction},
-                             MapSignTypeStringTestCase{"railroad_crossing", TrafficSignType::kRailroadCrossing},
-                             MapSignTypeStringTestCase{"no_overtaking", TrafficSignType::kNoOvertaking}));
+                        ::testing::Values(
+                            // Known mappings.
+                            MapSignTypeStringTestCase{"stop", TrafficSignType::kStop},
+                            MapSignTypeStringTestCase{"yield", TrafficSignType::kYield},
+                            MapSignTypeStringTestCase{"speed_limit", TrafficSignType::kSpeedLimit},
+                            MapSignTypeStringTestCase{"no_entry", TrafficSignType::kNoEntry},
+                            MapSignTypeStringTestCase{"one_way", TrafficSignType::kOneWay},
+                            MapSignTypeStringTestCase{"pedestrian_crossing", TrafficSignType::kPedestrianCrossing},
+                            MapSignTypeStringTestCase{"no_left_turn", TrafficSignType::kNoLeftTurn},
+                            MapSignTypeStringTestCase{"no_right_turn", TrafficSignType::kNoRightTurn},
+                            MapSignTypeStringTestCase{"no_u_turn", TrafficSignType::kNoUTurn},
+                            MapSignTypeStringTestCase{"school_zone", TrafficSignType::kSchoolZone},
+                            MapSignTypeStringTestCase{"construction", TrafficSignType::kConstruction},
+                            MapSignTypeStringTestCase{"railroad_crossing", TrafficSignType::kRailroadCrossing},
+                            MapSignTypeStringTestCase{"no_overtaking", TrafficSignType::kNoOvertaking}));
 
 INSTANTIATE_TEST_CASE_P(UnknownTypes, MapSignTypeStringTest,
-                         ::testing::Values(
-                             // Unrecognized strings map to kUnknown.
-                             MapSignTypeStringTestCase{"traffic_light", TrafficSignType::kUnknown},
-                             MapSignTypeStringTestCase{"", TrafficSignType::kUnknown},
-                             MapSignTypeStringTestCase{"unknown_value", TrafficSignType::kUnknown}));
+                        ::testing::Values(
+                            // Unrecognized strings map to kUnknown.
+                            MapSignTypeStringTestCase{"traffic_light", TrafficSignType::kUnknown},
+                            MapSignTypeStringTestCase{"", TrafficSignType::kUnknown},
+                            MapSignTypeStringTestCase{"unknown_value", TrafficSignType::kUnknown}));
 
 INSTANTIATE_TEST_CASE_P(CaseInsensitive, MapSignTypeStringTest,
-                         ::testing::Values(
-                             // Case-insensitive matching.
-                             MapSignTypeStringTestCase{"Stop", TrafficSignType::kStop},
-                             MapSignTypeStringTestCase{"STOP", TrafficSignType::kStop},
-                             MapSignTypeStringTestCase{"Yield", TrafficSignType::kYield},
-                             MapSignTypeStringTestCase{"SPEED_LIMIT", TrafficSignType::kSpeedLimit},
-                             MapSignTypeStringTestCase{"No_Overtaking", TrafficSignType::kNoOvertaking}));
+                        ::testing::Values(
+                            // Case-insensitive matching.
+                            MapSignTypeStringTestCase{"Stop", TrafficSignType::kStop},
+                            MapSignTypeStringTestCase{"STOP", TrafficSignType::kStop},
+                            MapSignTypeStringTestCase{"Yield", TrafficSignType::kYield},
+                            MapSignTypeStringTestCase{"SPEED_LIMIT", TrafficSignType::kSpeedLimit},
+                            MapSignTypeStringTestCase{"No_Overtaking", TrafficSignType::kNoOvertaking}));
 
 }  // namespace
 }  // namespace test


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/maliput/maliput/pull/741

## Summary
* New traffic sign type mapper module for easier testing when adding new `TrafficSignType`s.
* Support for `NoOvertaking` traffic signs in the traffic signal database.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
