### PR TITLE
TrafficControlDevice database wildcard matching

### DIFF
--- a/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
+++ b/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
@@ -58,6 +58,7 @@ odr_signal_types:
       subtype: "-1"
       country: "OpenDRIVE"
       country_revision: null
+      name: "*"
     properties:
       device_type: traffic_light
       description: "Standard three-bulb vertical traffic light with red, yellow, and green bulbs."
@@ -155,6 +156,7 @@ odr_signal_types:
       subtype: "10"
       country: "OpenDRIVE"
       country_revision: null
+      name: "*"
     properties:
       device_type: traffic_light
       description: "Three-bulb traffic light with optional arrow support (left/straight/right)."
@@ -220,6 +222,7 @@ odr_signal_types:
       subtype: "-1"
       country: "OpenDRIVE"
       country_revision: null
+      name: "*"
     properties:
       device_type: traffic_light
       description: "Pedestrian walk/don't walk signal (red standing figure on black background / green walking figure on black background)."
@@ -269,6 +272,7 @@ odr_signal_types:
       subtype: "-1"
       country: "OpenDRIVE"
       country_revision: null
+      name: "*"
     properties:
       device_type: traffic_sign
       device_semantics: stop
@@ -287,6 +291,7 @@ odr_signal_types:
       subtype: "-1"
       country: "OpenDRIVE"
       country_revision: null
+      name: "*"
     properties:
       device_type: traffic_sign
       description: "Unknown sign. No specific behavior defined."

--- a/src/maliput_malidrive/builder/traffic_signal_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_signal_books_builder.cc
@@ -92,6 +92,7 @@ TrafficSignalBooks TrafficSignalBooksBuilder::operator()() const {
           }(),
           signal.country,
           signal.country_revision,
+          signal.name,
       };
 
       const auto definition_opt = loader.Lookup(fingerprint);

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -31,7 +31,6 @@
 #include <utility>
 
 #include <maliput/common/maliput_throw.h>
-#include <yaml-cpp/yaml.h>
 
 #include "maliput_malidrive/common/macros.h"
 #include "maliput_malidrive/traffic_control_device/device_type.h"
@@ -39,6 +38,54 @@
 
 namespace malidrive {
 namespace traffic_control_device {
+
+bool TrafficControlDeviceParser::IsWildcard(const std::string& value) { return value == kWildcard; }
+
+bool TrafficControlDeviceParser::IsWildcard(const std::optional<std::string>& value) {
+  return value.has_value() && *value == kWildcard;
+}
+
+int TrafficControlDeviceParser::Specificity(const TrafficControlDeviceFingerprint& fp) {
+  // Each field contributes 1 to specificity when it is NOT a wildcard.
+  // nullopt is specific; only "*" is non-specific.
+  int score = 0;
+  if (!IsWildcard(fp.type)) ++score;
+  if (!IsWildcard(fp.subtype)) ++score;
+  if (!IsWildcard(fp.country)) ++score;
+  if (!IsWildcard(fp.country_revision)) ++score;
+  return score;
+}
+
+bool TrafficControlDeviceParser::Matches(const TrafficControlDeviceFingerprint& db_entry,
+                                         const TrafficControlDeviceFingerprint& query) {
+  // For each field: db_entry matches if it is the wildcard OR equals the query field.
+  auto field_matches = [](const std::string& db_val, const std::string& query_val) -> bool {
+    return IsWildcard(db_val) || db_val == query_val;
+  };
+  auto optional_field_matches = [](const std::optional<std::string>& db_opt,
+                                   const std::optional<std::string>& query_opt) -> bool {
+    if (IsWildcard(db_opt)) return true;
+    return db_opt == query_opt;
+  };
+  return field_matches(db_entry.type, query.type) && optional_field_matches(db_entry.subtype, query.subtype) &&
+         optional_field_matches(db_entry.country, query.country) &&
+         optional_field_matches(db_entry.country_revision, query.country_revision);
+}
+
+bool TrafficControlDeviceParser::CanOverlap(const TrafficControlDeviceFingerprint& a,
+                                            const TrafficControlDeviceFingerprint& b) {
+  // Two entries can overlap when, for every field, at least one is wildcard OR both are equal.
+  auto field_can_overlap = [](const std::string& va, const std::string& vb) -> bool {
+    return IsWildcard(va) || IsWildcard(vb) || va == vb;
+  };
+  auto optional_field_can_overlap = [](const std::optional<std::string>& oa,
+                                       const std::optional<std::string>& ob) -> bool {
+    return IsWildcard(oa) || IsWildcard(ob) || oa == ob;
+  };
+  return field_can_overlap(a.type, b.type) && optional_field_can_overlap(a.subtype, b.subtype) &&
+         optional_field_can_overlap(a.country, b.country) &&
+         optional_field_can_overlap(a.country_revision, b.country_revision);
+}
 
 namespace {
 
@@ -295,7 +342,9 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
   return tcd_definition;
 }
 
-std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> BuildFrom(const YAML::Node& root) {
+}  // namespace
+
+std::vector<TrafficControlDeviceDefinition> TrafficControlDeviceParser::BuildFrom(const YAML::Node& root) {
   MALIDRIVE_THROW_UNLESS(root.IsMap(), maliput::common::road_network_description_parser_error);
 
   // Get odr_signal_types array.
@@ -303,29 +352,41 @@ std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefiniti
   MALIDRIVE_THROW_UNLESS(signals_node.IsDefined(), maliput::common::road_network_description_parser_error);
   MALIDRIVE_THROW_UNLESS(signals_node.IsSequence(), maliput::common::road_network_description_parser_error);
 
-  std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> result;
+  std::vector<TrafficControlDeviceDefinition> result;
   // Parse each signal definition.
   for (const auto& signal_node : signals_node) {
-    const auto signal_definition = ParseSignalDefinition(signal_node);
-    const auto& it = result.emplace(signal_definition.fingerprint, signal_definition);
-    if (!it.second) {
-      result[signal_definition.fingerprint] = signal_definition;
+    result.push_back(ParseSignalDefinition(signal_node));
+  }
+
+  // Pairwise conflict validation: two entries conflict when they can overlap AND have equal specificity.
+  for (std::size_t i = 0; i < result.size(); ++i) {
+    for (std::size_t j = i + 1; j < result.size(); ++j) {
+      const auto& fp_i = result[i].fingerprint;
+      const auto& fp_j = result[j].fingerprint;
+      if (CanOverlap(fp_i, fp_j) && Specificity(fp_i) == Specificity(fp_j)) {
+        MALIDRIVE_THROW_MESSAGE(
+            "Conflicting traffic control device database entries with equal specificity: "
+            "entry '" +
+                result[i].description + "' (type='" + fp_i.type +
+                "') conflicts with "
+                "entry '" +
+                result[j].description + "' (type='" + fp_j.type + "').",
+            maliput::common::road_network_description_parser_error);
+      }
     }
   }
 
   return result;
 }
 
-}  // namespace
-
-std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition>
-TrafficControlDeviceParser::LoadFromString(const std::string& yaml_content) {
+std::vector<TrafficControlDeviceDefinition> TrafficControlDeviceParser::LoadFromString(
+    const std::string& yaml_content) {
   YAML::Node root = YAML::Load(yaml_content);
   return BuildFrom(root);
 }
 
-std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition>
-TrafficControlDeviceParser::LoadFromFile(const std::string& yaml_file_path) {
+std::vector<TrafficControlDeviceDefinition> TrafficControlDeviceParser::LoadFromFile(
+    const std::string& yaml_file_path) {
   YAML::Node root = YAML::LoadFile(yaml_file_path);
   return BuildFrom(root);
 }

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -53,6 +53,7 @@ int TrafficControlDeviceParser::Specificity(const TrafficControlDeviceFingerprin
   if (!IsWildcard(fp.subtype)) ++score;
   if (!IsWildcard(fp.country)) ++score;
   if (!IsWildcard(fp.country_revision)) ++score;
+  if (!IsWildcard(fp.name)) ++score;
   return score;
 }
 
@@ -69,7 +70,8 @@ bool TrafficControlDeviceParser::Matches(const TrafficControlDeviceFingerprint& 
   };
   return field_matches(db_entry.type, query.type) && optional_field_matches(db_entry.subtype, query.subtype) &&
          optional_field_matches(db_entry.country, query.country) &&
-         optional_field_matches(db_entry.country_revision, query.country_revision);
+         optional_field_matches(db_entry.country_revision, query.country_revision) &&
+         optional_field_matches(db_entry.name, query.name);
 }
 
 bool TrafficControlDeviceParser::CanOverlap(const TrafficControlDeviceFingerprint& a,
@@ -84,7 +86,8 @@ bool TrafficControlDeviceParser::CanOverlap(const TrafficControlDeviceFingerprin
   };
   return field_can_overlap(a.type, b.type) && optional_field_can_overlap(a.subtype, b.subtype) &&
          optional_field_can_overlap(a.country, b.country) &&
-         optional_field_can_overlap(a.country_revision, b.country_revision);
+         optional_field_can_overlap(a.country_revision, b.country_revision) &&
+         optional_field_can_overlap(a.name, b.name);
 }
 
 namespace {
@@ -294,6 +297,10 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
 
   if (const auto revision = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kCountryRevision)) {
     tcd_definition.fingerprint.country_revision = revision;
+  }
+
+  if (const auto name = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kName)) {
+    tcd_definition.fingerprint.name = name;
   }
 
   // --- Parse properties ---

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -196,24 +196,57 @@ class TrafficControlDeviceParser {
   /// A field set to this value matches any query value for that field.
   static constexpr char kWildcard[] = "*";
 
-  /// Returns true if @p value is the wildcard string.
+  /// Returns true if @p value equals the wildcard string `kWildcard` (`"*"`).
+  ///
+  /// @param value The string to test.
+  /// @return `true` if @p value is `"*"`, `false` otherwise.
   static bool IsWildcard(const std::string& value);
 
-  /// Returns true if @p value is present and equals the wildcard string.
+  /// Returns true if @p value is present and equals the wildcard string `kWildcard` (`"*"`).
+  ///
+  /// A `std::nullopt` argument returns `false` — absent fields are treated as specific constraints,
+  /// not as wildcards.
+  ///
+  /// @param value The optional string to test.
+  /// @return `true` if @p value holds `"*"`, `false` if it is `std::nullopt` or any other string.
   static bool IsWildcard(const std::optional<std::string>& value);
 
-  /// Computes the specificity of @p fp: the number of fields that are NOT wildcards.
-  /// @p nullopt counts as specific (constrains to "absent"); only `"*"` is non-specific.
-  /// Returns a value in [0, 5].
+  /// Computes the specificity score of @p fp: the count of fields that are NOT wildcards.
+  ///
+  /// A field contributes 1 to the score regardless of whether it is a concrete string or
+  /// `std::nullopt`. Only the literal `"*"` string is considered non-specific (contributes 0).
+  /// The score ranges from 0 (all five fields are `"*"`) to 5 (no field is `"*"`).
+  ///
+  /// @param fp The fingerprint to evaluate.
+  /// @return Integer in [0, 5] representing the number of non-wildcard fields.
   static int Specificity(const TrafficControlDeviceFingerprint& fp);
 
-  /// Returns true if @p db_entry matches @p query.
-  /// A field in @p db_entry matches the corresponding @p query field if the db_entry field is the
-  /// wildcard string or equals the query field. The @p query is expected to never contain wildcards.
+  /// Returns true if @p db_entry matches @p query for lookup purposes.
+  ///
+  /// A field in @p db_entry matches the corresponding field in @p query if:
+  ///   - the db_entry field is the wildcard `"*"` (matches any query value, including `nullopt`), or
+  ///   - both fields compare equal (including both being `std::nullopt`).
+  ///
+  /// @note @p query is expected to carry no wildcards — it is built directly from XODR signal data.
+  ///
+  /// @param db_entry A fingerprint loaded from the YAML database. May contain `"*"` wildcards.
+  /// @param query    A fingerprint built from an XODR signal. Must not contain `"*"`.
+  /// @return `true` if every field of @p db_entry matches the corresponding field of @p query.
   static bool Matches(const TrafficControlDeviceFingerprint& db_entry, const TrafficControlDeviceFingerprint& query);
 
-  /// Returns true if there exists at least one input that would match both @p a and @p b.
-  /// Per field: overlap if at least one is wildcard OR both are equal.
+  /// Returns true if there exists at least one input fingerprint that would match both @p a and @p b.
+  ///
+  /// Per-field rule: the two fingerprints can overlap on a given field if at least one of them
+  /// carries the wildcard `"*"` for that field, or both carry the same concrete value (including
+  /// both being `std::nullopt`). All five fields must satisfy this condition simultaneously for
+  /// the function to return `true`.
+  ///
+  /// This is used at database load time to detect conflicting entries that have equal specificity
+  /// and would therefore produce an ambiguous lookup result.
+  ///
+  /// @param a First fingerprint (may contain wildcards).
+  /// @param b Second fingerprint (may contain wildcards).
+  /// @return `true` if @p a and @p b can both match the same query input.
   static bool CanOverlap(const TrafficControlDeviceFingerprint& a, const TrafficControlDeviceFingerprint& b);
 
  private:

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -38,6 +38,7 @@
 #include <maliput/api/rules/traffic_lights.h>
 #include <maliput/math/quaternion.h>
 #include <maliput/math/vector.h>
+#include <yaml-cpp/yaml.h>
 
 #include "maliput_malidrive/traffic_control_device/device_type.h"
 
@@ -178,18 +179,46 @@ class TrafficControlDeviceParser {
   /// Loads a traffic control device database from a YAML string.
   ///
   /// @param yaml_content The YAML content as a string.
-  /// @return Map of signal identifiers to their definitions.
-  /// @throws maliput::common::road_network_description_parser_error if YAML parsing fails or schema validation fails.
-  static std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> LoadFromString(
-      const std::string& yaml_content);
+  /// @return Vector of signal definitions. Entries are validated for conflicts at load time.
+  /// @throws maliput::common::road_network_description_parser_error if YAML parsing fails, schema validation
+  ///         fails, or two entries with equal specificity overlap.
+  static std::vector<TrafficControlDeviceDefinition> LoadFromString(const std::string& yaml_content);
 
   /// Loads a traffic control device database from a YAML file.
   ///
   /// @param file_path Path to the YAML database file.
-  /// @return Map of signal identifiers to their definitions.
-  /// @throws maliput::common::road_network_description_parser_error YAML parsing or schema validation fails.
-  static std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> LoadFromFile(
-      const std::string& yaml_file_path);
+  /// @return Vector of signal definitions. Entries are validated for conflicts at load time.
+  /// @throws maliput::common::road_network_description_parser_error if YAML parsing fails, schema validation
+  ///         fails, or two entries with equal specificity overlap.
+  static std::vector<TrafficControlDeviceDefinition> LoadFromFile(const std::string& yaml_file_path);
+
+  /// The wildcard value for traffic control device fingerprint fields.
+  /// A field set to this value matches any query value for that field.
+  static constexpr char kWildcard[] = "*";
+
+  /// Returns true if @p value is the wildcard string.
+  static bool IsWildcard(const std::string& value);
+
+  /// Returns true if @p value is present and equals the wildcard string.
+  static bool IsWildcard(const std::optional<std::string>& value);
+
+  /// Computes the specificity of @p fp: the number of fields that are NOT wildcards.
+  /// @p nullopt counts as specific (constrains to "absent"); only `"*"` is non-specific.
+  /// Returns a value in [0, 4].
+  static int Specificity(const TrafficControlDeviceFingerprint& fp);
+
+  /// Returns true if @p db_entry matches @p query.
+  /// A field in @p db_entry matches the corresponding @p query field if the db_entry field is the
+  /// wildcard string or equals the query field. The @p query is expected to never contain wildcards.
+  static bool Matches(const TrafficControlDeviceFingerprint& db_entry, const TrafficControlDeviceFingerprint& query);
+
+  /// Returns true if there exists at least one input that would match both @p a and @p b.
+  /// Per field: overlap if at least one is wildcard OR both are equal.
+  static bool CanOverlap(const TrafficControlDeviceFingerprint& a, const TrafficControlDeviceFingerprint& b);
+
+ private:
+  /// Builds a vector of definitions from a parsed YAML root node.
+  static std::vector<TrafficControlDeviceDefinition> BuildFrom(const YAML::Node& root);
 };
 
 }  // namespace traffic_control_device

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -28,11 +28,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <maliput/api/rules/traffic_lights.h>
@@ -113,10 +111,12 @@ struct TrafficControlDeviceFingerprint {
   std::optional<std::string> country;
   /// Optional country standard revision.
   std::optional<std::string> country_revision;
+  /// Optional signal name. Matches XODR signal name attribute.
+  std::optional<std::string> name;
 
   bool operator==(const TrafficControlDeviceFingerprint& other) const {
     return type == other.type && subtype == other.subtype && country == other.country &&
-           country_revision == other.country_revision;
+           country_revision == other.country_revision && name == other.name;
   }
   bool operator!=(const TrafficControlDeviceFingerprint& other) const { return !(*this == other); }
 };
@@ -204,7 +204,7 @@ class TrafficControlDeviceParser {
 
   /// Computes the specificity of @p fp: the number of fields that are NOT wildcards.
   /// @p nullopt counts as specific (constrains to "absent"); only `"*"` is non-specific.
-  /// Returns a value in [0, 4].
+  /// Returns a value in [0, 5].
   static int Specificity(const TrafficControlDeviceFingerprint& fp);
 
   /// Returns true if @p db_entry matches @p query.
@@ -223,46 +223,3 @@ class TrafficControlDeviceParser {
 
 }  // namespace traffic_control_device
 }  // namespace malidrive
-
-namespace std {
-
-/// Hash function to use TrafficControlDeviceFingerprint as a key in unordered containers. Combines the hash of each
-/// member variable.
-template <>
-struct hash<malidrive::traffic_control_device::TrafficControlDeviceFingerprint> {
-  size_t operator()(const malidrive::traffic_control_device::TrafficControlDeviceFingerprint& f) const {
-    size_t seed = 0;
-
-    // https://www.boost.org/doc/libs/1_84_0/libs/container_hash/doc/html/hash.html#notes_hash_combine
-    // During the Boost formal review, Dave Harris pointed out that this suffers from the so-called
-    // "zero trap"; if seed is initially 0, and all the inputs are 0 (or hash to 0), seed remains 0 no
-    // matter how many input values are combined.
-    // This is an undesirable property, because it causes containers of zeroes to have a zero hash value
-    // regardless of their sizes.
-    // To fix this, the arbitrary constant 0x9e3779b9 (the golden ratio in a 32 bit fixed point
-    // representation) was added to the computation.
-    auto hash_combine = [&seed](const auto& v) {
-      using T = std::decay_t<decltype(v)>;
-      seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    };
-
-    // 1. Hash the mandatory string.
-    hash_combine(f.type);
-
-    // 2. Hash optionals (only if they have values, otherwise use a constant).
-    auto hash_optional = [&](const auto& opt) {
-      if (opt) {
-        hash_combine(*opt);
-      } else {
-        hash_combine(size_t(0));  // Or any sentinel value
-      }
-    };
-
-    hash_optional(f.subtype);
-    hash_optional(f.country);
-    hash_optional(f.country_revision);
-
-    return seed;
-  }
-};
-}  // namespace std

--- a/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.cc
+++ b/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.cc
@@ -28,6 +28,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
 
+#include <maliput/common/maliput_throw.h>
+
+#include "maliput_malidrive/common/macros.h"
+
 namespace malidrive {
 namespace traffic_control_device {
 
@@ -37,13 +41,37 @@ TrafficControlDeviceDatabaseLoader::TrafficControlDeviceDatabaseLoader(const std
   }
 }
 
+TrafficControlDeviceDatabaseLoader TrafficControlDeviceDatabaseLoader::FromString(const std::string& yaml_content) {
+  TrafficControlDeviceDatabaseLoader loader;
+  loader.definitions_ = TrafficControlDeviceParser::LoadFromString(yaml_content);
+  return loader;
+}
+
 std::optional<TrafficControlDeviceDefinition> TrafficControlDeviceDatabaseLoader::Lookup(
     const TrafficControlDeviceFingerprint& fingerprint) const {
-  const auto it = definitions_.find(fingerprint);
-  if (it == definitions_.end()) {
+  const TrafficControlDeviceDefinition* best = nullptr;
+  int best_specificity = -1;
+
+  for (const auto& def : definitions_) {
+    if (TrafficControlDeviceParser::Matches(def.fingerprint, fingerprint)) {
+      const int specificity = TrafficControlDeviceParser::Specificity(def.fingerprint);
+      if (specificity > best_specificity) {
+        best_specificity = specificity;
+        best = &def;
+      } else if (specificity == best_specificity) {
+        // Two matches with equal specificity should have been caught at load time.
+        MALIDRIVE_THROW_MESSAGE(
+            "Multiple traffic control device database entries with equal specificity matched the "
+            "same query; this indicates a database conflict that was not caught at load time.",
+            maliput::common::road_network_description_parser_error);
+      }
+    }
+  }
+
+  if (best == nullptr) {
     return std::nullopt;
   }
-  return it->second;
+  return *best;
 }
 
 }  // namespace traffic_control_device

--- a/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h
+++ b/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h
@@ -30,7 +30,7 @@
 
 #include <optional>
 #include <string>
-#include <unordered_map>
+#include <vector>
 
 #include "maliput_malidrive/traffic_control_device/parser.h"
 
@@ -42,7 +42,7 @@ namespace traffic_control_device {
 ///
 /// The loader is backed by the @ref TrafficControlDeviceParser. When a file path is
 /// provided at construction time the file is parsed immediately; subsequent
-/// @ref Lookup calls are O(1) map lookups with no additional I/O.
+/// @ref Lookup calls perform a linear scan with specificity ranking.
 ///
 /// If no file path is provided (std::nullopt) the loader starts empty and all
 /// @ref Lookup calls will return std::nullopt.
@@ -57,6 +57,14 @@ class TrafficControlDeviceDatabaseLoader {
   ///         cannot be parsed or fails schema validation.
   explicit TrafficControlDeviceDatabaseLoader(const std::optional<std::string>& file_path);
 
+  /// Constructs a TrafficControlDeviceDatabaseLoader from a YAML string.
+  ///
+  /// @param yaml_content The YAML content as a string.
+  /// @return A TrafficControlDeviceDatabaseLoader instance initialized with the definitions from the YAML content.
+  /// @throws maliput::common::road_network_description_parser_error if the YAML
+  ///         cannot be parsed or fails schema validation.
+  static TrafficControlDeviceDatabaseLoader FromString(const std::string& yaml_content);
+
   /// Looks up a TrafficControlDeviceDefinition by fingerprint.
   ///
   /// @param fingerprint The @ref TrafficControlDeviceFingerprint to look up.
@@ -65,7 +73,8 @@ class TrafficControlDeviceDatabaseLoader {
   std::optional<TrafficControlDeviceDefinition> Lookup(const TrafficControlDeviceFingerprint& fingerprint) const;
 
  private:
-  std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> definitions_;
+  TrafficControlDeviceDatabaseLoader() = default;
+  std::vector<TrafficControlDeviceDefinition> definitions_;
 };
 
 }  // namespace traffic_control_device

--- a/src/maliput_malidrive/traffic_control_device/yaml_helper.h
+++ b/src/maliput_malidrive/traffic_control_device/yaml_helper.h
@@ -50,6 +50,7 @@ struct TrafficControlDeviceConstants {
   static constexpr const char* kSubtype = "subtype";
   static constexpr const char* kCountry = "country";
   static constexpr const char* kCountryRevision = "country_revision";
+  static constexpr const char* kName = "name";
   // properties fields.
   static constexpr const char* kDeviceType = "device_type";
   static constexpr const char* kDeviceSemantics = "device_semantics";

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -884,6 +884,7 @@ odr_signal_types:
       subtype: "*"
       country: "*"
       country_revision: "*"
+      name: "*"
     properties:
       device_type: traffic_sign
       device_semantics: generic
@@ -990,76 +991,157 @@ GTEST_TEST(WildcardParsingTest, AllFieldsStoredAsLiteralAsterisk) {
   EXPECT_EQ(defs[0].fingerprint.subtype, "*");
   EXPECT_EQ(defs[0].fingerprint.country, "*");
   EXPECT_EQ(defs[0].fingerprint.country_revision, "*");
+  EXPECT_EQ(defs[0].fingerprint.name, "*");
 }
 
 GTEST_TEST(SpecificityCalculationTest, AllConcrete) {
   const TrafficControlDeviceFingerprint fp{
-      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = "2020"};
-  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 4);
+      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = "2020", .name = "TrafficLight"};
+  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 5);
 }
 
 GTEST_TEST(SpecificityCalculationTest, AllWildcards) {
-  const TrafficControlDeviceFingerprint fp{.type = "*", .subtype = "*", .country = "*", .country_revision = "*"};
+  const TrafficControlDeviceFingerprint fp{
+      .type = "*", .subtype = "*", .country = "*", .country_revision = "*", .name = "*"};
   EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 0);
 }
 
 GTEST_TEST(SpecificityCalculationTest, NulloptIsSpecific) {
-  const TrafficControlDeviceFingerprint fp{
-      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
-  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 4);
+  const TrafficControlDeviceFingerprint fp{.type = "1000001",
+                                           .subtype = std::nullopt,
+                                           .country = std::nullopt,
+                                           .country_revision = std::nullopt,
+                                           .name = std::nullopt};
+  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 5);
 }
 
 GTEST_TEST(SpecificityCalculationTest, Mixed) {
-  // type concrete, subtype wildcard, country concrete, country_revision nullopt -> 3
-  const TrafficControlDeviceFingerprint fp{
-      .type = "1000001", .subtype = "*", .country = "OpenDRIVE", .country_revision = std::nullopt};
-  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 3);
+  // type concrete, subtype wildcard, country concrete, country_revision nullopt, name nullopt -> 4
+  const TrafficControlDeviceFingerprint fp{.type = "1000001",
+                                           .subtype = "*",
+                                           .country = "OpenDRIVE",
+                                           .country_revision = std::nullopt,
+                                           .name = std::nullopt};
+  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 4);
 }
 
 GTEST_TEST(MatchingLogicTest, ExactMatchReturnsTrue) {
-  const TrafficControlDeviceFingerprint db_entry{
-      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
-  const TrafficControlDeviceFingerprint query{
-      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint db_entry{.type = "1000001",
+                                                 .subtype = "10",
+                                                 .country = "OpenDRIVE",
+                                                 .country_revision = std::nullopt,
+                                                 .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query{.type = "1000001",
+                                              .subtype = "10",
+                                              .country = "OpenDRIVE",
+                                              .country_revision = std::nullopt,
+                                              .name = std::nullopt};
   EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query));
 }
 
 GTEST_TEST(MatchingLogicTest, WildcardTypeMatchesAny) {
-  const TrafficControlDeviceFingerprint db_entry{
-      .type = "*", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
-  const TrafficControlDeviceFingerprint query{
-      .type = "anything", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint db_entry{.type = "*",
+                                                 .subtype = std::nullopt,
+                                                 .country = std::nullopt,
+                                                 .country_revision = std::nullopt,
+                                                 .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query{.type = "anything",
+                                              .subtype = std::nullopt,
+                                              .country = std::nullopt,
+                                              .country_revision = std::nullopt,
+                                              .name = std::nullopt};
   EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query));
 }
 
 GTEST_TEST(MatchingLogicTest, WildcardSubtypeMatchesPresentAndNullopt) {
-  const TrafficControlDeviceFingerprint db_entry{
-      .type = "1000001", .subtype = "*", .country = std::nullopt, .country_revision = std::nullopt};
-  const TrafficControlDeviceFingerprint query_with_subtype{
-      .type = "1000001", .subtype = "10", .country = std::nullopt, .country_revision = std::nullopt};
-  const TrafficControlDeviceFingerprint query_nullopt_subtype{
-      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint db_entry{.type = "1000001",
+                                                 .subtype = "*",
+                                                 .country = std::nullopt,
+                                                 .country_revision = std::nullopt,
+                                                 .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query_with_subtype{.type = "1000001",
+                                                           .subtype = "10",
+                                                           .country = std::nullopt,
+                                                           .country_revision = std::nullopt,
+                                                           .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query_nullopt_subtype{.type = "1000001",
+                                                              .subtype = "10",
+                                                              .country = std::nullopt,
+                                                              .country_revision = std::nullopt,
+                                                              .name = std::nullopt};
   EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_with_subtype));
   EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_nullopt_subtype));
 }
 
 GTEST_TEST(MatchingLogicTest, NulloptSubtypeOnlyMatchesNullopt) {
-  const TrafficControlDeviceFingerprint db_entry{
-      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
-  const TrafficControlDeviceFingerprint query_nullopt{
-      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
-  const TrafficControlDeviceFingerprint query_concrete{
-      .type = "1000001", .subtype = "10", .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint db_entry{.type = "1000001",
+                                                 .subtype = std::nullopt,
+                                                 .country = std::nullopt,
+                                                 .country_revision = std::nullopt,
+                                                 .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query_nullopt{.type = "1000001",
+                                                      .subtype = std::nullopt,
+                                                      .country = std::nullopt,
+                                                      .country_revision = std::nullopt,
+                                                      .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query_concrete{.type = "1000001",
+                                                       .subtype = "10",
+                                                       .country = std::nullopt,
+                                                       .country_revision = std::nullopt,
+                                                       .name = std::nullopt};
   EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_nullopt));
   EXPECT_FALSE(TrafficControlDeviceParser::Matches(db_entry, query_concrete));
 }
 
 GTEST_TEST(MatchingLogicTest, ConcreteMismatchReturnsFalse) {
-  const TrafficControlDeviceFingerprint db_entry{
-      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
-  const TrafficControlDeviceFingerprint query{
-      .type = "1000002", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint db_entry{.type = "1000001",
+                                                 .subtype = "10",
+                                                 .country = "OpenDRIVE",
+                                                 .country_revision = std::nullopt,
+                                                 .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query{.type = "1000002",
+                                              .subtype = "10",
+                                              .country = "OpenDRIVE",
+                                              .country_revision = std::nullopt,
+                                              .name = std::nullopt};
   EXPECT_FALSE(TrafficControlDeviceParser::Matches(db_entry, query));
+}
+
+GTEST_TEST(MatchingLogicTest, WildcardNameMatchesPresentAndNullopt) {
+  const TrafficControlDeviceFingerprint db_entry{.type = "1000001",
+                                                 .subtype = std::nullopt,
+                                                 .country = std::nullopt,
+                                                 .country_revision = std::nullopt,
+                                                 .name = "*"};
+  const TrafficControlDeviceFingerprint query_with_name{.type = "1000001",
+                                                        .subtype = std::nullopt,
+                                                        .country = std::nullopt,
+                                                        .country_revision = std::nullopt,
+                                                        .name = "stop_sign"};
+  const TrafficControlDeviceFingerprint query_nullopt_name{
+      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_with_name));
+  EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_nullopt_name));
+}
+
+GTEST_TEST(MatchingLogicTest, NulloptNameOnlyMatchesNullopt) {
+  const TrafficControlDeviceFingerprint db_entry{.type = "1000001",
+                                                 .subtype = std::nullopt,
+                                                 .country = std::nullopt,
+                                                 .country_revision = std::nullopt,
+                                                 .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query_nullopt{.type = "1000001",
+                                                      .subtype = std::nullopt,
+                                                      .country = std::nullopt,
+                                                      .country_revision = std::nullopt,
+                                                      .name = std::nullopt};
+  const TrafficControlDeviceFingerprint query_with_name{.type = "1000001",
+                                                        .subtype = std::nullopt,
+                                                        .country = std::nullopt,
+                                                        .country_revision = std::nullopt,
+                                                        .name = "stop_sign"};
+  EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_nullopt));
+  EXPECT_FALSE(TrafficControlDeviceParser::Matches(db_entry, query_with_name));
 }
 
 GTEST_TEST(ConflictDetectionTest, EqualSpecificityOverlapThrows) {
@@ -1073,8 +1155,11 @@ GTEST_TEST(ConflictDetectionTest, DifferentSpecificityOverlapDoesNotThrow) {
 
 GTEST_TEST(WildcardLookupTest, ExactMatchPreferredOverWildcard) {
   const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kWildcardLookupDb);
-  const TrafficControlDeviceFingerprint query{
-      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query{.type = "1000001",
+                                              .subtype = "10",
+                                              .country = "OpenDRIVE",
+                                              .country_revision = std::nullopt,
+                                              .name = std::nullopt};
   const auto result = loader.Lookup(query);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "exact_match");
@@ -1082,8 +1167,11 @@ GTEST_TEST(WildcardLookupTest, ExactMatchPreferredOverWildcard) {
 
 GTEST_TEST(WildcardLookupTest, PartialWildcardPreferredOverCatchAll) {
   const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kWildcardLookupDb);
-  const TrafficControlDeviceFingerprint query{
-      .type = "1000001", .subtype = "99", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query{.type = "1000001",
+                                              .subtype = "99",
+                                              .country = "OpenDRIVE",
+                                              .country_revision = std::nullopt,
+                                              .name = std::nullopt};
   const auto result = loader.Lookup(query);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "partial_wildcard");
@@ -1091,8 +1179,11 @@ GTEST_TEST(WildcardLookupTest, PartialWildcardPreferredOverCatchAll) {
 
 GTEST_TEST(WildcardLookupTest, FallbackToCatchAll) {
   const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kWildcardLookupDb);
-  const TrafficControlDeviceFingerprint query{
-      .type = "9999999", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query{.type = "9999999",
+                                              .subtype = std::nullopt,
+                                              .country = std::nullopt,
+                                              .country_revision = std::nullopt,
+                                              .name = std::nullopt};
   const auto result = loader.Lookup(query);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "catch_all");
@@ -1100,19 +1191,54 @@ GTEST_TEST(WildcardLookupTest, FallbackToCatchAll) {
 
 GTEST_TEST(WildcardLookupTest, NoMatchReturnsNullopt) {
   const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kTrafficControlDeviceDb);
-  const TrafficControlDeviceFingerprint query{
-      .type = "9999999", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query{.type = "9999999",
+                                              .subtype = std::nullopt,
+                                              .country = std::nullopt,
+                                              .country_revision = std::nullopt,
+                                              .name = std::nullopt};
   const auto result = loader.Lookup(query);
   EXPECT_FALSE(result.has_value());
 }
 
 GTEST_TEST(WildcardLookupTest, CatchAllMatchesAnyQuery) {
   const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kWildcardParsingDb);
-  const TrafficControlDeviceFingerprint query{
-      .type = "any_type", .subtype = "any_subtype", .country = "any_country", .country_revision = "rev1"};
+  const TrafficControlDeviceFingerprint query{.type = "any_type",
+                                              .subtype = "any_subtype",
+                                              .country = "any_country",
+                                              .country_revision = "rev1",
+                                              .name = "any_name"};
   const auto result = loader.Lookup(query);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "generic");
+}
+
+GTEST_TEST(WildcardLookupTest, ConcreteNameWinsOverWildcardName) {
+  const char kNameLookupDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      name: "stop_sign"
+    properties:
+      device_type: traffic_sign
+      device_semantics: concrete_name
+      description: "Concrete name entry"
+      bulbs: []
+      rule_states: []
+  - odr_representation:
+      type: "1000001"
+      name: "*"
+    properties:
+      device_type: traffic_sign
+      device_semantics: wildcard_name
+      description: "Wildcard name entry"
+      bulbs: []
+      rule_states: []
+)";
+  const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kNameLookupDb);
+  const TrafficControlDeviceFingerprint query{.type = "1000001", .name = "stop_sign"};
+  const auto result = loader.Lookup(query);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->device_semantics, "concrete_name");
 }
 
 }  // namespace

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -28,11 +28,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/traffic_control_device/parser.h"
 
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 
 #include <gtest/gtest.h>
+#include <maliput/common/maliput_throw.h>
 
+#include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
 #include "utility/resources.h"
 
 namespace malidrive {
@@ -202,17 +205,24 @@ odr_signal_types:
           value: "Stop"
 )";
 
+// Returns a pointer to the first definition whose fingerprint equals @p fp, or nullptr if not found.
+const TrafficControlDeviceDefinition* FindDefinition(const std::vector<TrafficControlDeviceDefinition>& defs,
+                                                     const TrafficControlDeviceFingerprint& fp) {
+  const auto it = std::find_if(defs.begin(), defs.end(),
+                               [&fp](const TrafficControlDeviceDefinition& d) { return d.fingerprint == fp; });
+  return it != defs.end() ? &(*it) : nullptr;
+}
+
 class TrafficControlDeviceParserTest : public ::testing::Test {
  public:
   static void SetUpTestCase() {
     signal_definitions_ = TrafficControlDeviceParser::LoadFromString(kTrafficControlDeviceDb);
   }
-  static std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition> signal_definitions_;
+  static std::vector<TrafficControlDeviceDefinition> signal_definitions_;
 };
 
 // Needed to allocate memory for static member variable.
-std::unordered_map<TrafficControlDeviceFingerprint, TrafficControlDeviceDefinition>
-    TrafficControlDeviceParserTest::signal_definitions_;
+std::vector<TrafficControlDeviceDefinition> TrafficControlDeviceParserTest::signal_definitions_;
 
 TEST_F(TrafficControlDeviceParserTest, LoadFromString) {
   EXPECT_EQ(signal_definitions_.size(), 4);
@@ -228,8 +238,8 @@ TEST_F(TrafficControlDeviceParserTest, LoadFromString) {
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
   };
-  EXPECT_TRUE(signal_definitions_.find(standard_fingerprint) != signal_definitions_.end());
-  EXPECT_TRUE(signal_definitions_.find(arrow_fingerprint) != signal_definitions_.end());
+  EXPECT_NE(FindDefinition(signal_definitions_, standard_fingerprint), nullptr);
+  EXPECT_NE(FindDefinition(signal_definitions_, arrow_fingerprint), nullptr);
 }
 
 TEST_F(TrafficControlDeviceParserTest, ValidateTrafficSign) {
@@ -239,7 +249,9 @@ TEST_F(TrafficControlDeviceParserTest, ValidateTrafficSign) {
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
   };
-  const auto& dut = signal_definitions_.at(sign_fingerprint);
+  const auto* dut_ptr = FindDefinition(signal_definitions_, sign_fingerprint);
+  ASSERT_NE(dut_ptr, nullptr);
+  const auto& dut = *dut_ptr;
 
   EXPECT_EQ(dut.fingerprint.type, "206");
   EXPECT_EQ(dut.fingerprint.subtype, "30");
@@ -261,7 +273,9 @@ TEST_F(TrafficControlDeviceParserTest, ValidateSignalType1000001) {
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
   };
-  const auto& dut = signal_definitions_.at(fingerprint);
+  const auto* dut_ptr = FindDefinition(signal_definitions_, fingerprint);
+  ASSERT_NE(dut_ptr, nullptr);
+  const auto& dut = *dut_ptr;
 
   EXPECT_EQ(dut.fingerprint.type, "1000001");
   EXPECT_EQ(dut.fingerprint.subtype, std::nullopt);
@@ -296,7 +310,9 @@ TEST_F(TrafficControlDeviceParserTest, ValidateArrowSignal) {
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
   };
-  const auto& dut = signal_definitions_.at(arrow_fingerprint);
+  const auto* dut_ptr = FindDefinition(signal_definitions_, arrow_fingerprint);
+  ASSERT_NE(dut_ptr, nullptr);
+  const auto& dut = *dut_ptr;
 
   EXPECT_EQ(dut.fingerprint.type, "1000011");
   EXPECT_EQ(dut.fingerprint.subtype, "10");
@@ -319,7 +335,9 @@ TEST_F(TrafficControlDeviceParserTest, DefaultBulbStatesAndBoundingBox) {
       .country = std::nullopt,
       .country_revision = std::nullopt,
   };
-  const auto& dut = signal_definitions_.at(default_fingerprint);
+  const auto* dut_ptr = FindDefinition(signal_definitions_, default_fingerprint);
+  ASSERT_NE(dut_ptr, nullptr);
+  const auto& dut = *dut_ptr;
 
   EXPECT_EQ(dut.fingerprint.type, "default_bulb_state");
   EXPECT_EQ(dut.description, "Signal with default bulb states and bounding box");
@@ -346,21 +364,9 @@ TEST_F(TrafficControlDeviceParserTest, DefaultBulbStatesAndBoundingBox) {
   EXPECT_NEAR(default_bulb.bounding_box.p_BMax.z(), 0.1778, kTolerance);
 }
 
-GTEST_TEST(RepeatedTrafficControlDeviceParserTest, RepeatedFingerprintOverwrites) {
-  const auto signal_definitions = TrafficControlDeviceParser::LoadFromString(kRepeatedTrafficControlDeviceDb);
-  EXPECT_EQ(signal_definitions.size(), 1);
-  const TrafficControlDeviceFingerprint fingerprint{
-      .type = "1234567",
-      .subtype = "11",
-      .country = "OpenDRIVE",
-      .country_revision = std::nullopt,
-  };
-  EXPECT_TRUE(signal_definitions.find(fingerprint) != signal_definitions.end());
-  const auto& definition = signal_definitions.at(fingerprint);
-  EXPECT_EQ(definition.description, "Single green bulb traffic light");
-  EXPECT_EQ(definition.device_type, traffic_control_device::TrafficControlDeviceType::kTrafficLight);
-  EXPECT_EQ(definition.bulbs.size(), 1);
-  EXPECT_EQ(definition.bulbs[0].id, "GreenBulb");
+GTEST_TEST(RepeatedTrafficControlDeviceParserTest, RepeatedFingerprintThrows) {
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kRepeatedTrafficControlDeviceDb),
+               maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(TrafficControlDeviceYamlFileParserTest, LoadFromFile) {
@@ -865,6 +871,248 @@ GTEST_TEST(TrafficControlDeviceDefinitionEqualityOperatorTest, DifferentRuleStat
   };
   EXPECT_NE(definition1, definition2);
   EXPECT_TRUE(definition1 != definition2);
+}
+
+// ---------------------------------------------------------------------------
+// YAML fixtures for wildcard / specificity / lookup tests
+// ---------------------------------------------------------------------------
+
+const char kWildcardParsingDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "*"
+      subtype: "*"
+      country: "*"
+      country_revision: "*"
+    properties:
+      device_type: traffic_sign
+      device_semantics: generic
+      description: "All-wildcard entry"
+      bulbs: []
+      rule_states: []
+)";
+
+const char kConflictingDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      subtype: "*"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      device_semantics: generic
+      description: "Entry A"
+      bulbs: []
+      rule_states: []
+  - odr_representation:
+      type: "1000001"
+      subtype: "*"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      device_semantics: generic
+      description: "Entry B"
+      bulbs: []
+      rule_states: []
+)";
+
+const char kDifferentSpecificityDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      subtype: "*"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      device_semantics: more_specific
+      description: "More specific entry"
+      bulbs: []
+      rule_states: []
+  - odr_representation:
+      type: "1000001"
+      subtype: "*"
+      country: "*"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      device_semantics: less_specific
+      description: "Less specific entry"
+      bulbs: []
+      rule_states: []
+)";
+
+const char kWildcardLookupDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      subtype: "10"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      device_semantics: exact_match
+      description: "Exact match entry"
+      bulbs: []
+      rule_states: []
+  - odr_representation:
+      type: "1000001"
+      subtype: "*"
+      country: "OpenDRIVE"
+      country_revision: null
+    properties:
+      device_type: traffic_sign
+      device_semantics: partial_wildcard
+      description: "Partial wildcard entry"
+      bulbs: []
+      rule_states: []
+  - odr_representation:
+      type: "*"
+      subtype: "*"
+      country: "*"
+      country_revision: "*"
+    properties:
+      device_type: traffic_sign
+      device_semantics: catch_all
+      description: "Catch-all entry"
+      bulbs: []
+      rule_states: []
+)";
+
+// ---- Step 5: New wildcard / specificity / conflict / lookup tests ----
+
+GTEST_TEST(WildcardParsingTest, AllFieldsStoredAsLiteralAsterisk) {
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kWildcardParsingDb);
+  ASSERT_EQ(defs.size(), 1u);
+  EXPECT_EQ(defs[0].fingerprint.type, "*");
+  EXPECT_EQ(defs[0].fingerprint.subtype, "*");
+  EXPECT_EQ(defs[0].fingerprint.country, "*");
+  EXPECT_EQ(defs[0].fingerprint.country_revision, "*");
+}
+
+GTEST_TEST(SpecificityCalculationTest, AllConcrete) {
+  const TrafficControlDeviceFingerprint fp{
+      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = "2020"};
+  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 4);
+}
+
+GTEST_TEST(SpecificityCalculationTest, AllWildcards) {
+  const TrafficControlDeviceFingerprint fp{.type = "*", .subtype = "*", .country = "*", .country_revision = "*"};
+  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 0);
+}
+
+GTEST_TEST(SpecificityCalculationTest, NulloptIsSpecific) {
+  const TrafficControlDeviceFingerprint fp{
+      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 4);
+}
+
+GTEST_TEST(SpecificityCalculationTest, Mixed) {
+  // type concrete, subtype wildcard, country concrete, country_revision nullopt -> 3
+  const TrafficControlDeviceFingerprint fp{
+      .type = "1000001", .subtype = "*", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  EXPECT_EQ(TrafficControlDeviceParser::Specificity(fp), 3);
+}
+
+GTEST_TEST(MatchingLogicTest, ExactMatchReturnsTrue) {
+  const TrafficControlDeviceFingerprint db_entry{
+      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query{
+      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query));
+}
+
+GTEST_TEST(MatchingLogicTest, WildcardTypeMatchesAny) {
+  const TrafficControlDeviceFingerprint db_entry{
+      .type = "*", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query{
+      .type = "anything", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query));
+}
+
+GTEST_TEST(MatchingLogicTest, WildcardSubtypeMatchesPresentAndNullopt) {
+  const TrafficControlDeviceFingerprint db_entry{
+      .type = "1000001", .subtype = "*", .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query_with_subtype{
+      .type = "1000001", .subtype = "10", .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query_nullopt_subtype{
+      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_with_subtype));
+  EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_nullopt_subtype));
+}
+
+GTEST_TEST(MatchingLogicTest, NulloptSubtypeOnlyMatchesNullopt) {
+  const TrafficControlDeviceFingerprint db_entry{
+      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query_nullopt{
+      .type = "1000001", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query_concrete{
+      .type = "1000001", .subtype = "10", .country = std::nullopt, .country_revision = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::Matches(db_entry, query_nullopt));
+  EXPECT_FALSE(TrafficControlDeviceParser::Matches(db_entry, query_concrete));
+}
+
+GTEST_TEST(MatchingLogicTest, ConcreteMismatchReturnsFalse) {
+  const TrafficControlDeviceFingerprint db_entry{
+      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  const TrafficControlDeviceFingerprint query{
+      .type = "1000002", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  EXPECT_FALSE(TrafficControlDeviceParser::Matches(db_entry, query));
+}
+
+GTEST_TEST(ConflictDetectionTest, EqualSpecificityOverlapThrows) {
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kConflictingDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(ConflictDetectionTest, DifferentSpecificityOverlapDoesNotThrow) {
+  EXPECT_NO_THROW(TrafficControlDeviceParser::LoadFromString(kDifferentSpecificityDb));
+}
+
+GTEST_TEST(WildcardLookupTest, ExactMatchPreferredOverWildcard) {
+  const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kWildcardLookupDb);
+  const TrafficControlDeviceFingerprint query{
+      .type = "1000001", .subtype = "10", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  const auto result = loader.Lookup(query);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->device_semantics, "exact_match");
+}
+
+GTEST_TEST(WildcardLookupTest, PartialWildcardPreferredOverCatchAll) {
+  const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kWildcardLookupDb);
+  const TrafficControlDeviceFingerprint query{
+      .type = "1000001", .subtype = "99", .country = "OpenDRIVE", .country_revision = std::nullopt};
+  const auto result = loader.Lookup(query);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->device_semantics, "partial_wildcard");
+}
+
+GTEST_TEST(WildcardLookupTest, FallbackToCatchAll) {
+  const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kWildcardLookupDb);
+  const TrafficControlDeviceFingerprint query{
+      .type = "9999999", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const auto result = loader.Lookup(query);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->device_semantics, "catch_all");
+}
+
+GTEST_TEST(WildcardLookupTest, NoMatchReturnsNullopt) {
+  const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kTrafficControlDeviceDb);
+  const TrafficControlDeviceFingerprint query{
+      .type = "9999999", .subtype = std::nullopt, .country = std::nullopt, .country_revision = std::nullopt};
+  const auto result = loader.Lookup(query);
+  EXPECT_FALSE(result.has_value());
+}
+
+GTEST_TEST(WildcardLookupTest, CatchAllMatchesAnyQuery) {
+  const auto loader = TrafficControlDeviceDatabaseLoader::FromString(kWildcardParsingDb);
+  const TrafficControlDeviceFingerprint query{
+      .type = "any_type", .subtype = "any_subtype", .country = "any_country", .country_revision = "rev1"};
+  const auto result = loader.Lookup(query);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->device_semantics, "generic");
 }
 
 }  // namespace

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -874,6 +874,159 @@ GTEST_TEST(TrafficControlDeviceDefinitionEqualityOperatorTest, DifferentRuleStat
 }
 
 // ---------------------------------------------------------------------------
+// IsWildcard tests
+// ---------------------------------------------------------------------------
+
+GTEST_TEST(IsWildcardStringTest, WildcardStringReturnsTrue) {
+  EXPECT_TRUE(TrafficControlDeviceParser::IsWildcard(std::string("*")));
+}
+
+GTEST_TEST(IsWildcardStringTest, NonWildcardStringReturnsFalse) {
+  EXPECT_FALSE(TrafficControlDeviceParser::IsWildcard(std::string("1000001")));
+}
+
+GTEST_TEST(IsWildcardStringTest, EmptyStringReturnsFalse) {
+  EXPECT_FALSE(TrafficControlDeviceParser::IsWildcard(std::string("")));
+}
+
+GTEST_TEST(IsWildcardOptionalTest, PresentWildcardReturnsTrue) {
+  EXPECT_TRUE(TrafficControlDeviceParser::IsWildcard(std::optional<std::string>{"*"}));
+}
+
+GTEST_TEST(IsWildcardOptionalTest, NulloptReturnsFalse) {
+  EXPECT_FALSE(TrafficControlDeviceParser::IsWildcard(std::optional<std::string>{std::nullopt}));
+}
+
+GTEST_TEST(IsWildcardOptionalTest, PresentNonWildcardReturnsFalse) {
+  EXPECT_FALSE(TrafficControlDeviceParser::IsWildcard(std::optional<std::string>{"OpenDRIVE"}));
+}
+
+// ---------------------------------------------------------------------------
+// CanOverlap tests
+// ---------------------------------------------------------------------------
+
+GTEST_TEST(CanOverlapTest, BothAllWildcardsOverlap) {
+  const TrafficControlDeviceFingerprint a{
+      .type = "*", .subtype = "*", .country = "*", .country_revision = "*", .name = "*"};
+  const TrafficControlDeviceFingerprint b{
+      .type = "*", .subtype = "*", .country = "*", .country_revision = "*", .name = "*"};
+  EXPECT_TRUE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+GTEST_TEST(CanOverlapTest, SameConcreteValuesOverlap) {
+  const TrafficControlDeviceFingerprint a{.type = "1000001",
+                                          .subtype = "10",
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  const TrafficControlDeviceFingerprint b{.type = "1000001",
+                                          .subtype = "10",
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+GTEST_TEST(CanOverlapTest, WildcardOnOneSideOverlapsConcreteOnOtherSide) {
+  const TrafficControlDeviceFingerprint a{.type = "1000001",
+                                          .subtype = "*",
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  const TrafficControlDeviceFingerprint b{.type = "1000001",
+                                          .subtype = "10",
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+GTEST_TEST(CanOverlapTest, WildcardOnOneSideOverlapsNulloptOnOtherSide) {
+  const TrafficControlDeviceFingerprint a{.type = "1000001",
+                                          .subtype = "*",
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  const TrafficControlDeviceFingerprint b{.type = "1000001",
+                                          .subtype = std::nullopt,
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+GTEST_TEST(CanOverlapTest, DifferentConcreteValuesOnOneFieldNoOverlap) {
+  const TrafficControlDeviceFingerprint a{.type = "1000001",
+                                          .subtype = "10",
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  const TrafficControlDeviceFingerprint b{.type = "9999999",
+                                          .subtype = "10",
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  EXPECT_FALSE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+GTEST_TEST(CanOverlapTest, ConcreteVsNulloptOnSameFieldNoOverlap) {
+  // subtype = "10" vs subtype = nullopt: neither is a wildcard and they differ.
+  const TrafficControlDeviceFingerprint a{.type = "1000001",
+                                          .subtype = "10",
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  const TrafficControlDeviceFingerprint b{.type = "1000001",
+                                          .subtype = std::nullopt,
+                                          .country = "OpenDRIVE",
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  EXPECT_FALSE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+GTEST_TEST(CanOverlapTest, BothNulloptOnFieldOverlap) {
+  const TrafficControlDeviceFingerprint a{.type = "1000001",
+                                          .subtype = std::nullopt,
+                                          .country = std::nullopt,
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  const TrafficControlDeviceFingerprint b{.type = "1000001",
+                                          .subtype = std::nullopt,
+                                          .country = std::nullopt,
+                                          .country_revision = std::nullopt,
+                                          .name = std::nullopt};
+  EXPECT_TRUE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+GTEST_TEST(CanOverlapTest, NameFieldDifferencePreventsOverlap) {
+  const TrafficControlDeviceFingerprint a{.type = "1000001",
+                                          .subtype = std::nullopt,
+                                          .country = std::nullopt,
+                                          .country_revision = std::nullopt,
+                                          .name = "stop_sign"};
+  const TrafficControlDeviceFingerprint b{.type = "1000001",
+                                          .subtype = std::nullopt,
+                                          .country = std::nullopt,
+                                          .country_revision = std::nullopt,
+                                          .name = "yield_sign"};
+  EXPECT_FALSE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+GTEST_TEST(CanOverlapTest, WildcardNameOverlapsAnyName) {
+  const TrafficControlDeviceFingerprint a{.type = "1000001",
+                                          .subtype = std::nullopt,
+                                          .country = std::nullopt,
+                                          .country_revision = std::nullopt,
+                                          .name = "*"};
+  const TrafficControlDeviceFingerprint b{.type = "1000001",
+                                          .subtype = std::nullopt,
+                                          .country = std::nullopt,
+                                          .country_revision = std::nullopt,
+                                          .name = "stop_sign"};
+  EXPECT_TRUE(TrafficControlDeviceParser::CanOverlap(a, b));
+}
+
+// ---------------------------------------------------------------------------
 // YAML fixtures for wildcard / specificity / lookup tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# 🎉 New feature

Closes #453 

## Summary
* Support wildcard matching for the `odr_description` elements in the `TrafficControlDevice` database.
  * These include `type`, `subtype`, `country` and `country_revision`.
  * Wildcard matching occurs exclusively if the field is marked as `"*"`.
  * Omitted optional fields do not count as wildcards, nor do `null` fields.
* Add `name` as part of the `odr_description` for finer match against OpenDRIVE signals.
* Support wildcard matching against `name`.
* Matching is based on the most specific match found. 
  * So if a lookup returns multiple matches, the one with the most specificity (least amount of wildcards) will be returned.
  * In consequence, if 2 or more matches have equal max specificity, the database will be rejected on load time.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
