### PR TITLE
Prepare for maliput_malidrive release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package maliput_malidrive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.22.0 (2026-04-21)
+-------------------
+* Refactor traffic sign mapper while adding new sign type no_overtaking. (`#441 <https://github.com/maliput/maliput_malidrive/issues/441>`_)
+* Treat XODR roadMark objects as stopLines if their name state so. (`#440 <https://github.com/maliput/maliput_malidrive/issues/440>`_)
+* Support unknown traffic signs in the database. (`#438 <https://github.com/maliput/maliput_malidrive/issues/438>`_)
+* Implement RoadObject API (`#434 <https://github.com/maliput/maliput_malidrive/issues/434>`_)
+* Build `TrafficSignBook` and fill it with `TrafficSign`s (`#421 <https://github.com/maliput/maliput_malidrive/issues/421>`_)
+* Contributors: Santiago Lopez
+
 0.21.2 (2026-04-14)
 -------------------
 * Discarding superelevations outside road length (`#436 <https://github.com/maliput/maliput_malidrive/issues/436>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##############################################################################
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(maliput_malidrive LANGUAGES C CXX VERSION 0.21.2)
+project(maliput_malidrive LANGUAGES C CXX VERSION 0.22.0)
 
 ##############################################################################
 # CMake Support

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,14 +5,14 @@ Welcome to Maliput Malidrive!
 module(
     name = "maliput_malidrive",
     compatibility_level = 1,
-    version = "0.21.2",
+    version = "0.22.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.15.0")
+bazel_dep(name = "maliput", version = "1.16.0")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>maliput_malidrive</name>
-  <version>0.21.2</version>
+  <version>0.22.0</version>
   <description>maliput_malidrive backend</description>
   <license file="LICENSE">BSD Clause 3</license>
   <maintainer email="andrew.best@tri.global">Andrew Best</maintainer>


### PR DESCRIPTION
# 🎈 Release

## Summary
* Point to maliput `1.16.0` version.
* Prepare for maliput_malidrive `0.22.0` release.

## After PR is merged
Push git tag `0.22.0` to trigger BCR release.

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
