### PR TITLE
Update traffic control device database structure.

### DIFF
--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -54,14 +54,14 @@ namespace params {
 /// Parameters related to the creation of the RoadGeometry can be seen at @ref road_geometry_configuration_builder_keys.
 ///
 /// Parameters for passing filepath to road rulebook, rule registry, traffic light book, phase ring book, intersection
-/// book and traffic signal database are listed below.
+/// book and traffic control device database are listed below.
 /// @{
 
 /// Path to the configuration file to load a RoadRulebook
 ///   - Default: ""
 static constexpr char const* kRoadRuleBook{"road_rule_book"};
 
-/// Path to the configuration file to load a RoadRulebook
+/// Path to the configuration file to load a RuleRegistry
 ///   - Default: ""
 static constexpr char const* kRuleRegistry{"rule_registry"};
 

--- a/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
+++ b/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
@@ -280,3 +280,17 @@ odr_signal_types:
       rule_states:
         - conditions: []
           value: "StopThenGo"
+
+  # Unknown sign.
+  - odr_representation:
+      type: "999"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      description: "Unknown sign. No specific behavior defined."
+
+      rule_states:
+        - conditions: []
+          value: ""

--- a/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
+++ b/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
@@ -30,11 +30,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-# Traffic Signal Type Database for maliput.
+# Traffic Control Device Database for maliput.
 #
-# This YAML file defines reusable traffic signal type definitions that describe:
+# This YAML file defines reusable traffic control device type definitions that describe:
 # - The physical structure of traffic lights (bulbs, groups, dimensions).
 # - The rule logic mapping bulb state combinations to Right-Of-Way rule values.
+# - The semantic meaning of traffic signs (e.g., stop sign semantics).
 #
 # Usage:
 # When parsing an OpenDRIVE (.xodr) file, traffic signals are defined with:
@@ -50,220 +51,232 @@
 # - Bulb position/orientation: relative to traffic light frame.
 # - Traffic light position/orientation: relative to road network inertial frame (from XODR signal).
 
-traffic_signal_types:
+odr_signal_types:
   # Standard three-bulb vertical traffic light (Red above Yellow above Green).
-  - type: "1000001"
-    subtype: "-1"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "Standard three-bulb vertical traffic light with red, yellow, and green bulbs."
+  - odr_representation:
+      type: "1000001"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_light
+      description: "Standard three-bulb vertical traffic light with red, yellow, and green bulbs."
 
-    # List of bulbs
-    bulbs:
-      - id: "RedBulb"
-        # Position relative to traffic light frame (meters).
-        position_traffic_light: [0.0, 0.0, 0.4]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        # Bulb color: must be one of {Red, Yellow, Green}.
-        color: "Red"
-        # Bulb type: must be one of {Round, Arrow, ArrowLeft, ArrowRight, ArrowUp, ArrowUpperLeft, ArrowUpperRight, UTurnLeft, UTurnRight, Walk, DontWalk}.
-        type: "Round"
-        # Possible states this bulb can be in: subset of {Off, On, Blinking}.
-        states: ["Off", "On", "Blinking"]
-        # Optional: custom bounding box for this bulb.
-        # If omitted, uses maliput default (~12" lens: 0.356m tall x 0.356m wide x 0.177m deep).
-        bounding_box:
-          p_min: [-0.0889, -0.1778, -0.1778]
-          p_max: [0.0889, 0.1778, 0.1778]
+      # List of bulbs
+      bulbs:
+        - id: "RedBulb"
+          # Position relative to traffic light frame (meters).
+          position_traffic_light: [0.0, 0.0, 0.4]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          # Bulb color: must be one of {Red, Yellow, Green}.
+          color: "Red"
+          # Bulb type: must be one of {Round, Arrow, ArrowLeft, ArrowRight, ArrowUp, ArrowUpperLeft, ArrowUpperRight, UTurnLeft, UTurnRight, Walk, DontWalk}.
+          type: "Round"
+          # Possible states this bulb can be in: subset of {Off, On, Blinking}.
+          states: ["Off", "On", "Blinking"]
+          # Optional: custom bounding box for this bulb.
+          # If omitted, uses maliput default (~12" lens: 0.356m tall x 0.356m wide x 0.177m deep).
+          bounding_box:
+            p_min: [-0.0889, -0.1778, -0.1778]
+            p_max: [0.0889, 0.1778, 0.1778]
 
-      - id: "YellowBulb"
-        position_traffic_light: [0.0, 0.0, 0.0]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Yellow"
-        type: "Round"
-        states: ["Off", "On", "Blinking"]
+        - id: "YellowBulb"
+          position_traffic_light: [0.0, 0.0, 0.0]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Yellow"
+          type: "Round"
+          states: ["Off", "On", "Blinking"]
 
-      - id: "GreenBulb"
-        position_traffic_light: [0.0, 0.0, -0.4]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Green"
-        type: "Round"
-        states: ["Off", "On"]
+        - id: "GreenBulb"
+          position_traffic_light: [0.0, 0.0, -0.4]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Green"
+          type: "Round"
+          states: ["Off", "On"]
 
-    # Rule conditions: map bulb state combinations to Right-Of-Way rule values.
-    # Each condition defines a set of (bulb_id, state) pairs.
-    # When these conditions are met, the corresponding rule value is applied.
-    rule_states:
-      # Red only: Stop.
-      - condition:
-          - bulb: "RedBulb"
-            state: "On"
-          - bulb: "YellowBulb"
-            state: "Off"
-          - bulb: "GreenBulb"
-            state: "Off"
-        value: "Stop"
+      # Rule conditions: map bulb state combinations to Right-Of-Way rule values.
+      # Each condition defines a set of (bulb_id, state) pairs.
+      # When these conditions are met, the corresponding rule value is applied.
+      rule_states:
+        # Red only: Stop.
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "On"
+            - bulb_id: "YellowBulb"
+              state: "Off"
+            - bulb_id: "GreenBulb"
+              state: "Off"
+          value: "Stop"
 
-      # Red blinking: Stop and prepare to proceed.
-      - condition:
-          - bulb: "RedBulb"
-            state: "Blinking"
-          - bulb: "YellowBulb"
-            state: "Off"
-          - bulb: "GreenBulb"
-            state: "Off"
-        value: "StopThenGo"
+        # Red blinking: Stop and prepare to proceed.
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "Blinking"
+            - bulb_id: "YellowBulb"
+              state: "Off"
+            - bulb_id: "GreenBulb"
+              state: "Off"
+          value: "StopThenGo"
 
-      # Yellow solid: Stop if safe, otherwise proceed with caution.
-      - condition:
-          - bulb: "RedBulb"
-            state: "Off"
-          - bulb: "YellowBulb"
-            state: "On"
-          - bulb: "GreenBulb"
-            state: "Off"
-        value: "StopIfSafe"
+        # Yellow solid: Stop if safe, otherwise proceed with caution.
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "Off"
+            - bulb_id: "YellowBulb"
+              state: "On"
+            - bulb_id: "GreenBulb"
+              state: "Off"
+          value: "StopIfSafe"
 
-      # Yellow blinking: Proceed with caution.
-      - condition:
-          - bulb: "RedBulb"
-            state: "Off"
-          - bulb: "YellowBulb"
-            state: "Blinking"
-          - bulb: "GreenBulb"
-            state: "Off"
-        value: "ProceedWithCaution"
+        # Yellow blinking: Proceed with caution.
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "Off"
+            - bulb_id: "YellowBulb"
+              state: "Blinking"
+            - bulb_id: "GreenBulb"
+              state: "Off"
+          value: "ProceedWithCaution"
 
-      # Green solid: Proceed.
-      - condition:
-          - bulb: "RedBulb"
-            state: "Off"
-          - bulb: "YellowBulb"
-            state: "Off"
-          - bulb: "GreenBulb"
-            state: "On"
-        value: "Go"
+        # Green solid: Proceed.
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "Off"
+            - bulb_id: "YellowBulb"
+              state: "Off"
+            - bulb_id: "GreenBulb"
+              state: "On"
+          value: "Go"
 
   # Three-bulb traffic light with arrow support.
   # Can display turn arrows in green (left, straight, right).
-  - type: "1000011"
-    subtype: "10"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "Three-bulb traffic light with optional arrow support (left/straight/right)."
+  - odr_representation:
+      type: "1000011"
+      subtype: "10"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_light
+      description: "Three-bulb traffic light with optional arrow support (left/straight/right)."
 
-    bulbs:
-      - id: "RedBulb"
-        position_traffic_light: [0.0, 0.0, 0.4]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Red"
-        type: "Round"
-        states: ["Off", "On", "Blinking"]
+      bulbs:
+        - id: "RedBulb"
+          position_traffic_light: [0.0, 0.0, 0.4]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Red"
+          type: "Round"
+          states: ["Off", "On", "Blinking"]
 
-      - id: "YellowBulb"
-        position_traffic_light: [0.0, 0.0, 0.0]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Yellow"
-        type: "Round"
-        states: ["Off", "On", "Blinking"]
+        - id: "YellowBulb"
+          position_traffic_light: [0.0, 0.0, 0.0]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Yellow"
+          type: "Round"
+          states: ["Off", "On", "Blinking"]
 
-      - id: "GreenArrow"
-        position_traffic_light: [0.0, 0.0, -0.4]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Green"
-        type: "Arrow"
-        states: ["Off", "On"]
-        # Arrow orientation in radians, measured along bulb +X axis relative to +Y axis.
-        # 0.0 rad = arrow points in +Y direction (right from approaching vehicle perspective).
-        # π/2 rad = arrow points in +Z direction (straight).
-        # π rad = arrow points in -Y direction (left).
-        arrow_orientation_rad: 1.5707963267948966  # π/2 rad (straight).
+        - id: "GreenArrow"
+          position_traffic_light: [0.0, 0.0, -0.4]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Green"
+          type: "Arrow"
+          states: ["Off", "On"]
+          # Arrow orientation in radians, measured along bulb +X axis relative to +Y axis.
+          # 0.0 rad = arrow points in +Y direction (right from approaching vehicle perspective).
+          # π/2 rad = arrow points in +Z direction (straight).
+          # π rad = arrow points in -Y direction (left).
+          arrow_orientation_rad: 1.5707963267948966  # π/2 rad (straight).
 
-    rule_states:
-      - condition:
-          - bulb: "RedBulb"
-            state: "On"
-          - bulb: "YellowBulb"
-            state: "Off"
-          - bulb: "GreenArrow"
-            state: "Off"
-        value: "Stop"
+      rule_states:
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "On"
+            - bulb_id: "YellowBulb"
+              state: "Off"
+            - bulb_id: "GreenArrow"
+              state: "Off"
+          value: "Stop"
 
-      - condition:
-          - bulb: "RedBulb"
-            state: "Off"
-          - bulb: "YellowBulb"
-            state: "On"
-          - bulb: "GreenArrow"
-            state: "Off"
-        value: "StopIfSafe"
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "Off"
+            - bulb_id: "YellowBulb"
+              state: "On"
+            - bulb_id: "GreenArrow"
+              state: "Off"
+          value: "StopIfSafe"
 
-      - condition:
-          - bulb: "RedBulb"
-            state: "Off"
-          - bulb: "YellowBulb"
-            state: "Off"
-          - bulb: "GreenArrow"
-            state: "On"
-        value: "Go"
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "Off"
+            - bulb_id: "YellowBulb"
+              state: "Off"
+            - bulb_id: "GreenArrow"
+              state: "On"
+          value: "Go"
 
   # Pedestrian signal with walk/don't walk.
-  - type: "1000002"
-    subtype: "-1"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "Pedestrian walk/don't walk signal (red standing figure on black background / green walking figure on black background)."
+  - odr_representation:
+      type: "1000002"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_light
+      description: "Pedestrian walk/don't walk signal (red standing figure on black background / green walking figure on black background)."
 
-    bulbs:
-      # Black background with red standing figure hand (Don't Walk).
-      - id: "DontWalkBulb"
-        position_traffic_light: [0.0, 0.0, 0.1]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Red"
-        type: "Round"
-        states: ["Off", "On"]
+      bulbs:
+        # Black background with red standing figure hand (Don't Walk).
+        - id: "DontWalkBulb"
+          position_traffic_light: [0.0, 0.0, 0.1]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Red"
+          type: "Round"
+          states: ["Off", "On"]
 
-      # Black background with green walking figure (Walk).
-      - id: "WalkBulb"
-        position_traffic_light: [0.0, 0.0, -0.1]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Green"
-        type: "Round"
-        states: ["Off", "On", "Blinking"]
+        # Black background with green walking figure (Walk).
+        - id: "WalkBulb"
+          position_traffic_light: [0.0, 0.0, -0.1]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Green"
+          type: "Round"
+          states: ["Off", "On", "Blinking"]
 
-    rule_states:
-      - condition:
-          - bulb: "DontWalkBulb"
-            state: "On"
-          - bulb: "WalkBulb"
-            state: "Off"
-        value: "Stop"
+      rule_states:
+        - conditions:
+            - bulb_id: "DontWalkBulb"
+              state: "On"
+            - bulb_id: "WalkBulb"
+              state: "Off"
+          value: "Stop"
 
-      - condition:
-          - bulb: "DontWalkBulb"
-            state: "Off"
-          - bulb: "WalkBulb"
-            state: "On"
-        value: "Go"
+        - conditions:
+            - bulb_id: "DontWalkBulb"
+              state: "Off"
+            - bulb_id: "WalkBulb"
+              state: "On"
+          value: "Go"
 
-      - condition:
-          - bulb: "DontWalkBulb"
-            state: "Off"
-          - bulb: "WalkBulb"
-            state: "Blinking"
-        value: "ProceedWithCaution"
+        - conditions:
+            - bulb_id: "DontWalkBulb"
+              state: "Off"
+            - bulb_id: "WalkBulb"
+              state: "Blinking"
+          value: "ProceedWithCaution"
 
   # Stop sign (static traffic sign, not a traffic light).
-  - type: "206"
-    subtype: "-1"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "Stop sign. Requires a complete stop before entering the intersection."
-    sign_type: "stop"
+  - odr_representation:
+      type: "206"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      device_semantics: stop
+      description: "Stop sign. Requires a complete stop before entering the intersection."
 
-    # Stop signs have no bulbs.
-    bulbs: []
+      # Stop signs have no bulbs.
+      bulbs: []
 
-    rule_states:
-      - condition: []
-        value: "StopThenGo"
+      rule_states:
+        - conditions: []
+          value: "StopThenGo"

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -90,11 +90,11 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
   }
   const auto& definition = definition_opt.value();
 
-  // Only build TrafficLight objects for signals whose database device_type is "traffic_light".
-  if (definition.device_type != kTrafficLightDeviceType) {
+  // Only build TrafficLight objects for signals whose database device_type is kTrafficLight.
+  if (definition.device_type != traffic_control_device::TrafficControlDeviceType::kTrafficLight) {
     maliput::log()->debug("TrafficLightBuilder: signal id='", signal_.id.string(), "' has device_type='",
-                          definition.device_type, "', expected '", kTrafficLightDeviceType,
-                          "'. Skipping TrafficLight creation.");
+                          traffic_control_device::TrafficControlDeviceTypeToString(definition.device_type),
+                          "', expected 'traffic_light'. Skipping TrafficLight creation.");
     return nullptr;
   }
 

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -90,10 +90,10 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
   }
   const auto& definition = definition_opt.value();
 
-  // Only build TrafficLight objects for signals whose database sign_type is "traffic_light".
-  if (definition.sign_type != kTrafficLightSignType) {
-    maliput::log()->debug("TrafficLightBuilder: signal id='", signal_.id.string(), "' has sign_type='",
-                          definition.sign_type, "', expected '", kTrafficLightSignType,
+  // Only build TrafficLight objects for signals whose database device_type is "traffic_light".
+  if (definition.device_type != kTrafficLightDeviceType) {
+    maliput::log()->debug("TrafficLightBuilder: signal id='", signal_.id.string(), "' has device_type='",
+                          definition.device_type, "', expected '", kTrafficLightDeviceType,
                           "'. Skipping TrafficLight creation.");
     return nullptr;
   }

--- a/src/maliput_malidrive/builder/traffic_light_builder.h
+++ b/src/maliput_malidrive/builder/traffic_light_builder.h
@@ -55,8 +55,8 @@ namespace builder {
 /// value.
 class TrafficLightBuilder {
  public:
-  /// The sign_type value that identifies a traffic light in the YAML database.
-  static constexpr const char* kTrafficLightSignType = "traffic_light";
+  /// The device_type value that identifies a traffic light in the YAML database.
+  static constexpr const char* kTrafficLightDeviceType = "traffic_light";
 
   /// Constructs a TrafficLightBuilder.
   ///
@@ -78,7 +78,7 @@ class TrafficLightBuilder {
   ///
   /// @returns A unique_ptr to the constructed TrafficLight, or nullptr if no
   ///          matching definition was found in the YAML database for the signal
-  ///          or the definition's sign_type is not "traffic_light".
+  ///          or the definition's device_type is not "traffic_light".
   std::unique_ptr<const maliput::api::rules::TrafficLight> operator()() const;
 
  private:

--- a/src/maliput_malidrive/builder/traffic_light_builder.h
+++ b/src/maliput_malidrive/builder/traffic_light_builder.h
@@ -50,14 +50,12 @@ namespace builder {
 /// inputs and call @ref operator()() to produce the result.
 ///
 /// When no matching @ref traffic_control_device::TrafficControlDeviceDefinition is found in
-/// the loader for the given signal's type/subtype/country fingerprint, the
-/// builder returns nullptr. Callers are responsible for checking the return
-/// value.
+/// the loader for the given signal's type/subtype/country fingerprint, or when
+/// the definition's @ref traffic_control_device::TrafficControlDeviceType is not
+/// @ref traffic_control_device::TrafficControlDeviceType::kTrafficLight, the builder
+/// returns nullptr.
 class TrafficLightBuilder {
  public:
-  /// The device_type value that identifies a traffic light in the YAML database.
-  static constexpr const char* kTrafficLightDeviceType = "traffic_light";
-
   /// Constructs a TrafficLightBuilder.
   ///
   /// @param signal The XODR signal to build a @ref maliput::api::rules::TrafficLight from.

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -96,10 +96,11 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   }
   const auto& definition = definition_opt.value();
 
-  const auto sign_type = MapSignTypeString(definition.sign_type);
-  if (sign_type == maliput::api::rules::TrafficSignType::kUnknown) {
-    maliput::log()->debug("TrafficSignBuilder: unrecognized sign_type='", definition.sign_type, "' for signal id='",
-                          signal_.id.string(), "'. Defaulting to TrafficSignType::kUnknown.");
+  const auto sign_meaning = MapSignTypeString(definition.device_semantics.value_or("other"));
+  if (sign_meaning == maliput::api::rules::TrafficSignType::kUnknown) {
+    maliput::log()->debug("TrafficSignBuilder: unrecognized device_semantics='",
+                          definition.device_semantics.value_or("other"), "' for signal id='", signal_.id.string(),
+                          "'. Defaulting to TrafficSignType::kUnknown.");
   }
 
   const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry_);
@@ -129,13 +130,14 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
   maliput::log()->debug("TrafficSignBuilder: creating TrafficSign for signal id='", signal_.id.string(), "' type='",
-                        signal_.type, "' subtype='", signal_.subtype, "' sign_type='", definition.sign_type,
-                        "'. TrafficSign position: (x=", pos.x(), ", y=", pos.y(), ", z=", pos.z(),
+                        signal_.type, "' subtype='", signal_.subtype, "' device_semantics='",
+                        definition.device_semantics.value_or("other"), "'. TrafficSign position: (x=", pos.x(),
+                        ", y=", pos.y(), ", z=", pos.z(),
                         ") with orientation (roll=0, pitch=0, yaw=", orientation_road_network.yaw(),
                         "), related_lanes=", related_lanes.size(), ".");
 
   return std::make_unique<maliput::api::rules::TrafficSign>(maliput::api::rules::TrafficSign::Id(signal_.id.string()),
-                                                            sign_type, pos, orientation_road_network, signal_.text,
+                                                            sign_meaning, pos, orientation_road_network, signal_.text,
                                                             std::move(related_lanes), bounding_box);
 }
 

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -96,6 +96,14 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   }
   const auto& definition = definition_opt.value();
 
+  // Only build TrafficSign objects for signals whose database device_type is kTrafficSign.
+  if (definition.device_type != traffic_control_device::TrafficControlDeviceType::kTrafficSign) {
+    maliput::log()->debug("TrafficSignBuilder: signal id='", signal_.id.string(), "' has device_type='",
+                          traffic_control_device::TrafficControlDeviceTypeToString(definition.device_type),
+                          "', expected 'traffic_sign'. Skipping TrafficSign creation.");
+    return nullptr;
+  }
+
   const auto sign_meaning = MapSignTypeString(definition.device_semantics.value_or("other"));
   if (sign_meaning == maliput::api::rules::TrafficSignType::kUnknown) {
     maliput::log()->debug("TrafficSignBuilder: unrecognized device_semantics='",

--- a/src/maliput_malidrive/builder/traffic_sign_builder.h
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.h
@@ -49,9 +49,7 @@ namespace builder {
 /// inputs and call @ref operator()() to produce the result.
 ///
 /// When no matching @ref traffic_control_device::TrafficControlDeviceDefinition is found in
-/// the loader for the given signal's type/subtype/country fingerprint, or when
-/// the definition's device_semantics cannot be mapped to a known
-/// @ref maliput::api::rules::TrafficSignType, the builder returns nullptr.
+/// the loader for the given signal's type/subtype/country fingerprint, the builder returns nullptr.
 class TrafficSignBuilder {
  public:
   /// Constructs a TrafficSignBuilder.

--- a/src/maliput_malidrive/builder/traffic_sign_builder.h
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.h
@@ -50,7 +50,7 @@ namespace builder {
 ///
 /// When no matching @ref traffic_control_device::TrafficControlDeviceDefinition is found in
 /// the loader for the given signal's type/subtype/country fingerprint, or when
-/// the definition's sign_type cannot be mapped to a known
+/// the definition's device_semantics cannot be mapped to a known
 /// @ref maliput::api::rules::TrafficSignType, the builder returns nullptr.
 class TrafficSignBuilder {
  public:

--- a/src/maliput_malidrive/builder/traffic_sign_builder.h
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.h
@@ -49,7 +49,8 @@ namespace builder {
 /// inputs and call @ref operator()() to produce the result.
 ///
 /// When no matching @ref traffic_control_device::TrafficControlDeviceDefinition is found in
-/// the loader for the given signal's type/subtype/country fingerprint, the builder returns nullptr.
+/// the loader for the given signal's type/subtype/country/country_revision fingerprint, or the device_type is not
+/// @ref traffic_control_device::TrafficControlDeviceType::kTrafficSign, the builder returns nullptr.
 class TrafficSignBuilder {
  public:
   /// Constructs a TrafficSignBuilder.

--- a/src/maliput_malidrive/builder/traffic_sign_type_mapper.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_type_mapper.cc
@@ -36,7 +36,7 @@
 namespace malidrive {
 namespace builder {
 
-maliput::api::rules::TrafficSignType MapSignTypeString(const std::string& sign_type_str) {
+maliput::api::rules::TrafficSignType MapSignTypeString(const std::string& device_semantics) {
   using T = maliput::api::rules::TrafficSignType;
   static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper{
       {"stop", T::kStop},
@@ -52,8 +52,11 @@ maliput::api::rules::TrafficSignType MapSignTypeString(const std::string& sign_t
       {"construction", T::kConstruction},
       {"railroad_crossing", T::kRailroadCrossing},
       {"no_overtaking", T::kNoOvertaking},
+      {"give_way", T::kYield},
+      {"speed_limit_begin", T::kSpeedLimit},
+      {"crosswalk", T::kPedestrianCrossing},
   };
-  std::string lower = sign_type_str;
+  std::string lower = device_semantics;
   std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
   const auto it = kMapper.find(lower);
   return it != kMapper.end() ? it->second : T::kUnknown;

--- a/src/maliput_malidrive/builder/traffic_sign_type_mapper.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_type_mapper.cc
@@ -29,6 +29,7 @@
 #include "maliput_malidrive/builder/traffic_sign_type_mapper.h"
 
 #include <algorithm>
+#include <cctype>
 #include <unordered_map>
 
 #include <maliput/common/maliput_hash.h>

--- a/src/maliput_malidrive/builder/traffic_sign_type_mapper.h
+++ b/src/maliput_malidrive/builder/traffic_sign_type_mapper.h
@@ -35,7 +35,7 @@
 namespace malidrive {
 namespace builder {
 
-/// Maps a sign_type string from the YAML traffic signal database to a
+/// Maps a device_semantics string from the YAML traffic control device database to a
 /// @ref maliput::api::rules::TrafficSignType enum.
 ///
 /// The comparison is case-insensitive: "Stop", "STOP", and "stop" all
@@ -43,9 +43,9 @@ namespace builder {
 ///
 /// Any unrecognized string (including "traffic_light") maps to kUnknown.
 ///
-/// @param sign_type_str The sign_type value from the YAML database.
+/// @param device_semantics The device_semantics value from the YAML database.
 /// @returns The corresponding TrafficSignType, or kUnknown if not recognized.
-maliput::api::rules::TrafficSignType MapSignTypeString(const std::string& sign_type_str);
+maliput::api::rules::TrafficSignType MapSignTypeString(const std::string& device_semantics);
 
 }  // namespace builder
 }  // namespace malidrive

--- a/src/maliput_malidrive/builder/traffic_signal_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_signal_books_builder.cc
@@ -111,7 +111,7 @@ TrafficSignalBooks TrafficSignalBooksBuilder::operator()() const {
         refs = refs_it->second;
       }
 
-      if (definition.sign_type == TrafficLightBuilder::kTrafficLightSignType) {
+      if (definition.device_type == TrafficLightBuilder::kTrafficLightDeviceType) {
         auto tl = TrafficLightBuilder(signal, road_id, loader, road_geometry_, refs)();
         if (tl) {
           auto* tlb_impl = dynamic_cast<maliput::TrafficLightBook*>(tlb.get());

--- a/src/maliput_malidrive/builder/traffic_signal_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_signal_books_builder.cc
@@ -111,18 +111,20 @@ TrafficSignalBooks TrafficSignalBooksBuilder::operator()() const {
         refs = refs_it->second;
       }
 
-      if (definition.device_type == TrafficLightBuilder::kTrafficLightDeviceType) {
+      if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kTrafficLight) {
         auto tl = TrafficLightBuilder(signal, road_id, loader, road_geometry_, refs)();
         if (tl) {
           auto* tlb_impl = dynamic_cast<maliput::TrafficLightBook*>(tlb.get());
           tlb_impl->AddTrafficLight(std::move(tl));
         }
-      } else {
-        // Static traffic sign.
+      } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kTrafficSign) {
         auto ts = TrafficSignBuilder(signal, road_id, loader, road_geometry_, std::move(refs))();
         if (ts) {
           tsb->AddTrafficSign(std::move(ts));
         }
+      } else {
+        maliput::log()->debug("TrafficSignalBooksBuilder: definition for signal id='", signal.id.string(),
+                              "' has unrecognized device type. Skipping.");
       }
     }
   }

--- a/src/maliput_malidrive/builder/traffic_signal_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_signal_books_builder.cc
@@ -112,7 +112,7 @@ TrafficSignalBooks TrafficSignalBooksBuilder::operator()() const {
       }
 
       if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kTrafficLight) {
-        auto tl = TrafficLightBuilder(signal, road_id, loader, road_geometry_, refs)();
+        auto tl = TrafficLightBuilder(signal, road_id, loader, road_geometry_, std::move(refs))();
         if (tl) {
           auto* tlb_impl = dynamic_cast<maliput::TrafficLightBook*>(tlb.get());
           tlb_impl->AddTrafficLight(std::move(tl));

--- a/src/maliput_malidrive/builder/traffic_signal_books_builder.h
+++ b/src/maliput_malidrive/builder/traffic_signal_books_builder.h
@@ -54,7 +54,7 @@ struct TrafficSignalBooks {
 /// Compared to the alternative design (separate `TrafficLightBookBuilder` /
 /// `TrafficSignBookBuilder`), this builder:
 ///  - Parses the YAML database exactly once.
-///  - Routes each XODR signal to the right book using the `sign_type` field of
+///  - Routes each XODR signal to the right book using the `device_type` field of
 ///    the matching @ref traffic_control_device::TrafficControlDeviceDefinition:
 ///      - `"traffic_light"` → @ref maliput::api::rules::TrafficLight
 ///        added to the TrafficLightBook.

--- a/src/maliput_malidrive/traffic_control_device/CMakeLists.txt
+++ b/src/maliput_malidrive/traffic_control_device/CMakeLists.txt
@@ -2,9 +2,10 @@
 # Malidrive traffic signal
 ##############################################################################
 add_library(traffic_control_device
+  device_type.cc
+  parser.cc
   traffic_control_device_database_loader.cc
   yaml_helper.cc
-  parser.cc
 )
 add_library(maliput_malidrive::traffic_control_device ALIAS traffic_control_device)
 set_target_properties(traffic_control_device

--- a/src/maliput_malidrive/traffic_control_device/README.md
+++ b/src/maliput_malidrive/traffic_control_device/README.md
@@ -87,7 +87,7 @@ The `device_semantics` matching is **case-insensitive**: `"No_Entry"`, `"NO_ENTR
 
 #### Signal Fingerprint Matching
 
-Each signal definition in the database is uniquely identified by a **fingerprint** composed of four fields:
+Each signal definition in the database is uniquely identified by a **fingerprint** composed of the following fields:
 
 | Field              | Required | Description                                |
 | ------------------ | -------- | ------------------------------------------ |
@@ -96,7 +96,7 @@ Each signal definition in the database is uniquely identified by a **fingerprint
 | `country`          | No       | Country code or standard                   |
 | `country_revision` | No       | Country standard revision                  |
 
-Only `type` is mandatory; `subtype`, `country`, and `country_revision` may be omitted (treated as null). When the parser looks up an XODR signal in the database, all four fields are compared — omitted fields match only when the corresponding database entry also leaves them unset. This means two entries that share the same `type` but differ in any optional field (present vs. absent, or different values) are considered distinct definitions.
+Only `type` is mandatory; `subtype`, `country`, and `country_revision` may be omitted (treated as null). When the parser looks up an XODR signal in the database, all fields are compared — omitted fields match only when the corresponding database entry also leaves them unset. This means two entries that share the same `type` but differ in any optional field (present vs. absent, or different values) are considered distinct definitions.
 
 ### Bulbs
 
@@ -167,7 +167,7 @@ See `resources/traffic_control_device_db/traffic_control_device_db_example.yaml`
 A parser loading these files should:
 
 1. Load the YAML file
-2. For each signal in the XODR file with type/subtype/country/country_revision/name matching a database entry:
+2. For each signal in the XODR file with type/subtype/country/country_revision matching a database entry:
    - Check the `device_type` to know whether to create a maliput `maliput::api::rules::TrafficLight` or `maliput::api::rules::TrafficSign`
    - If it is a `maliput::api::rules::TrafficSign`, assign its type by mapping the `device_semantics` field
    - If it is a `maliput::api::rules::TrafficLight`, load its bulb structure

--- a/src/maliput_malidrive/traffic_control_device/README.md
+++ b/src/maliput_malidrive/traffic_control_device/README.md
@@ -1,6 +1,6 @@
 # Traffic Control Device database parser
 
-This directory contains a C++ parser and supporting utilities that read and validate YAML-based traffic device definitions to create maliput traffic control devices objects such as `TrafficLight`s and `TrafficSign`s.
+This directory contains a C++ parser and supporting utilities that read and validate YAML-based traffic device definitions to create maliput traffic control devices such as `TrafficLight`s and `TrafficSign`s.
 
 ## Overview
 
@@ -37,7 +37,7 @@ Each YAML file in this directory should define a list of signal types under the 
     type: "1000001"           # Signal type identifier (must match XODR signal type)
     subtype: "-1"             # Optional: signal subtype ("-1" / "none" treated as absent)
     country: "OpenDRIVE"      # Optional: country code or standard
-    countryRevision: null     # Optional: country standard revision
+    country_revision: null     # Optional: country standard revision
   properties:
     device_type: traffic_light  # Required: "traffic_light" or "traffic_sign"
     device_semantics: stop      # Optional: semantic meaning for traffic signs

--- a/src/maliput_malidrive/traffic_control_device/README.md
+++ b/src/maliput_malidrive/traffic_control_device/README.md
@@ -1,21 +1,19 @@
-# Traffic Signal Database Parser
+# Traffic Control Device database parser
 
-This directory contains a C++ parser and supporting utilities that read and validate YAML-based traffic signal type definitions to create maliput traffic signal objects such as `TrafficLight`s and `TrafficSign`s.
+This directory contains a C++ parser and supporting utilities that read and validate YAML-based traffic device definitions to create maliput traffic control devices objects such as `TrafficLight`s and `TrafficSign`s.
 
 ## Overview
 
-A traffic signal type definition describes the physical structure and control logic of a traffic signal. Each definition specifies:
+A traffic control device type definition describes the physical structure, semantics, and control logic of a traffic control device. Each definition contains two sections:
 
-- **Signal kind**: Whether it is a dynamic traffic light or a static traffic sign
-- **Bulb structure**: Colors, types (round/arrow), states, dimensions, and positions
-- **Bulbs**: A list of bulbs with specified orientation
-- **Rule logic**: Mapping from bulb state combinations to Right-Of-Way Rule values
+- **`odr_representation`**: The OpenDRIVE signal attributes used to match the device type (`type`, `subtype`, `country`, `country_revision`)
+- **`properties`**: The device's characteristics — `device_type`, `device_semantics`, bulb structure, rule states, bounding box, and more
 
-The parser in this directory reads YAML files containing these traffic signal type definitions, validates them, and creates the corresponding maliput `TrafficLight` and `TrafficSign` objects.
+The parser in this directory reads YAML files containing these traffic control device type definitions, validates them, and creates the corresponding maliput `TrafficLight` and `TrafficSign` objects.
 
 ## How It Works
 
-When parsing an OpenDRIVE (`*.xodr`) road network file, traffic signals are referenced with a `type` attribute:
+When parsing an OpenDRIVE (`*.xodr`) road network file, traffic signals carry attributes such as `type`, `subtype`, `country`, and `country_revision`:
 
 ```xml
 <signal type="1000001" subtype="-1" country="OpenDRIVE" s="10.5" t="2.0" zOffset="4.5" ... />
@@ -23,41 +21,57 @@ When parsing an OpenDRIVE (`*.xodr`) road network file, traffic signals are refe
 
 A parser uses this database to:
 
-1. **Look up the signal type** (e.g., `1000001`) in the YAML database
-2. **Create a maliput TrafficLight** object with bulbs from the type definition
-3. **Create Right-Of-Way rules** mapping bulb state conditions to rule values (Go, Stop, etc.)
-4. **Link rules to affected lanes** using the signal's validity information from the XODR file
+1. **Match the signal** against an `odr_representation` entry using `type`, `subtype`, `country`, and `country_revision`
+2. **Determine the device category** from `device_type` — either `traffic_light` or `traffic_sign`
+3. **Create a maliput `TrafficLight` or `TrafficSign`** — for traffic signs, `device_semantics` is mapped to a `TrafficSignType`
+4. **Link to affected lanes** using the signal's validity information from the XODR file
 
 ## YAML Structure
 
-Each YAML file in this directory should define a list of signal types under the top-level key `traffic_signal_types`. Each signal type entry contains:
+Each YAML file in this directory should define a list of signal types under the top-level key `odr_signal_types`. Each entry uses a two-level structure:
 
 ### Signal Type Header
 
 ```yaml
-- type: "1000001"               # Signal type identifier (must match XODR signal type)
-  subtype: "-1"                 # Optional: signal subtype for finer matching
-  country: "OpenDRIVE"          # Optional: country code or standard
-  country_revision: null        # Optional: country standard revision
-  description: "..."            # Human-readable description
-  sign_type: "stop"             # Optional: signal type identifier. Defaults to "traffic_light" if omitted.
+- odr_representation:
+    type: "1000001"           # Signal type identifier (must match XODR signal type)
+    subtype: "-1"             # Optional: signal subtype ("-1" / "none" treated as absent)
+    country: "OpenDRIVE"      # Optional: country code or standard
+    countryRevision: null     # Optional: country standard revision
+  properties:
+    device_type: traffic_light  # Required: "traffic_light" or "traffic_sign"
+    device_semantics: stop      # Optional: semantic meaning for traffic signs
+    description: "..."          # Optional: Human-readable description
+    is_position_dynamic: false  # Optional: whether position may change at runtime
+    default_bounding_box:       # Optional: device-level bounding box
+      p_min: [x, y, z]
+      p_max: [x, y, z]
 ```
 
-#### `sign_type`
+#### `device_type`
 
-String field that identifies the signal variant. Defaults to `"traffic_light"` when not present in the YAML file. Use a different value (e.g., `"stop"`, `"yield"`, `"speed_limit"`) to identify static traffic signs.
+Required string that identifies the signal category. Used to route signals to the right maliput book:
 
-The supported `sign_type` values and their mapping to `maliput::api::rules::TrafficSignType` are:
+| `device_type` value  | Result                                              |
+|----------------------|-----------------------------------------------------|
+| `"traffic_light"`    | Creates a `maliput::api::rules::TrafficLight`       |
+| `"traffic_sign"`     | Creates a `maliput::api::rules::TrafficSign`        |
 
-| `sign_type` value        | `TrafficSignType` enum      |
-|--------------------------|-----------------------------|
-| `"traffic_light"`        | *(handled as TrafficLight, not a TrafficSign)* |
+#### `device_semantics`
+
+Optional string for traffic signs that identifies the semantic meaning. Defaults to `"other"` when absent. The supported values and their mapping to `maliput::api::rules::TrafficSignType` are:
+
+| `device_semantics` value | `TrafficSignType` enum      |
+|--------------------------|------------------------------|
 | `"stop"`                 | `kStop`                     |
 | `"yield"`                | `kYield`                    |
+| `"give_way"`             | `kYield`                    |
 | `"speed_limit"`          | `kSpeedLimit`               |
+| `"speed_limit_begin"`    | `kSpeedLimit`               |
 | `"no_entry"`             | `kNoEntry`                  |
 | `"one_way"`              | `kOneWay`                   |
 | `"pedestrian_crossing"`  | `kPedestrianCrossing`       |
+| `"crosswalk"`            | `kPedestrianCrossing`       |
 | `"no_left_turn"`         | `kNoLeftTurn`               |
 | `"no_right_turn"`        | `kNoRightTurn`              |
 | `"no_u_turn"`            | `kNoUTurn`                  |
@@ -67,9 +81,9 @@ The supported `sign_type` values and their mapping to `maliput::api::rules::Traf
 | `"no_overtaking"`        | `kNoOvertaking`             |
 | *(any other value)*      | `kUnknown`                  |
 
-If `sign_type` is set to a value not listed above (and is not `"traffic_light"`), the builder will still create a `TrafficSign` with `TrafficSignType::kUnknown`. This allows the database to contain signal definitions for region-specific or non-standard sign types without requiring code changes.
+If `device_semantics` is set to a value not listed above, the builder will still create a `TrafficSign` with `TrafficSignType::kUnknown`. This allows the database to contain signal definitions for region-specific or non-standard sign types without requiring code changes.
 
-The `sign_type` matching is **case-insensitive**: `"No_Entry"`, `"NO_ENTRY"`, and `"no_entry"` are all equivalent.
+The `device_semantics` matching is **case-insensitive**: `"No_Entry"`, `"NO_ENTRY"`, and `"no_entry"` are all equivalent.
 
 #### Signal Fingerprint Matching
 
@@ -107,13 +121,13 @@ Each signal type contains a list of `bulbs`:
 Rule states map bulb state combinations to Right-Of-Way Rule values:
 
 ```yaml
-  rule_states:
-    - condition:
-        - bulb: "BulbId"
-          state: "On"
-        - bulb: "OtherBulbId"
-          state: "Off"
-      value: "Go"              # Rule value: Go, Stop, StopIfSafe, StopThenGo, ProceedWithCaution, or SignalMalfunctioning
+      rule_states:
+        - conditions:
+            - bulb_id: "BulbId"
+              state: "On"
+            - bulb_id: "OtherBulbId"
+              state: "Off"
+          value: "Go"              # Rule value: Go, Stop, StopIfSafe, StopThenGo, ProceedWithCaution, or SignalMalfunctioning
 ```
 
 ## Coordinate Frames
@@ -140,19 +154,6 @@ Three possible states for bulbs:
 
 Not all bulbs support all states. Define `states` array to specify which states are valid for each bulb.
 
-## Right-Of-Way Rule Values
-
-When bulb state conditions are met, the parser creates rules with one of these values:
-
-| Value                  | Meaning                                                           |
-| ---------------------- | ----------------------------------------------------------------- |
-| `Go`                   | Proceed through the intersection                                  |
-| `Stop`                 | Must stop before entering intersection                            |
-| `StopIfSafe`           | Stop if safe to do so; may proceed if unsafe to stop              |
-| `StopThenGo`           | Stop, then proceed when safe (e.g., blinking red)                 |
-| `ProceedWithCaution`   | Proceed but watch for conflicting traffic (e.g., flashing yellow) |
-| `SignalMalfunctioning` | Traffic signal is not functioning correctly                       |
-
 ## Examples
 
 See `resources/traffic_control_device_db/traffic_control_device_db_example.yaml` for detailed examples including:
@@ -166,12 +167,12 @@ See `resources/traffic_control_device_db/traffic_control_device_db_example.yaml`
 A parser loading these files should:
 
 1. Load the YAML file
-2. For each signal in the XODR file with type/subtype matching a database entry:
-   - Create a `maliput::api::rules::TrafficLight` with bulbs
-   - Create `maliput::api::rules::DiscreteValueRule` entries for each applicable lane
-   - Map bulb state conditions to Right-Of-Way rule values
-3. Add the rules to the `maliput::api::rules::RoadRulebook`
-4. Add the traffic light to the `maliput::api::rules::TrafficLightBook`
+2. For each signal in the XODR file with type/subtype/country/country_revision/name matching a database entry:
+   - Check the `device_type` to know whether to create a maliput `maliput::api::rules::TrafficLight` or `maliput::api::rules::TrafficSign`
+   - If it is a `maliput::api::rules::TrafficSign`, assign its type by mapping the `device_semantics` field
+   - If it is a `maliput::api::rules::TrafficLight`, load its bulb structure
+3. Check for lane validities in the XODR file and set the related lanes for each signal and traffic light.
+4. Add `maliput::api::rules::TrafficSign`s to the `maliput::api::rules::TrafficSignBook` and `maliput::api::rules::TrafficLight`s to the `maliput::api::rules::TrafficLightBook`
 
 ## Color Mapping to maliput
 
@@ -207,6 +208,5 @@ YAML states map to `maliput::api::rules::BulbState` enum:
 
 ## Notes
 
-- Severity for all Right-Of-Way rules is fixed at 0 (strict enforcement)
 - If `bounding_box` is omitted, maliput uses default dimensions (~12" lens: 0.356m tall × 0.356m wide × 0.177m deep)
 - Arrow orientation is only valid (and required) when `type: "Arrow"`

--- a/src/maliput_malidrive/traffic_control_device/device_type.cc
+++ b/src/maliput_malidrive/traffic_control_device/device_type.cc
@@ -29,6 +29,7 @@
 #include "maliput_malidrive/traffic_control_device/device_type.h"
 
 #include <algorithm>
+#include <cctype>
 #include <unordered_map>
 
 #include <maliput/common/maliput_hash.h>

--- a/src/maliput_malidrive/traffic_control_device/device_type.cc
+++ b/src/maliput_malidrive/traffic_control_device/device_type.cc
@@ -1,0 +1,63 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/traffic_control_device/device_type.h"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include <maliput/common/maliput_hash.h>
+
+namespace malidrive {
+namespace traffic_control_device {
+
+TrafficControlDeviceType StringToTrafficControlDeviceType(const std::string& device_type_str) {
+  using T = TrafficControlDeviceType;
+  static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper{
+      {"traffic_light", T::kTrafficLight},
+      {"traffic_sign", T::kTrafficSign},
+  };
+  std::string lower = device_type_str;
+  std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+  const auto it = kMapper.find(lower);
+  return it != kMapper.end() ? it->second : T::kUnknown;
+}
+
+const char* TrafficControlDeviceTypeToString(TrafficControlDeviceType device_type) {
+  switch (device_type) {
+    case TrafficControlDeviceType::kTrafficLight:
+      return "traffic_light";
+    case TrafficControlDeviceType::kTrafficSign:
+      return "traffic_sign";
+    default:
+      return "unknown";
+  }
+}
+
+}  // namespace traffic_control_device
+}  // namespace malidrive

--- a/src/maliput_malidrive/traffic_control_device/device_type.h
+++ b/src/maliput_malidrive/traffic_control_device/device_type.h
@@ -1,0 +1,70 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+
+namespace malidrive {
+namespace traffic_control_device {
+
+/// Identifies the category of a traffic control device.
+///
+/// Parsed from the `device_type` field of the YAML database `properties` section.
+enum class TrafficControlDeviceType {
+  kTrafficLight,  ///< Device is a traffic light ("traffic_light").
+  kTrafficSign,   ///< Device is a traffic sign ("traffic_sign").
+  kUnknown,       ///< Unrecognized or missing device_type value.
+};
+
+/// Converts a `device_type` string from the YAML database to a
+/// @ref TrafficControlDeviceType enum value.
+///
+/// Recognized values (case-insensitive):
+///   - `"traffic_light"` → `kTrafficLight`
+///   - `"traffic_sign"`  → `kTrafficSign`
+///
+/// Any other string maps to `kUnknown`.
+///
+/// @param device_type_str  The `device_type` string from the YAML `properties` section.
+/// @returns The corresponding @ref TrafficControlDeviceType.
+TrafficControlDeviceType StringToTrafficControlDeviceType(const std::string& device_type_str);
+
+/// Converts a @ref TrafficControlDeviceType enum value back to its canonical
+/// YAML string representation.
+///
+///   - `kTrafficLight` → `"traffic_light"`
+///   - `kTrafficSign`  → `"traffic_sign"`
+///   - `kUnknown`      → `"unknown"`
+///
+/// @param device_type  The @ref TrafficControlDeviceType to convert.
+/// @returns The corresponding string.
+const char* TrafficControlDeviceTypeToString(TrafficControlDeviceType device_type);
+
+}  // namespace traffic_control_device
+}  // namespace malidrive

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -160,24 +160,24 @@ BulbDefinition ParseBulb(const YAML::Node& bulb_node) {
 // @return A RuleState with the parsed values.
 RuleState ParseRuleState(const YAML::Node& rule_state_node) {
   MALIDRIVE_THROW_UNLESS(rule_state_node.IsMap(), maliput::common::road_network_description_parser_error);
-  MALIDRIVE_THROW_UNLESS(rule_state_node[RuleStateConstants::kCondition].IsDefined(),
+  MALIDRIVE_THROW_UNLESS(rule_state_node[RuleStateConstants::kConditions].IsDefined(),
                          maliput::common::road_network_description_parser_error);
-  ValidateSequenceSize(rule_state_node[RuleStateConstants::kCondition], RuleStateConstants::kCondition);
+  ValidateSequenceSize(rule_state_node[RuleStateConstants::kConditions], RuleStateConstants::kConditions);
   MALIDRIVE_THROW_UNLESS(rule_state_node[RuleStateConstants::kValue].IsDefined(),
                          maliput::common::road_network_description_parser_error);
 
   RuleState rule_state;
 
   // Parse bulb conditions.
-  for (const auto& condition_node : rule_state_node[RuleStateConstants::kCondition]) {
+  for (const auto& condition_node : rule_state_node[RuleStateConstants::kConditions]) {
     MALIDRIVE_THROW_UNLESS(condition_node.IsMap(), maliput::common::road_network_description_parser_error);
-    MALIDRIVE_THROW_UNLESS(condition_node[BulbStateConditionConstants::kBulb].IsDefined(),
+    MALIDRIVE_THROW_UNLESS(condition_node[BulbStateConditionConstants::kBulbId].IsDefined(),
                            maliput::common::road_network_description_parser_error);
     MALIDRIVE_THROW_UNLESS(condition_node[BulbStateConditionConstants::kState].IsDefined(),
                            maliput::common::road_network_description_parser_error);
 
     BulbStateCondition condition;
-    condition.bulb_id = GetRequiredStringField(condition_node, BulbStateConditionConstants::kBulb);
+    condition.bulb_id = GetRequiredStringField(condition_node, BulbStateConditionConstants::kBulbId);
     condition.state = StringToBulbState(GetRequiredStringField(condition_node, BulbStateConditionConstants::kState));
 
     rule_state.bulb_conditions.push_back(condition);
@@ -190,55 +190,101 @@ RuleState ParseRuleState(const YAML::Node& rule_state_node) {
 }
 
 // Helper function to parse a TrafficControlDeviceDefinition from a YAML map.
-// @param signal_node The YAML node representing a traffic signal definition.
+// @param entry_node The YAML node representing one entry in odr_signal_types.
+//        Expected structure:
+//          odr_representation:
+//            type: ...
+//            subtype: ...
+//            country: ...
+//            country_revision: ...
+//          properties:
+//            device_type: ...
+//            device_semantics: ...
+//            is_position_dynamic: ...
+//            default_bounding_box: ...
+//            description: ...
+//            bulbs: ...
+//            rule_states: ...
 // @return A TrafficControlDeviceDefinition with the parsed values.
-TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& signal_node) {
-  MALIDRIVE_THROW_UNLESS(signal_node.IsMap(), maliput::common::road_network_description_parser_error);
-  MALIDRIVE_THROW_UNLESS(signal_node[TrafficControlDeviceConstants::kType].IsDefined(),
+TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_node) {
+  MALIDRIVE_THROW_UNLESS(entry_node.IsMap(), maliput::common::road_network_description_parser_error);
+
+  // Validate and extract the odr_representation sub-node.
+  MALIDRIVE_THROW_UNLESS(entry_node[TrafficControlDeviceConstants::kOdrRepresentation].IsDefined(),
                          maliput::common::road_network_description_parser_error);
-  MALIDRIVE_THROW_UNLESS(signal_node[TrafficControlDeviceConstants::kDescription].IsDefined(),
+  MALIDRIVE_THROW_UNLESS(entry_node[TrafficControlDeviceConstants::kOdrRepresentation].IsMap(),
                          maliput::common::road_network_description_parser_error);
-  MALIDRIVE_THROW_UNLESS(signal_node[TrafficControlDeviceConstants::kBulbs].IsDefined(),
+  const YAML::Node& repr_node = entry_node[TrafficControlDeviceConstants::kOdrRepresentation];
+
+  // Validate and extract the properties sub-node.
+  MALIDRIVE_THROW_UNLESS(entry_node[TrafficControlDeviceConstants::kProperties].IsDefined(),
+                         maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(entry_node[TrafficControlDeviceConstants::kProperties].IsMap(),
+                         maliput::common::road_network_description_parser_error);
+  const YAML::Node& props_node = entry_node[TrafficControlDeviceConstants::kProperties];
+
+  // device_type is required.
+  MALIDRIVE_THROW_UNLESS(props_node[TrafficControlDeviceConstants::kDeviceType].IsDefined(),
                          maliput::common::road_network_description_parser_error);
 
   TrafficControlDeviceDefinition signal_definition;
 
-  // Parse required fields.
-  signal_definition.fingerprint.type = GetRequiredStringField(signal_node, TrafficControlDeviceConstants::kType);
-  signal_definition.description = GetRequiredStringField(signal_node, TrafficControlDeviceConstants::kDescription);
+  // --- Parse fingerprint from odr_representation ---
+  signal_definition.fingerprint.type = GetRequiredStringField(repr_node, TrafficControlDeviceConstants::kType);
 
-  // Parse optional fields.
-  if (const auto subtype = GetOptionalStringField(signal_node, TrafficControlDeviceConstants::kSubtype)) {
-    if (subtype.has_value() && (subtype.value() == "-1" || subtype.value() == "none")) {
+  if (const auto subtype = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kSubtype)) {
+    if (subtype.value() == "-1" || subtype.value() == "none") {
       signal_definition.fingerprint.subtype = std::nullopt;
     } else {
       signal_definition.fingerprint.subtype = subtype;
     }
   }
 
-  if (const auto country = GetOptionalStringField(signal_node, TrafficControlDeviceConstants::kCountry)) {
+  if (const auto country = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kCountry)) {
     signal_definition.fingerprint.country = country;
   }
 
-  if (const auto revision = GetOptionalStringField(signal_node, TrafficControlDeviceConstants::kCountryRevision)) {
+  if (const auto revision = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kCountryRevision)) {
     signal_definition.fingerprint.country_revision = revision;
   }
 
-  // Parse sign type (optional). Defaults to "traffic_light" when not present.
-  const auto sign_type_opt = GetOptionalStringField(signal_node, TrafficControlDeviceConstants::kSignType);
-  signal_definition.sign_type = sign_type_opt.has_value() ? sign_type_opt.value() : "traffic_light";
+  // --- Parse properties ---
+  signal_definition.device_type = GetRequiredStringField(props_node, TrafficControlDeviceConstants::kDeviceType);
 
-  // Parse bulbs.
-  ValidateSequenceSize(signal_node[TrafficControlDeviceConstants::kBulbs], TrafficControlDeviceConstants::kBulbs);
-  for (const auto& bulb_node : signal_node[TrafficControlDeviceConstants::kBulbs]) {
-    signal_definition.bulbs.push_back(ParseBulb(bulb_node));
+  signal_definition.device_semantics =
+      GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDeviceSemantics);
+
+  // is_position_dynamic (optional bool, defaults to false).
+  if (props_node[TrafficControlDeviceConstants::kIsPositionDynamic].IsDefined() &&
+      !props_node[TrafficControlDeviceConstants::kIsPositionDynamic].IsNull()) {
+    signal_definition.is_position_dynamic = props_node[TrafficControlDeviceConstants::kIsPositionDynamic].as<bool>();
+  }
+
+  // description (optional).
+  if (const auto desc = GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDescription)) {
+    signal_definition.description = desc.value();
+  }
+
+  // default_bounding_box at device level (optional).
+  if (props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsDefined() &&
+      !props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsNull()) {
+    signal_definition.default_bounding_box =
+        ParseBoundingBox(props_node[TrafficControlDeviceConstants::kDefaultBoundingBox]);
+  }
+
+  // Parse bulbs (optional sequence).
+  if (props_node[TrafficControlDeviceConstants::kBulbs].IsDefined()) {
+    ValidateSequenceSize(props_node[TrafficControlDeviceConstants::kBulbs], TrafficControlDeviceConstants::kBulbs);
+    for (const auto& bulb_node : props_node[TrafficControlDeviceConstants::kBulbs]) {
+      signal_definition.bulbs.push_back(ParseBulb(bulb_node));
+    }
   }
 
   // Parse rule_states (optional).
-  if (signal_node[TrafficControlDeviceConstants::kRuleStates].IsDefined()) {
-    ValidateSequenceSize(signal_node[TrafficControlDeviceConstants::kRuleStates],
+  if (props_node[TrafficControlDeviceConstants::kRuleStates].IsDefined()) {
+    ValidateSequenceSize(props_node[TrafficControlDeviceConstants::kRuleStates],
                          TrafficControlDeviceConstants::kRuleStates);
-    for (const auto& rule_state_node : signal_node[TrafficControlDeviceConstants::kRuleStates]) {
+    for (const auto& rule_state_node : props_node[TrafficControlDeviceConstants::kRuleStates]) {
       signal_definition.rule_states.push_back(ParseRuleState(rule_state_node));
     }
   }
@@ -249,8 +295,8 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& signal_no
 std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> BuildFrom(const YAML::Node& root) {
   MALIDRIVE_THROW_UNLESS(root.IsMap(), maliput::common::road_network_description_parser_error);
 
-  // Get traffic_signal_types array.
-  const YAML::Node& signals_node = root["traffic_signal_types"];
+  // Get odr_signal_types array.
+  const YAML::Node& signals_node = root[TrafficControlDeviceConstants::kOdrSignalTypes];
   MALIDRIVE_THROW_UNLESS(signals_node.IsDefined(), maliput::common::road_network_description_parser_error);
   MALIDRIVE_THROW_UNLESS(signals_node.IsSequence(), maliput::common::road_network_description_parser_error);
 

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -34,6 +34,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include "maliput_malidrive/common/macros.h"
+#include "maliput_malidrive/traffic_control_device/device_type.h"
 #include "maliput_malidrive/traffic_control_device/yaml_helper.h"
 
 namespace malidrive {
@@ -227,48 +228,50 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
   MALIDRIVE_THROW_UNLESS(props_node[TrafficControlDeviceConstants::kDeviceType].IsDefined(),
                          maliput::common::road_network_description_parser_error);
 
-  TrafficControlDeviceDefinition signal_definition;
+  TrafficControlDeviceDefinition tcd_definition;
 
   // --- Parse fingerprint from odr_representation ---
-  signal_definition.fingerprint.type = GetRequiredStringField(repr_node, TrafficControlDeviceConstants::kType);
+  tcd_definition.fingerprint.type = GetRequiredStringField(repr_node, TrafficControlDeviceConstants::kType);
 
   if (const auto subtype = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kSubtype)) {
     if (subtype.value() == "-1" || subtype.value() == "none") {
-      signal_definition.fingerprint.subtype = std::nullopt;
+      tcd_definition.fingerprint.subtype = std::nullopt;
     } else {
-      signal_definition.fingerprint.subtype = subtype;
+      tcd_definition.fingerprint.subtype = subtype;
     }
   }
 
   if (const auto country = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kCountry)) {
-    signal_definition.fingerprint.country = country;
+    tcd_definition.fingerprint.country = country;
   }
 
   if (const auto revision = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kCountryRevision)) {
-    signal_definition.fingerprint.country_revision = revision;
+    tcd_definition.fingerprint.country_revision = revision;
   }
 
   // --- Parse properties ---
-  signal_definition.device_type = GetRequiredStringField(props_node, TrafficControlDeviceConstants::kDeviceType);
+  const std::string device_type_str = GetRequiredStringField(props_node, TrafficControlDeviceConstants::kDeviceType);
+  tcd_definition.device_type = StringToTrafficControlDeviceType(device_type_str);
+  MALIDRIVE_VALIDATE(tcd_definition.device_type != TrafficControlDeviceType::kUnknown,
+                     maliput::common::road_network_description_parser_error, "Invalid device type: " + device_type_str);
 
-  signal_definition.device_semantics =
-      GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDeviceSemantics);
+  tcd_definition.device_semantics = GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDeviceSemantics);
 
   // is_position_dynamic (optional bool, defaults to false).
   if (props_node[TrafficControlDeviceConstants::kIsPositionDynamic].IsDefined() &&
       !props_node[TrafficControlDeviceConstants::kIsPositionDynamic].IsNull()) {
-    signal_definition.is_position_dynamic = props_node[TrafficControlDeviceConstants::kIsPositionDynamic].as<bool>();
+    tcd_definition.is_position_dynamic = props_node[TrafficControlDeviceConstants::kIsPositionDynamic].as<bool>();
   }
 
   // description (optional).
   if (const auto desc = GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDescription)) {
-    signal_definition.description = desc.value();
+    tcd_definition.description = desc.value();
   }
 
   // default_bounding_box at device level (optional).
   if (props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsDefined() &&
       !props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsNull()) {
-    signal_definition.default_bounding_box =
+    tcd_definition.default_bounding_box =
         ParseBoundingBox(props_node[TrafficControlDeviceConstants::kDefaultBoundingBox]);
   }
 
@@ -276,7 +279,7 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
   if (props_node[TrafficControlDeviceConstants::kBulbs].IsDefined()) {
     ValidateSequenceSize(props_node[TrafficControlDeviceConstants::kBulbs], TrafficControlDeviceConstants::kBulbs);
     for (const auto& bulb_node : props_node[TrafficControlDeviceConstants::kBulbs]) {
-      signal_definition.bulbs.push_back(ParseBulb(bulb_node));
+      tcd_definition.bulbs.push_back(ParseBulb(bulb_node));
     }
   }
 
@@ -285,11 +288,11 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
     ValidateSequenceSize(props_node[TrafficControlDeviceConstants::kRuleStates],
                          TrafficControlDeviceConstants::kRuleStates);
     for (const auto& rule_state_node : props_node[TrafficControlDeviceConstants::kRuleStates]) {
-      signal_definition.rule_states.push_back(ParseRuleState(rule_state_node));
+      tcd_definition.rule_states.push_back(ParseRuleState(rule_state_node));
     }
   }
 
-  return signal_definition;
+  return tcd_definition;
 }
 
 std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> BuildFrom(const YAML::Node& root) {

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -125,17 +125,30 @@ struct TrafficControlDeviceDefinition {
   TrafficControlDeviceFingerprint fingerprint;
   /// Human-readable description of this signal definition.
   std::string description;
-  /// Type of traffic signal. Defaults to "traffic_light" when not specified in the YAML database.
-  /// Use a different value (e.g. "stop", "yield") to identify static traffic signs.
-  std::string sign_type;
-  /// Bulbs in this traffic signal.
+  /// Device type string (e.g. "traffic_light", "traffic_sign", "road_marking").
+  /// Required field; read from properties.device_type in the YAML database.
+  std::string device_type;
+  /// Optional device semantics string (e.g. "stop", "give_way", "no_overtaking").
+  /// Read from properties.device_semantics. Defaults to "other" when absent.
+  std::optional<std::string> device_semantics;
+  /// Whether the device position is dynamic (moveable). Defaults to false.
+  bool is_position_dynamic{false};
+  /// Optional device-level bounding box. When set, represents the overall device dimensions.
+  /// Individual bulbs may still carry their own per-bulb bounding boxes.
+  std::optional<maliput::api::rules::Bulb::BoundingBox> default_bounding_box;
+  /// Bulbs in this traffic signal (only relevant when device_type == "traffic_light").
   std::vector<BulbDefinition> bulbs;
   /// Rule conditions mapping bulb state combinations to Right-Of-Way rule values.
   std::vector<RuleState> rule_states;
 
   bool operator==(const TrafficControlDeviceDefinition& other) const {
-    return fingerprint == other.fingerprint && description == other.description && sign_type == other.sign_type &&
-           bulbs == other.bulbs && rule_states == other.rule_states;
+    const bool bbox_equal =
+        (default_bounding_box.has_value() == other.default_bounding_box.has_value()) &&
+        (!default_bounding_box.has_value() || (default_bounding_box->p_BMin == other.default_bounding_box->p_BMin &&
+                                               default_bounding_box->p_BMax == other.default_bounding_box->p_BMax));
+    return fingerprint == other.fingerprint && description == other.description && device_type == other.device_type &&
+           device_semantics == other.device_semantics && is_position_dynamic == other.is_position_dynamic &&
+           bbox_equal && bulbs == other.bulbs && rule_states == other.rule_states;
   }
   bool operator!=(const TrafficControlDeviceDefinition& other) const { return !(*this == other); }
 };

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -175,7 +175,7 @@ struct TrafficControlDeviceDefinition {
 /// 4. Link the resulting objects to their affected lanes using signal validity data from the XODR file.
 class TrafficControlDeviceParser {
  public:
-  /// Loads a traffic signal database from a YAML string.
+  /// Loads a traffic control device database from a YAML string.
   ///
   /// @param yaml_content The YAML content as a string.
   /// @return Map of signal identifiers to their definitions.
@@ -183,7 +183,7 @@ class TrafficControlDeviceParser {
   static std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> LoadFromString(
       const std::string& yaml_content);
 
-  /// Loads a traffic signal database from a YAML file.
+  /// Loads a traffic control device database from a YAML file.
   ///
   /// @param file_path Path to the YAML database file.
   /// @return Map of signal identifiers to their definitions.

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -131,7 +131,7 @@ struct TrafficControlDeviceDefinition {
   /// Required field; validated at parse time — kUnknown is rejected with a parser error.
   TrafficControlDeviceType device_type{TrafficControlDeviceType::kUnknown};
   /// Optional device semantics string (e.g. "stop", "give_way", "no_overtaking").
-  /// Read from properties.device_semantics. Defaults to "other" when absent.
+  /// Read from properties.device_semantics.
   std::optional<std::string> device_semantics;
   /// Whether the device position is dynamic (moveable). Defaults to false.
   bool is_position_dynamic{false};

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -39,6 +39,8 @@
 #include <maliput/math/quaternion.h>
 #include <maliput/math/vector.h>
 
+#include "maliput_malidrive/traffic_control_device/device_type.h"
+
 namespace malidrive {
 namespace traffic_control_device {
 
@@ -125,9 +127,9 @@ struct TrafficControlDeviceDefinition {
   TrafficControlDeviceFingerprint fingerprint;
   /// Human-readable description of this signal definition.
   std::string description;
-  /// Device type string (e.g. "traffic_light", "traffic_sign", "road_marking").
-  /// Required field; read from properties.device_type in the YAML database.
-  std::string device_type;
+  /// Device category parsed from the `device_type` field in the YAML database `properties` section.
+  /// Required field; validated at parse time — kUnknown is rejected with a parser error.
+  TrafficControlDeviceType device_type{TrafficControlDeviceType::kUnknown};
   /// Optional device semantics string (e.g. "stop", "give_way", "no_overtaking").
   /// Read from properties.device_semantics. Defaults to "other" when absent.
   std::optional<std::string> device_semantics;
@@ -153,21 +155,24 @@ struct TrafficControlDeviceDefinition {
   bool operator!=(const TrafficControlDeviceDefinition& other) const { return !(*this == other); }
 };
 
-/// Traffic signal parser that loads traffic signal definitions from a YAML database. These are then
-/// used in tandem with XODR signal data to create maliput TrafficLights and associated Right-Of-Way rules.
+/// Parser that loads traffic control device definitions from a YAML database using the `odr_signal_types`
+/// schema. The resulting definitions are used in tandem with XODR signal data to create maliput
+/// `TrafficLight` and `TrafficSign` objects.
 ///
 /// Design:
-/// - TrafficLights and DiscreteValueRules are independent systems that operate in parallel.
-/// - Both are created from the same XODR signal, but are not formally linked.
-/// - TrafficLights provide visual representation (bulbs with states).
-/// - DiscreteValueRules provide Right-Of-Way behavior (discrete values mapped to bulb states).
-/// - They are synchronized externally: when rule states change, bulb states change.
+/// - Each definition carries a `device_type` field that determines whether a `TrafficLight` or
+///   `TrafficSign` is created for a given XODR signal.
+/// - For traffic lights: `TrafficLight` is created with its bulbs and associated rule states.
+/// - For traffic signs: a `TrafficSign` is created with its type derived from the `device_semantics` field.
 ///
 /// Workflow:
-/// 1. Load signal database: TrafficControlDeviceParser::LoadFromFile().
-/// 2. For each signal in XODR, extract its type/subtype and look up signal definition.
-/// 3. Create traffic light: TrafficControlDeviceParser::CreateTrafficLight().
-/// 4. Create rules (one per affected lane/road): TrafficControlDeviceParser::CreateRules().
+/// 1. Load the device database: `TrafficControlDeviceParser::LoadFromFile()` or `LoadFromString()`.
+/// 2. For each signal in the XODR file, match its `type`/`subtype`/`country`/`country_revision`
+///    against a loaded `TrafficControlDeviceFingerprint`.
+/// 3. Inspect `device_type` to route the signal to the appropriate builder:
+///    - `"traffic_light"` → build a `TrafficLight`.
+///    - `"traffic_sign"`  → build a `TrafficSign` whose type is mapped from `device_semantics`.
+/// 4. Link the resulting objects to their affected lanes using signal validity data from the XODR file.
 class TrafficControlDeviceParser {
  public:
   /// Loads a traffic signal database from a YAML string.

--- a/src/maliput_malidrive/traffic_control_device/yaml_helper.h
+++ b/src/maliput_malidrive/traffic_control_device/yaml_helper.h
@@ -38,7 +38,7 @@
 namespace malidrive {
 namespace traffic_control_device {
 
-/// Constants for traffic signal description YAML fields.
+/// Constants for traffic control device description YAML fields.
 struct TrafficControlDeviceConstants {
   // Root-level keys.
   static constexpr const char* kOdrSignalTypes = "odr_signal_types";

--- a/src/maliput_malidrive/traffic_control_device/yaml_helper.h
+++ b/src/maliput_malidrive/traffic_control_device/yaml_helper.h
@@ -40,12 +40,22 @@ namespace traffic_control_device {
 
 /// Constants for traffic signal description YAML fields.
 struct TrafficControlDeviceConstants {
+  // Root-level keys.
+  static constexpr const char* kOdrSignalTypes = "odr_signal_types";
+  // Entry-level structural keys.
+  static constexpr const char* kOdrRepresentation = "odr_representation";
+  static constexpr const char* kProperties = "properties";
+  // odr_representation fields.
   static constexpr const char* kType = "type";
   static constexpr const char* kSubtype = "subtype";
   static constexpr const char* kCountry = "country";
   static constexpr const char* kCountryRevision = "country_revision";
+  // properties fields.
+  static constexpr const char* kDeviceType = "device_type";
+  static constexpr const char* kDeviceSemantics = "device_semantics";
+  static constexpr const char* kIsPositionDynamic = "is_position_dynamic";
+  static constexpr const char* kDefaultBoundingBox = "default_bounding_box";
   static constexpr const char* kDescription = "description";
-  static constexpr const char* kSignType = "sign_type";
   static constexpr const char* kBulbs = "bulbs";
   static constexpr const char* kRuleStates = "rule_states";
 };
@@ -70,13 +80,13 @@ struct BoundingBoxConstants {
 
 /// Constants for rule state YAML fields.
 struct RuleStateConstants {
-  static constexpr const char* kCondition = "condition";
+  static constexpr const char* kConditions = "conditions";
   static constexpr const char* kValue = "value";
 };
 
 /// Constants for bulb state condition YAML fields.
 struct BulbStateConditionConstants {
-  static constexpr const char* kBulb = "bulb";
+  static constexpr const char* kBulbId = "bulb_id";
   static constexpr const char* kState = "state";
 };
 

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -1446,8 +1446,8 @@ class TrafficSignalBooksCreationTest : public ::testing::Test {};
 // Verifies that when figure8_trafficlights.xodr is loaded together with the
 // traffic_control_device_db_example.yaml database, the TrafficLightBook is populated
 // with 4 traffic lights (all signals in that XODR have type "1000001" which
-// maps to sign_type="traffic_light") and the TrafficSignBook is empty because
-// there are no static traffic sign signals in that map.
+// maps to device_type="traffic_light") and the TrafficSignBook is empty because
+// there are no device_type="traffic_sign" signals in that map.
 TEST_F(TrafficSignalBooksCreationTest, FigureEightTrafficLightsPopulatedFromDb) {
   const std::string xodr_file_path =
       utility::FindResourceInPath("figure8_trafficlights/figure8_trafficlights.xodr", kMalidriveResourceFolder);
@@ -1475,7 +1475,7 @@ TEST_F(TrafficSignalBooksCreationTest, FigureEightTrafficLightsPopulatedFromDb) 
 
 // Verifies that when TwoRoadsWithTrafficSigns.xodr is loaded together with the
 // traffic_control_device_db_example.yaml database, the TrafficSignBook is populated
-// with 2 stop signs (signals of type "206" which map to sign_type="stop") and
+// with 2 stop signs (signals of type "206" which map to device_semantics="stop") and
 // the TrafficLightBook is empty because there are no traffic light signals in
 // that map.
 TEST_F(TrafficSignalBooksCreationTest, TwoRoadsTrafficSignsPopulatedFromDb) {
@@ -1499,7 +1499,7 @@ TEST_F(TrafficSignalBooksCreationTest, TwoRoadsTrafficSignsPopulatedFromDb) {
   // TwoRoadsWithTrafficSigns.xodr has no traffic lights.
   EXPECT_TRUE(dut->traffic_light_book()->TrafficLights().empty());
   // TwoRoadsWithTrafficSigns.xodr defines 2 stop sign signals (type "206")
-  // which the example database maps to sign_type="stop".
+  // which the example database maps to device_semantics="stop".
   EXPECT_EQ(2, static_cast<int>(dut->traffic_sign_book()->TrafficSigns().size()));
 }
 

--- a/test/regression/builder/traffic_light_builder_test.cc
+++ b/test/regression/builder/traffic_light_builder_test.cc
@@ -167,9 +167,9 @@ TEST_F(TrafficLightBuilderFigure8Test, BuildTrafficLightNoMatchingDefinition) {
 }
 
 // Verifies that the builder returns nullptr when the matching definition in the
-// YAML database has a sign_type other than "traffic_light" (e.g. "stop").
+// YAML database has a device_type other than "traffic_light" (e.g. "traffic_sign").
 TEST_F(TrafficLightBuilderFigure8Test, BuildTrafficLightNonTrafficLightSignType) {
-  // Type "206" exists in the YAML database with sign_type: "stop".
+  // Type "206" exists in the YAML database with device_type: "traffic_sign".
   xodr::signal::Signal stop_signal = signal_;
   stop_signal.type = "206";
 

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -112,11 +112,11 @@ TEST_F(TrafficSignBuilderFigure8Test, ConstructorThrows) {
 }
 
 // Verifies that the builder creates a TrafficSign with TrafficSignType::kUnknown
-// when the signal's type maps to an unrecognized sign_type in the YAML database.
+// when the signal's type has no device_semantics in the YAML database.
 TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignReturnsUnknownForUnrecognizedSignType) {
-  // The figure8 signal has type "1000001" which resolves to sign_type "traffic_light".
-  // "traffic_light" is not mapped to any TrafficSignType enum, so the builder
-  // should create a TrafficSign with TrafficSignType::kUnknown.
+  // The figure8 signal has type "1000001" which resolves to device_type "traffic_light"
+  // with no device_semantics. "other" (the default) is not mapped to any TrafficSignType
+  // enum, so the builder should create a TrafficSign with TrafficSignType::kUnknown.
   TrafficSignBuilder builder(signal_, xodr::RoadHeader::Id("44"), *loader_, road_geometry_);
   auto traffic_sign = builder();
   ASSERT_NE(traffic_sign, nullptr);
@@ -124,7 +124,7 @@ TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignReturnsUnknownForUnrecogni
 }
 
 // Verifies that a TrafficSign is successfully created from a XODR signal whose
-// type maps to sign_type "stop" in the YAML database (type "206").
+// type maps to device_semantics "stop" in the YAML database (type "206").
 TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSign) {
   xodr::signal::Signal stop_signal = signal_;
   stop_signal.type = "206";
@@ -181,7 +181,7 @@ TEST_F(TrafficSignBuilderFigure8Test, PositionOfTrafficSign) {
 //       no explicit validity (all lanes), signalReference to SS1.
 //
 // The companion YAML database (traffic_control_device_db_example.yaml) defines type
-// "206" as a static stop sign (sign_type: "stop").
+// "206" as a static stop sign (device_semantics: "stop").
 //
 // Expected maliput lane IDs:
 //   Road 1: "1_0_1" (left), "1_0_-1" (right)
@@ -227,7 +227,7 @@ TEST_F(TrafficSignBuilderTwoRoadsTest, TrafficSignSS1Fields) {
   // ID.
   EXPECT_EQ(maliput::api::rules::TrafficSign::Id("SS1"), ts->id());
 
-  // Type: "206" maps to sign_type "stop" → kStop.
+  // Type: "206" maps to device_semantics "stop" → kStop.
   EXPECT_EQ(maliput::api::rules::TrafficSignType::kStop, ts->type());
 
   // Position: Road 1 is straight at y=0, hdg=0. Signal at s=50, t=2, zOffset=1 → (50, 2, 1).
@@ -266,7 +266,7 @@ TEST_F(TrafficSignBuilderTwoRoadsTest, TrafficSignSS2Fields) {
   // ID.
   EXPECT_EQ(maliput::api::rules::TrafficSign::Id("SS2"), ts->id());
 
-  // Type: "206" maps to sign_type "stop" → kStop.
+  // Type: "206" maps to device_semantics "stop" → kStop.
   EXPECT_EQ(maliput::api::rules::TrafficSignType::kStop, ts->type());
 
   // Position: Road 2 starts at x=110, hdg=0. Signal at s=40, t=-2, zOffset=1 → (150, -2, 1).

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -64,7 +64,7 @@ static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
 // Builds a RoadNetwork from the figure8_trafficlights XODR (which contains
 // signals of type "1000001") and prepares a TrafficControlDeviceDatabaseLoader backed
 // by the example YAML database. Individual tests that require a static traffic
-// sign create a copy of the signal and change its type to "206" (stop sign).
+// sign create a copy of the signal and change its type to "206" (stop sign) or "999" (unknown sign).
 class TrafficSignBuilderFigure8Test : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -114,10 +114,11 @@ TEST_F(TrafficSignBuilderFigure8Test, ConstructorThrows) {
 // Verifies that the builder creates a TrafficSign with TrafficSignType::kUnknown
 // when the signal's type has no device_semantics in the YAML database.
 TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignReturnsUnknownForUnrecognizedSignType) {
-  // The figure8 signal has type "1000001" which resolves to device_type "traffic_light"
-  // with no device_semantics. "other" (the default) is not mapped to any TrafficSignType
-  // enum, so the builder should create a TrafficSign with TrafficSignType::kUnknown.
-  TrafficSignBuilder builder(signal_, xodr::RoadHeader::Id("44"), *loader_, road_geometry_);
+  // Changed parsed signal's type to "999", which maps to a signal with an unknown device_semantics in the database,
+  // so the builder should create a TrafficSign with TrafficSignType::kUnknown.
+  xodr::signal::Signal unknown_signal = signal_;
+  unknown_signal.type = "999";
+  TrafficSignBuilder builder(unknown_signal, xodr::RoadHeader::Id("44"), *loader_, road_geometry_);
   auto traffic_sign = builder();
   ASSERT_NE(traffic_sign, nullptr);
   EXPECT_EQ(maliput::api::rules::TrafficSignType::kUnknown, traffic_sign->type());

--- a/test/regression/builder/traffic_sign_type_mapper_test.cc
+++ b/test/regression/builder/traffic_sign_type_mapper_test.cc
@@ -69,7 +69,10 @@ INSTANTIATE_TEST_CASE_P(AllKnownTypes, MapSignTypeStringTest,
                             MapSignTypeStringTestCase{"school_zone", TrafficSignType::kSchoolZone},
                             MapSignTypeStringTestCase{"construction", TrafficSignType::kConstruction},
                             MapSignTypeStringTestCase{"railroad_crossing", TrafficSignType::kRailroadCrossing},
-                            MapSignTypeStringTestCase{"no_overtaking", TrafficSignType::kNoOvertaking}));
+                            MapSignTypeStringTestCase{"no_overtaking", TrafficSignType::kNoOvertaking},
+                            MapSignTypeStringTestCase{"give_way", TrafficSignType::kYield},
+                            MapSignTypeStringTestCase{"speed_limit_begin", TrafficSignType::kSpeedLimit},
+                            MapSignTypeStringTestCase{"crosswalk", TrafficSignType::kPedestrianCrossing}));
 
 INSTANTIATE_TEST_CASE_P(UnknownTypes, MapSignTypeStringTest,
                         ::testing::Values(

--- a/test/regression/traffic_control_device/CMakeLists.txt
+++ b/test/regression/traffic_control_device/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_TYPE UNIT)
 ##############################################################################
 
 set(UNIT_TEST_TRAFFIC_SIGNAL_SOURCES
+  device_type_test.cc
   parser_test.cc
 )
 

--- a/test/regression/traffic_control_device/device_type_test.cc
+++ b/test/regression/traffic_control_device/device_type_test.cc
@@ -1,0 +1,117 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/traffic_control_device/device_type.h"
+
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace malidrive {
+namespace traffic_control_device {
+namespace test {
+namespace {
+
+// ---------------------------------------------------------------------------
+// StringToTrafficControlDeviceType — known values
+// ---------------------------------------------------------------------------
+
+struct StringToTypeTestCase {
+  std::string input;
+  TrafficControlDeviceType expected;
+};
+
+class StringToTrafficControlDeviceTypeTest : public ::testing::TestWithParam<StringToTypeTestCase> {};
+
+TEST_P(StringToTrafficControlDeviceTypeTest, MapsCorrectly) {
+  EXPECT_EQ(GetParam().expected, StringToTrafficControlDeviceType(GetParam().input));
+}
+
+INSTANTIATE_TEST_CASE_P(KnownValues, StringToTrafficControlDeviceTypeTest,
+                        ::testing::Values(
+                            // Canonical lower-case forms.
+                            StringToTypeTestCase{"traffic_light", TrafficControlDeviceType::kTrafficLight},
+                            StringToTypeTestCase{"traffic_sign", TrafficControlDeviceType::kTrafficSign}));
+
+INSTANTIATE_TEST_CASE_P(CaseInsensitive, StringToTrafficControlDeviceTypeTest,
+                        ::testing::Values(
+                            // Upper-case variants.
+                            StringToTypeTestCase{"TRAFFIC_LIGHT", TrafficControlDeviceType::kTrafficLight},
+                            StringToTypeTestCase{"TRAFFIC_SIGN", TrafficControlDeviceType::kTrafficSign},
+                            // Mixed-case variants.
+                            StringToTypeTestCase{"Traffic_Light", TrafficControlDeviceType::kTrafficLight},
+                            StringToTypeTestCase{"Traffic_Sign", TrafficControlDeviceType::kTrafficSign}));
+
+INSTANTIATE_TEST_CASE_P(UnknownValues, StringToTrafficControlDeviceTypeTest,
+                        ::testing::Values(
+                            // Unrecognized strings map to kUnknown.
+                            StringToTypeTestCase{"", TrafficControlDeviceType::kUnknown},
+                            StringToTypeTestCase{"road_marking", TrafficControlDeviceType::kUnknown},
+                            StringToTypeTestCase{"other", TrafficControlDeviceType::kUnknown},
+                            StringToTypeTestCase{"unknown_value", TrafficControlDeviceType::kUnknown}));
+
+// ---------------------------------------------------------------------------
+// TrafficControlDeviceTypeToString — all enum values
+// ---------------------------------------------------------------------------
+
+struct TypeToStringTestCase {
+  TrafficControlDeviceType input;
+  std::string expected;
+};
+
+class TrafficControlDeviceTypeToStringTest : public ::testing::TestWithParam<TypeToStringTestCase> {};
+
+TEST_P(TrafficControlDeviceTypeToStringTest, MapsCorrectly) {
+  EXPECT_EQ(GetParam().expected, std::string(TrafficControlDeviceTypeToString(GetParam().input)));
+}
+
+INSTANTIATE_TEST_CASE_P(AllValues, TrafficControlDeviceTypeToStringTest,
+                        ::testing::Values(TypeToStringTestCase{TrafficControlDeviceType::kTrafficLight,
+                                                               "traffic_light"},
+                                          TypeToStringTestCase{TrafficControlDeviceType::kTrafficSign, "traffic_sign"},
+                                          TypeToStringTestCase{TrafficControlDeviceType::kUnknown, "unknown"}));
+
+// ---------------------------------------------------------------------------
+// Round-trip: StringToTrafficControlDeviceType ∘ TrafficControlDeviceTypeToString
+// ---------------------------------------------------------------------------
+
+TEST(TrafficControlDeviceTypeRoundTripTest, TrafficLight) {
+  const auto type = TrafficControlDeviceType::kTrafficLight;
+  EXPECT_EQ(type, StringToTrafficControlDeviceType(TrafficControlDeviceTypeToString(type)));
+}
+
+TEST(TrafficControlDeviceTypeRoundTripTest, TrafficSign) {
+  const auto type = TrafficControlDeviceType::kTrafficSign;
+  EXPECT_EQ(type, StringToTrafficControlDeviceType(TrafficControlDeviceTypeToString(type)));
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace traffic_control_device
+}  // namespace malidrive

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -45,143 +45,161 @@ static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
 constexpr double kTolerance = 1e-6;
 
 const char kTrafficControlDeviceDb[] = R"(
-traffic_signal_types:
-  - type: "1000001"
-    subtype: "-1"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "Standard three-bulb vertical traffic light"
-    bulbs:
-      - id: "RedBulb"
-        position_traffic_light: [0.0, 0.0, 0.4]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Red"
-        type: "Round"
-        states: ["Off", "On", "Blinking"]
-        bounding_box:
-          p_min: [-0.0889, -0.1778, -0.1778]
-          p_max: [0.0889, 0.1778, 0.1778]
-      - id: "YellowBulb"
-        position_traffic_light: [0.0, 0.0, 0.0]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Yellow"
-        type: "Round"
-        states: ["Off", "On", "Blinking"]
-      - id: "GreenBulb"
-        position_traffic_light: [0.0, 0.0, -0.4]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Green"
-        type: "Round"
-        states: ["Off", "On"]
-    rule_states:
-      - condition:
-          - bulb: "RedBulb"
-            state: "On"
-          - bulb: "YellowBulb"
-            state: "Off"
-          - bulb: "GreenBulb"
-            state: "Off"
-        value: "Stop"
-      - condition:
-          - bulb: "RedBulb"
-            state: "Off"
-          - bulb: "YellowBulb"
-            state: "Off"
-          - bulb: "GreenBulb"
-            state: "On"
-        value: "Go"
-  - type: "1000011"
-    subtype: "10"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "Traffic light with arrow"
-    bulbs:
-      - id: "GreenArrow"
-        position_traffic_light: [0.0, 0.0, 0.0]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Green"
-        type: "Arrow"
-        states: ["Off", "On"]
-        arrow_orientation_rad: 1.5707963267948966
-    rule_states:
-      - condition:
-          - bulb: "GreenArrow"
-            state: "On"
-        value: "Go"
-  - type: "default_bulb_state"
-    subtype: null
-    country: null
-    country_revision: null
-    description: "Signal with default bulb states and bounding box"
-    bulbs:
-      - id: "DefaultBulb"
-        position_traffic_light: [0.0, 0.0, 0.0]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Red"
-        type: "Round"
-    rule_states: []
-  - type: "206"
-    subtype: "30"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "No overtaking sign"
-    sign_type: "no_overtaking"
-    bulbs: []
-    rule_states:
-      - condition: []
-        value: "Stop"
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_light
+      description: "Standard three-bulb vertical traffic light"
+      bulbs:
+        - id: "RedBulb"
+          position_traffic_light: [0.0, 0.0, 0.4]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Red"
+          type: "Round"
+          states: ["Off", "On", "Blinking"]
+          bounding_box:
+            p_min: [-0.0889, -0.1778, -0.1778]
+            p_max: [0.0889, 0.1778, 0.1778]
+        - id: "YellowBulb"
+          position_traffic_light: [0.0, 0.0, 0.0]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Yellow"
+          type: "Round"
+          states: ["Off", "On", "Blinking"]
+        - id: "GreenBulb"
+          position_traffic_light: [0.0, 0.0, -0.4]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Green"
+          type: "Round"
+          states: ["Off", "On"]
+      rule_states:
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "On"
+            - bulb_id: "YellowBulb"
+              state: "Off"
+            - bulb_id: "GreenBulb"
+              state: "Off"
+          value: "Stop"
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "Off"
+            - bulb_id: "YellowBulb"
+              state: "Off"
+            - bulb_id: "GreenBulb"
+              state: "On"
+          value: "Go"
+  - odr_representation:
+      type: "1000011"
+      subtype: "10"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_light
+      description: "Traffic light with arrow"
+      bulbs:
+        - id: "GreenArrow"
+          position_traffic_light: [0.0, 0.0, 0.0]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Green"
+          type: "Arrow"
+          states: ["Off", "On"]
+          arrow_orientation_rad: 1.5707963267948966
+      rule_states:
+        - conditions:
+            - bulb_id: "GreenArrow"
+              state: "On"
+          value: "Go"
+  - odr_representation:
+      type: "default_bulb_state"
+      subtype: null
+      country: null
+      country_revision: null
+    properties:
+      device_type: traffic_light
+      description: "Signal with default bulb states and bounding box"
+      bulbs:
+        - id: "DefaultBulb"
+          position_traffic_light: [0.0, 0.0, 0.0]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Red"
+          type: "Round"
+      rule_states: []
+  - odr_representation:
+      type: "206"
+      subtype: "30"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      device_semantics: no_overtaking
+      description: "No overtaking sign"
+      bulbs: []
+      rule_states:
+        - conditions: []
+          value: "Stop"
 )";
 
 const char kRepeatedTrafficControlDeviceDb[] = R"(
-traffic_signal_types:
-  - type: "1234567"
-    subtype: "11"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "Single red bulb traffic light"
-    bulbs:
-      - id: "RedBulb"
-        position_traffic_light: [0.0, 0.0, 0.4]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Red"
-        type: "Round"
-        states: ["Off", "On", "Blinking"]
-        bounding_box:
-          p_min: [-0.0889, -0.1778, -0.1778]
-          p_max: [0.0889, 0.1778, 0.1778]
-    rule_states:
-      - condition:
-          - bulb: "RedBulb"
-            state: "On"
-        value: "Stop"
-      - condition:
-          - bulb: "RedBulb"
-            state: "Off"
-        value: "Go"
-  - type: "1234567"
-    subtype: "11"
-    country: "OpenDRIVE"
-    country_revision: null
-    description: "Single green bulb traffic light"
-    bulbs:
-      - id: "GreenBulb"
-        position_traffic_light: [0.0, 0.0, 0.4]
-        orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
-        color: "Green"
-        type: "Round"
-        states: ["Off", "On", "Blinking"]
-        bounding_box:
-          p_min: [-0.0889, -0.1778, -0.1778]
-          p_max: [0.0889, 0.1778, 0.1778]
-    rule_states:
-      - condition:
-          - bulb: "GreenBulb"
-            state: "On"
-        value: "Go"
-      - condition:
-          - bulb: "GreenBulb"
-            state: "Off"
-        value: "Stop"
+odr_signal_types:
+  - odr_representation:
+      type: "1234567"
+      subtype: "11"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_light
+      description: "Single red bulb traffic light"
+      bulbs:
+        - id: "RedBulb"
+          position_traffic_light: [0.0, 0.0, 0.4]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Red"
+          type: "Round"
+          states: ["Off", "On", "Blinking"]
+          bounding_box:
+            p_min: [-0.0889, -0.1778, -0.1778]
+            p_max: [0.0889, 0.1778, 0.1778]
+      rule_states:
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "On"
+          value: "Stop"
+        - conditions:
+            - bulb_id: "RedBulb"
+              state: "Off"
+          value: "Go"
+  - odr_representation:
+      type: "1234567"
+      subtype: "11"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_light
+      description: "Single green bulb traffic light"
+      bulbs:
+        - id: "GreenBulb"
+          position_traffic_light: [0.0, 0.0, 0.4]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: "Green"
+          type: "Round"
+          states: ["Off", "On", "Blinking"]
+          bounding_box:
+            p_min: [-0.0889, -0.1778, -0.1778]
+            p_max: [0.0889, 0.1778, 0.1778]
+      rule_states:
+        - conditions:
+            - bulb_id: "GreenBulb"
+              state: "On"
+          value: "Go"
+        - conditions:
+            - bulb_id: "GreenBulb"
+              state: "Off"
+          value: "Stop"
 )";
 
 class TrafficControlDeviceParserTest : public ::testing::Test {
@@ -227,7 +245,8 @@ TEST_F(TrafficControlDeviceParserTest, ValidateTrafficSign) {
   EXPECT_EQ(dut.fingerprint.subtype, "30");
   EXPECT_EQ(dut.fingerprint.country, "OpenDRIVE");
   EXPECT_EQ(dut.description, "No overtaking sign");
-  EXPECT_EQ(dut.sign_type, "no_overtaking");
+  EXPECT_EQ(dut.device_type, "traffic_sign");
+  EXPECT_EQ(dut.device_semantics, "no_overtaking");
 
   EXPECT_EQ(dut.bulbs.size(), 0);
   EXPECT_EQ(dut.rule_states.size(), 1);
@@ -248,7 +267,8 @@ TEST_F(TrafficControlDeviceParserTest, ValidateSignalType1000001) {
   EXPECT_EQ(dut.fingerprint.subtype, std::nullopt);
   EXPECT_EQ(dut.fingerprint.country, "OpenDRIVE");
   EXPECT_EQ(dut.description, "Standard three-bulb vertical traffic light");
-  EXPECT_EQ(dut.sign_type, "traffic_light");
+  EXPECT_EQ(dut.device_type, "traffic_light");
+  EXPECT_FALSE(dut.device_semantics.has_value());
 
   EXPECT_EQ(dut.bulbs.size(), 3);
 
@@ -281,7 +301,8 @@ TEST_F(TrafficControlDeviceParserTest, ValidateArrowSignal) {
   EXPECT_EQ(dut.fingerprint.type, "1000011");
   EXPECT_EQ(dut.fingerprint.subtype, "10");
   EXPECT_EQ(dut.description, "Traffic light with arrow");
-  EXPECT_EQ(dut.sign_type, "traffic_light");
+  EXPECT_EQ(dut.device_type, "traffic_light");
+  EXPECT_FALSE(dut.device_semantics.has_value());
 
   EXPECT_EQ(dut.bulbs.size(), 1);
 
@@ -302,7 +323,7 @@ TEST_F(TrafficControlDeviceParserTest, DefaultBulbStatesAndBoundingBox) {
 
   EXPECT_EQ(dut.fingerprint.type, "default_bulb_state");
   EXPECT_EQ(dut.description, "Signal with default bulb states and bounding box");
-  EXPECT_EQ(dut.sign_type, "traffic_light");
+  EXPECT_EQ(dut.device_type, "traffic_light");
 
   EXPECT_EQ(dut.bulbs.size(), 1);
 
@@ -337,7 +358,7 @@ GTEST_TEST(RepeatedTrafficControlDeviceParserTest, RepeatedFingerprintOverwrites
   EXPECT_TRUE(signal_definitions.find(fingerprint) != signal_definitions.end());
   const auto& definition = signal_definitions.at(fingerprint);
   EXPECT_EQ(definition.description, "Single green bulb traffic light");
-  EXPECT_EQ(definition.sign_type, "traffic_light");
+  EXPECT_EQ(definition.device_type, "traffic_light");
   EXPECT_EQ(definition.bulbs.size(), 1);
   EXPECT_EQ(definition.bulbs[0].id, "GreenBulb");
 }

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -245,7 +245,7 @@ TEST_F(TrafficControlDeviceParserTest, ValidateTrafficSign) {
   EXPECT_EQ(dut.fingerprint.subtype, "30");
   EXPECT_EQ(dut.fingerprint.country, "OpenDRIVE");
   EXPECT_EQ(dut.description, "No overtaking sign");
-  EXPECT_EQ(dut.device_type, "traffic_sign");
+  EXPECT_EQ(dut.device_type, traffic_control_device::TrafficControlDeviceType::kTrafficSign);
   EXPECT_EQ(dut.device_semantics, "no_overtaking");
 
   EXPECT_EQ(dut.bulbs.size(), 0);
@@ -267,7 +267,7 @@ TEST_F(TrafficControlDeviceParserTest, ValidateSignalType1000001) {
   EXPECT_EQ(dut.fingerprint.subtype, std::nullopt);
   EXPECT_EQ(dut.fingerprint.country, "OpenDRIVE");
   EXPECT_EQ(dut.description, "Standard three-bulb vertical traffic light");
-  EXPECT_EQ(dut.device_type, "traffic_light");
+  EXPECT_EQ(dut.device_type, traffic_control_device::TrafficControlDeviceType::kTrafficLight);
   EXPECT_FALSE(dut.device_semantics.has_value());
 
   EXPECT_EQ(dut.bulbs.size(), 3);
@@ -301,7 +301,7 @@ TEST_F(TrafficControlDeviceParserTest, ValidateArrowSignal) {
   EXPECT_EQ(dut.fingerprint.type, "1000011");
   EXPECT_EQ(dut.fingerprint.subtype, "10");
   EXPECT_EQ(dut.description, "Traffic light with arrow");
-  EXPECT_EQ(dut.device_type, "traffic_light");
+  EXPECT_EQ(dut.device_type, traffic_control_device::TrafficControlDeviceType::kTrafficLight);
   EXPECT_FALSE(dut.device_semantics.has_value());
 
   EXPECT_EQ(dut.bulbs.size(), 1);
@@ -323,7 +323,7 @@ TEST_F(TrafficControlDeviceParserTest, DefaultBulbStatesAndBoundingBox) {
 
   EXPECT_EQ(dut.fingerprint.type, "default_bulb_state");
   EXPECT_EQ(dut.description, "Signal with default bulb states and bounding box");
-  EXPECT_EQ(dut.device_type, "traffic_light");
+  EXPECT_EQ(dut.device_type, traffic_control_device::TrafficControlDeviceType::kTrafficLight);
 
   EXPECT_EQ(dut.bulbs.size(), 1);
 
@@ -358,7 +358,7 @@ GTEST_TEST(RepeatedTrafficControlDeviceParserTest, RepeatedFingerprintOverwrites
   EXPECT_TRUE(signal_definitions.find(fingerprint) != signal_definitions.end());
   const auto& definition = signal_definitions.at(fingerprint);
   EXPECT_EQ(definition.description, "Single green bulb traffic light");
-  EXPECT_EQ(definition.device_type, "traffic_light");
+  EXPECT_EQ(definition.device_type, traffic_control_device::TrafficControlDeviceType::kTrafficLight);
   EXPECT_EQ(definition.bulbs.size(), 1);
   EXPECT_EQ(definition.bulbs[0].id, "GreenBulb");
 }


### PR DESCRIPTION
# 🎉 New feature

Closes #447 

## Summary
Adopt new Traffic Control Device database format for traffic signals

### What changed
* YAML schema migration: The root key `traffic_signal_types` is replaced by `odr_signal_types`. Each entry now uses a two-level structure with an `odr_representation` sub-object (`type`, `subtype`, `country`, `country_revision`) and a `properties` sub-object (`device_type`, `device_semantics`, `is_position_dynamic`, `default_bounding_box`, `description`, `bulbs`, `rule_states`).

* `TrafficControlDeviceDefinition` struct: Removed `sign_type: std::string`. Added `device_type: std::string` (required) and `device_semantics: std::optional<std::string>` (optional, defaults to `"other"`). Added `is_position_dynamic: bool` and `default_bounding_box: std::optional<Bulb::BoundingBox>` at the definition level.

* Parser (`parser.cc`/`parser.h`): Updated `ParseSignalDefinition()` to read the nested `odr_representation`/`properties` structure. `ParseRuleState()` now reads `conditions` (was `condition`) and `bulb_id` (was `bulb`). `BuildFrom()` looks up `odr_signal_types` instead of `traffic_signal_types`.

* Builders: `TrafficLightBuilder` uses `kTrafficLightDeviceType = "traffic_light"` (was `kTrafficLightSignType`). `TrafficSignBuilder` maps `device_semantics` via `MapSignTypeString()`. `TrafficSignalBooksBuilder` routes on `device_type`.

* `traffic_sign_type_mapper`: Added three new `device_semantics` → `TrafficSignType` mappings:
  * `give_way` → `kYield]`
  * `speed_limit_begin` → `kSpeedLimit`
  * `crosswalk` → `kPedestrianCrossing`

* Example database (`traffic_control_device_db_example.yaml`): Migrated to the new schema.

* YAML helper constants (`yaml_helper.h`): New constants for `odr_signal_types`, `odr_representation`, `properties`, `device_type`, `device_semantics`, `is_position_dynamic`, `default_bounding_box`, `conditions`, `bulb_id`.

* Documentation (`README.md`): Updated YAML structure section, overview, and how-it-works sections to reflect the new schema and `device_type`/`device_semantics` fields.

* Tests: `parser_test.cc`, `traffic_light_builder_test.cc`, `traffic_sign_builder_test.cc`, `road_network_builder_test.cc`, and `traffic_sign_type_mapper_test.cc` updated to use the new format and new mappings.

### Behavior changes
* Database lookup key: A database file using the old `traffic_signal_types` root key will no longer be recognized — it must be migrated to `odr_signal_types`.

* Signal routing: Whether a signal becomes a `TrafficLight` or `TrafficSign` is now determined by the explicit `device_type` field (`"traffic_light"` / `"traffic_sign"`), rather than by the absence or presence of a `sign_type` value.

* Traffic sign semantics: The semantic meaning of a sign is carried by `device_semantics` instead of `sign_type`. Absent `device_semantics` defaults to `"other"`, which maps to `TrafficSignType::kUnknown`.

* Rule state conditions: The per-condition YAML keys changed from `condition`/`bulb` to `conditions`/`bulb_id`. Old database files using the previous keys will fail to parse.

* New semantics recognized: `give_way`, `speed_limit_begin`, and `crosswalk` are now valid `device_semantics` values and map to `kYield`, `kSpeedLimit`, and `kPedestrianCrossing` respectively.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.