### PR TITLE
Implement TrafficSign::GetValue interface.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ install (FILES resources/ArcLane.xodr
                resources/TShapeRoad.yaml
                resources/TwoRoadsWithTrafficLights.xodr
                resources/TwoRoadsWithTrafficSigns.xodr
+               resources/SingleRoadWithSpeedLimit.xodr
                resources/TwoWayRoadWithDoubleYellowCurve.xodr
          DESTINATION ${OPENDRIVE_SAMPLES_PATH})
 

--- a/resources/SingleRoadWithSpeedLimit.xodr
+++ b/resources/SingleRoadWithSpeedLimit.xodr
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2026, Woven by Toyota. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+ Single straight road with a speed-limit sign that carries a value and unit.
+
+ Road layout (viewed from above):
+
+     Road 1 (200 m, hdg=0)
+   ========================
+        lane 1
+   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+   (0,0) ──────── (200,0)
+   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+        lane -1
+   ========================
+       SL1 at s=100
+
+ Signal SL1 (on road 1):
+   - type="274", subtype="-1", country="OpenDRIVE", orientation="+"
+   - s=100, t=3, zOffset=2.5, value="60", unit="km/h"
+   - validity: fromLane=-1 toLane=-1
+
+ Expected maliput lane IDs:
+   Road 1: "1_0_1" (left), "1_0_-1" (right)
+
+ Expected TrafficSign:
+   - id: "SL1"
+   - type: kSpeedLimit
+   - GetValue(): TrafficSignValue{60.0, TrafficSignValueUnit::kKilometersPerHour}
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="4" name="SingleRoadWithSpeedLimit"/>
+    <road name="Road 1" length="2.0000000000000000e+2" id="1" junction="-1">
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="0.0000000000000000e+0" y="0.0000000000000000e+0" hdg="0.0000000000000000e+0" length="2.0000000000000000e+2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false"/>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <signal id="SL1" name="SpeedLimit60" s="1.0000000000000000e+2" t="3.0000000000000000e+0"
+                    zOffset="2.5000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="274" subtype="-1" value="60" unit="km/h"
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"
+                    text="60">
+                <validity fromLane="-1" toLane="-1"/>
+            </signal>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/resources/traffic_control_device_db/testing_database.yaml
+++ b/resources/traffic_control_device_db/testing_database.yaml
@@ -1,0 +1,47 @@
+# -*- yaml -*-
+#
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Woven by Toyota. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+odr_signal_types:
+  # Speed limit sign (static traffic sign).
+  - odr_representation:
+      type: "274"
+      subtype: "*"
+      country: "OpenDRIVE"
+      country_revision: null
+      name: "*"
+    properties:
+      device_type: traffic_sign
+      device_semantics: speed_limit
+      description: "Speed limit sign. Indicates the maximum permitted speed."
+
+      rule_states:
+        - conditions: []
+          value: "SpeedLimit"

--- a/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
+++ b/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
@@ -299,3 +299,19 @@ odr_signal_types:
       rule_states:
         - conditions: []
           value: ""
+
+  # Speed limit sign (static traffic sign).
+  - odr_representation:
+      type: "274"
+      subtype: "*"
+      country: "OpenDRIVE"
+      country_revision: null
+      name: "*"
+    properties:
+      device_type: traffic_sign
+      device_semantics: speed_limit
+      description: "Speed limit sign. Indicates the maximum permitted speed."
+
+      rule_states:
+        - conditions: []
+          value: "SpeedLimit"

--- a/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
+++ b/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
@@ -299,19 +299,3 @@ odr_signal_types:
       rule_states:
         - conditions: []
           value: ""
-
-  # Speed limit sign (static traffic sign).
-  - odr_representation:
-      type: "274"
-      subtype: "*"
-      country: "OpenDRIVE"
-      country_revision: null
-      name: "*"
-    properties:
-      device_type: traffic_sign
-      device_semantics: speed_limit
-      description: "Speed limit sign. Indicates the maximum permitted speed."
-
-      rule_states:
-        - conditions: []
-          value: "SpeedLimit"

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -66,6 +66,19 @@ std::optional<std::string> NormalizeSubtype(const std::string& subtype) {
   return subtype;
 }
 
+/// Maps a string to a TrafficSignValueUnit enum value.
+/// @param unit_string The string representation of the unit.
+/// @return The corresponding TrafficSignValueUnit enum value or std::nullopt if the string does not map to any Unit.
+std::optional<maliput::api::rules::TrafficSignValueUnit> StringToValueUnit(const std::string& unit_string) {
+  const auto mapper = maliput::api::rules::TrafficSignValueUnitMapper();
+  for (const auto& pair : mapper) {
+    if (pair.second == unit_string) {
+      return std::make_optional(pair.first);
+    }
+  }
+  return std::nullopt;
+}
+
 }  // namespace
 
 TrafficSignBuilder::TrafficSignBuilder(const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
@@ -137,6 +150,19 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
                                                 maliput::math::Vector3(depth, width, height),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
+  // Map the XODR signal value/unit pair to a TrafficSignValue, if present.
+  // A value of -1.0 is the XODR sentinel for "no value" and is skipped.
+  std::optional<maliput::api::rules::TrafficSignValue> traffic_sign_value;
+  if (signal_.value.has_value() && signal_.value->value != -1.0) {
+    const auto mapped_unit = StringToValueUnit(signal_.value->unit);
+    if (!mapped_unit.has_value()) {
+      MALIDRIVE_THROW_MESSAGE("TrafficSignBuilder: signal id='" + signal_.id.string() +
+                                  "' has value attribute with unrecognized unit '" + signal_.value->unit + "'.",
+                              maliput::common::road_network_description_parser_error);
+    }
+    traffic_sign_value = maliput::api::rules::TrafficSignValue{signal_.value->value, mapped_unit.value()};
+  }
+
   maliput::log()->debug("TrafficSignBuilder: creating TrafficSign for signal id='", signal_.id.string(), "' type='",
                         signal_.type, "' subtype='", signal_.subtype, "' device_semantics='",
                         definition.device_semantics.value_or("other"), "'. TrafficSign position: (x=", pos.x(),
@@ -146,7 +172,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
 
   return std::make_unique<maliput::api::rules::TrafficSign>(maliput::api::rules::TrafficSign::Id(signal_.id.string()),
                                                             sign_meaning, pos, orientation_road_network, signal_.text,
-                                                            std::move(related_lanes), bounding_box);
+                                                            std::move(related_lanes), bounding_box, traffic_sign_value);
 }
 
 }  // namespace builder

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -168,6 +168,16 @@ TEST_F(TrafficSignBuilderFigure8Test, PositionOfTrafficSign) {
   EXPECT_NEAR(position.y(), -2.8325, 1e-3);
 }
 
+// Verifies that the builder throws when a signal has a value with an unrecognized unit.
+TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignThrowsOnUnrecognizedUnit) {
+  xodr::signal::Signal bad_signal = signal_;
+  bad_signal.type = "206";
+  bad_signal.value = xodr::signal::Signal::Value{100.0, "unknown_unit"};
+
+  TrafficSignBuilder builder(bad_signal, xodr::RoadHeader::Id("44"), *loader_, road_geometry_);
+  EXPECT_THROW(builder(), maliput::common::road_network_description_parser_error);
+}
+
 // ---------------------------------------------------------------------------
 // Tests using TwoRoadsWithTrafficSigns.xodr / traffic_control_device_db/traffic_control_device_db_example.yaml.
 //
@@ -322,7 +332,7 @@ TEST_F(TrafficSignBuilderTwoRoadsTest, GetValueReturnsNulloptForStopSign) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests using SingleRoadWithSpeedLimit.xodr / traffic_control_device_db_example.yaml.
+// Tests using SingleRoadWithSpeedLimit.xodr / testing_database.yaml.
 //
 // This XODR defines a single straight road (Road 1) with a speed-limit signal
 // carrying value="60" and unit="km/h".
@@ -343,7 +353,7 @@ class TrafficSignBuilderSpeedLimitTest : public ::testing::Test {
     const std::string xodr_file =
         utility::FindResourceInPath("SingleRoadWithSpeedLimit.xodr", kMalidriveResourceFolder);
     const std::string yaml_db = utility::FindResourceInPath(
-        "traffic_control_device_db/traffic_control_device_db_example.yaml", kMalidriveResourceFolder);
+        "traffic_control_device_db/testing_database.yaml", kMalidriveResourceFolder);
 
     road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
                                                                              {params::kOpendriveFile, xodr_file},
@@ -385,16 +395,6 @@ TEST_F(TrafficSignBuilderSpeedLimitTest, SpeedLimitSignPosition) {
   EXPECT_NEAR(100., pos.x(), 1e-1);
   EXPECT_NEAR(3., pos.y(), 1e-1);
   EXPECT_NEAR(2.5, pos.z(), 1e-1);
-}
-
-// Verifies that the builder throws when a signal has a value with an unrecognized unit.
-TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignThrowsOnUnrecognizedUnit) {
-  xodr::signal::Signal bad_signal = signal_;
-  bad_signal.type = "274";
-  bad_signal.value = xodr::signal::Signal::Value{100.0, "unknown_unit"};
-
-  TrafficSignBuilder builder(bad_signal, xodr::RoadHeader::Id("44"), *loader_, road_geometry_);
-  EXPECT_THROW(builder(), maliput::common::road_network_description_parser_error);
 }
 
 }  // namespace

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -352,8 +352,8 @@ class TrafficSignBuilderSpeedLimitTest : public ::testing::Test {
   void SetUp() override {
     const std::string xodr_file =
         utility::FindResourceInPath("SingleRoadWithSpeedLimit.xodr", kMalidriveResourceFolder);
-    const std::string yaml_db = utility::FindResourceInPath(
-        "traffic_control_device_db/testing_database.yaml", kMalidriveResourceFolder);
+    const std::string yaml_db =
+        utility::FindResourceInPath("traffic_control_device_db/testing_database.yaml", kMalidriveResourceFolder);
 
     road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
                                                                              {params::kOpendriveFile, xodr_file},

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -39,6 +39,7 @@
 #include <maliput/api/road_network.h>
 #include <maliput/api/rules/traffic_sign.h>
 #include <maliput/api/rules/traffic_sign_book.h>
+#include <maliput/common/maliput_throw.h>
 
 #include "maliput_malidrive/base/road_geometry.h"
 #include "maliput_malidrive/builder/params.h"
@@ -311,6 +312,89 @@ TEST_F(TrafficSignBuilderTwoRoadsTest, TrafficLightBookIsEmpty) {
   const auto* tlb = road_network_->traffic_light_book();
   ASSERT_NE(tlb, nullptr);
   EXPECT_TRUE(tlb->TrafficLights().empty());
+}
+
+// Verifies that stop signs without a valid value/unit pair return std::nullopt from GetValue().
+TEST_F(TrafficSignBuilderTwoRoadsTest, GetValueReturnsNulloptForStopSign) {
+  const auto* ts = traffic_sign_book_->GetTrafficSign(maliput::api::rules::TrafficSign::Id("SS1"));
+  ASSERT_NE(ts, nullptr);
+  EXPECT_FALSE(ts->GetValue().has_value());
+}
+
+// ---------------------------------------------------------------------------
+// Tests using SingleRoadWithSpeedLimit.xodr / traffic_control_device_db_example.yaml.
+//
+// This XODR defines a single straight road (Road 1) with a speed-limit signal
+// carrying value="60" and unit="km/h".
+//
+//   Road 1 (200 m, hdg=0, x=[0,200]):
+//     - Signal SL1: type="274", s=100, t=3, orientation="+", zOffset=2.5,
+//       value="60", unit="km/h", validity={fromLane=-1, toLane=-1}.
+//
+// Expected TrafficSign:
+//   - id: "SL1"
+//   - type: kSpeedLimit
+//   - GetValue(): TrafficSignValue{60.0, kKilometersPerHour}
+// ---------------------------------------------------------------------------
+
+class TrafficSignBuilderSpeedLimitTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file =
+        utility::FindResourceInPath("SingleRoadWithSpeedLimit.xodr", kMalidriveResourceFolder);
+    const std::string yaml_db = utility::FindResourceInPath(
+        "traffic_control_device_db/traffic_control_device_db_example.yaml", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file},
+                                                                             {params::kTrafficControlDeviceDb, yaml_db},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    traffic_sign_book_ = road_network_->traffic_sign_book();
+    ASSERT_NE(traffic_sign_book_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::rules::TrafficSignBook* traffic_sign_book_{};
+};
+
+// Verifies that the speed-limit sign is created with correct type.
+TEST_F(TrafficSignBuilderSpeedLimitTest, SpeedLimitSignCreated) {
+  const auto* ts = traffic_sign_book_->GetTrafficSign(maliput::api::rules::TrafficSign::Id("SL1"));
+  ASSERT_NE(ts, nullptr);
+  EXPECT_EQ(maliput::api::rules::TrafficSignType::kSpeedLimit, ts->type());
+}
+
+// Verifies that GetValue() returns the expected numeric value and unit.
+TEST_F(TrafficSignBuilderSpeedLimitTest, GetValueReturnsExpectedValue) {
+  const auto* ts = traffic_sign_book_->GetTrafficSign(maliput::api::rules::TrafficSign::Id("SL1"));
+  ASSERT_NE(ts, nullptr);
+  const auto& value = ts->GetValue();
+  ASSERT_TRUE(value.has_value());
+  EXPECT_DOUBLE_EQ(60.0, value->value);
+  EXPECT_EQ(maliput::api::rules::TrafficSignValueUnit::kKilometersPerHour, value->unit);
+}
+
+// Verifies that the sign's position is correct.
+TEST_F(TrafficSignBuilderSpeedLimitTest, SpeedLimitSignPosition) {
+  const auto* ts = traffic_sign_book_->GetTrafficSign(maliput::api::rules::TrafficSign::Id("SL1"));
+  ASSERT_NE(ts, nullptr);
+  const auto& pos = ts->position_road_network();
+  EXPECT_NEAR(100., pos.x(), 1e-1);
+  EXPECT_NEAR(3., pos.y(), 1e-1);
+  EXPECT_NEAR(2.5, pos.z(), 1e-1);
+}
+
+// Verifies that the builder throws when a signal has a value with an unrecognized unit.
+TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignThrowsOnUnrecognizedUnit) {
+  xodr::signal::Signal bad_signal = signal_;
+  bad_signal.type = "274";
+  bad_signal.value = xodr::signal::Signal::Value{100.0, "unknown_unit"};
+
+  TrafficSignBuilder builder(bad_signal, xodr::RoadHeader::Id("44"), *loader_, road_geometry_);
+  EXPECT_THROW(builder(), maliput::common::road_network_description_parser_error);
 }
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature

## Summary
* TrafficSign::GetValue returns the Value/Unit read from XODR Signals.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
