### PR TITLE
Align signal's orientation with the s-direction traffic comes from.

### DIFF
--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -136,7 +136,7 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
   double orientation =
       rp.lane->GetOrientation(rp.pos).yaw() + (signal_.h_offset.has_value() ? signal_.h_offset.value() : 0.);
   maliput::api::Rotation orientation_road_network = maliput::api::Rotation::FromRpy(
-      0., 0., orientation + (signal_.orientation == xodr::signal::Orientation::kAgainstS ? M_PI : 0.));
+      0., 0., orientation + (signal_.orientation != xodr::signal::Orientation::kAgainstS ? M_PI : 0.));
 
   auto related_lanes =
       ResolveAndDeduplicateLaneIds(road_id_, signal_.s, signal_.validities, signal_references_, road_geometry_);

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -123,7 +123,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   const double orientation =
       rp.lane->GetOrientation(rp.pos).yaw() + (signal_.h_offset.has_value() ? signal_.h_offset.value() : 0.);
   const maliput::api::Rotation orientation_road_network = maliput::api::Rotation::FromRpy(
-      0., 0., orientation + (signal_.orientation == xodr::signal::Orientation::kAgainstS ? M_PI : 0.));
+      0., 0., orientation + (signal_.orientation != xodr::signal::Orientation::kAgainstS ? M_PI : 0.));
 
   auto related_lanes =
       ResolveAndDeduplicateLaneIds(road_id_, signal_.s, signal_.validities, signal_references_, road_geometry_);

--- a/test/regression/builder/traffic_light_builder_test.cc
+++ b/test/regression/builder/traffic_light_builder_test.cc
@@ -257,11 +257,11 @@ TEST_F(TrafficLightBuilderTwoRoadsTest, TrafficLightS1Fields) {
   EXPECT_NEAR(2., pos.y(), 1e-1);
   EXPECT_NEAR(6., pos.z(), 1e-1);
 
-  // Orientation: Road heading = 0, h_offset = 0, orientation = "+" → yaw ~ 0.
+  // Orientation: Road heading = 0, h_offset = 0, orientation = "+" → yaw ~ π.
   const auto& rot = tl->orientation_road_network();
   EXPECT_NEAR(0., rot.roll(), 1e-3);
   EXPECT_NEAR(0., rot.pitch(), 1e-3);
-  EXPECT_NEAR(0., rot.yaw(), 1e-1);
+  EXPECT_NEAR(M_PI, rot.yaw(), 1e-1);
 
   // BulbGroups: one group named "TrafficLight_S1_Bulbs".
   const auto bulb_groups = tl->bulb_groups();
@@ -338,11 +338,11 @@ TEST_F(TrafficLightBuilderTwoRoadsTest, TrafficLightS2Fields) {
   EXPECT_NEAR(-2., pos.y(), 1e-1);
   EXPECT_NEAR(6., pos.z(), 1e-1);
 
-  // Orientation: Road heading = 0, h_offset = 0, orientation = "-" (against S) → yaw ~ π.
+  // Orientation: Road heading = 0, h_offset = 0, orientation = "-" (against S) → yaw ~ 0.
   const auto& rot = tl->orientation_road_network();
   EXPECT_NEAR(0., rot.roll(), 1e-3);
   EXPECT_NEAR(0., rot.pitch(), 1e-3);
-  EXPECT_NEAR(M_PI, std::abs(rot.yaw()), 1e-1);
+  EXPECT_NEAR(0., std::abs(rot.yaw()), 1e-1);
 
   // BulbGroups: one group.
   const auto bulb_groups = tl->bulb_groups();

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -237,11 +237,11 @@ TEST_F(TrafficSignBuilderTwoRoadsTest, TrafficSignSS1Fields) {
   EXPECT_NEAR(2., pos.y(), 1e-1);
   EXPECT_NEAR(1., pos.z(), 1e-1);
 
-  // Orientation: Road heading = 0, h_offset = 0, orientation = "+" → yaw ~ 0.
+  // Orientation: Road heading = 0, h_offset = 0, orientation = "+" → yaw ~ π.
   const auto& rot = ts->orientation_road_network();
   EXPECT_NEAR(0., rot.roll(), 1e-3);
   EXPECT_NEAR(0., rot.pitch(), 1e-3);
-  EXPECT_NEAR(0., rot.yaw(), 1e-1);
+  EXPECT_NEAR(M_PI, rot.yaw(), 1e-1);
 
   // Related lanes for SS1:
   //   - From signal's own validity (fromLane=-1, toLane=-1) on road 1 → {"1_0_-1"}
@@ -276,11 +276,11 @@ TEST_F(TrafficSignBuilderTwoRoadsTest, TrafficSignSS2Fields) {
   EXPECT_NEAR(-2., pos.y(), 1e-1);
   EXPECT_NEAR(1., pos.z(), 1e-1);
 
-  // Orientation: Road heading = 0, h_offset = 0, orientation = "-" (against S) → yaw ~ π.
+  // Orientation: Road heading = 0, h_offset = 0, orientation = "-" (against S) → yaw ~ 0.
   const auto& rot = ts->orientation_road_network();
   EXPECT_NEAR(0., rot.roll(), 1e-3);
   EXPECT_NEAR(0., rot.pitch(), 1e-3);
-  EXPECT_NEAR(M_PI, std::abs(rot.yaw()), 1e-1);
+  EXPECT_NEAR(0., std::abs(rot.yaw()), 1e-1);
 
   // Related lanes for SS2:
   //   - From signal's own validity (empty → all lanes) on road 2 → {"2_0_1", "2_0_-1"}


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #460 

## Summary
* `orientation="+"` now sets XODR signals to look in the decreasing s-direction.
* `orientation="-"` now sets XODR signals to look in the increasing s-direction.
* `orientation="none"` now sets XODR signals to look in the decreasing s-direction.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
