### PR TITLE
Support odr_object_types entries in traffic_control_device database

### DIFF
--- a/src/maliput_malidrive/traffic_control_device/README.md
+++ b/src/maliput_malidrive/traffic_control_device/README.md
@@ -1,15 +1,22 @@
 # Traffic Control Device database parser
 
-This directory contains a C++ parser and supporting utilities that read and validate YAML-based traffic device definitions to create maliput traffic control devices such as `TrafficLight`s and `TrafficSign`s.
+This directory contains a C++ parser and supporting utilities that read and validate YAML-based traffic device definitions to create maliput traffic control devices such as `TrafficLight`s, `TrafficSign`s, `RoadMarking`s, and `RoadObject`s.
 
 ## Overview
 
 A traffic control device type definition describes the physical structure, semantics, and control logic of a traffic control device. Each definition contains two sections:
 
-- **`odr_representation`**: The OpenDRIVE signal attributes used to match the device type (`type`, `subtype`, `country`, `country_revision`)
-- **`properties`**: The device's characteristics — `device_type`, `device_semantics`, bulb structure, rule states, bounding box, and more
+- **`odr_representation`**: The OpenDRIVE signal / object attributes used to match the device type (`type`, `subtype`, `country`, `country_revision`, `name`).
+- **`properties`**: The device's characteristics — `device_type`, `device_semantics`, bulb structure, rule states, bounding box, and more.
 
-The parser in this directory reads YAML files containing these traffic control device type definitions, validates them, and creates the corresponding maliput `TrafficLight` and `TrafficSign` objects.
+The database has **two root keys**:
+
+- **`odr_signal_types`** — devices represented by OpenDRIVE `signal` elements (traffic lights, traffic signs).
+- **`odr_object_types`** — devices represented by OpenDRIVE `object` elements (road markings, road objects).
+
+At least one of the two root keys must be present. The parser returns a single flat `std::vector<TrafficControlDeviceDefinition>` that mixes signal and object entries; downstream code discriminates them via the `device_type` field.
+
+The parser in this directory reads YAML files containing these traffic control device type definitions, validates them, and creates the corresponding maliput `TrafficLight`, `TrafficSign`, road marking, and road object representations.
 
 ## How It Works
 
@@ -19,43 +26,87 @@ When parsing an OpenDRIVE (`*.xodr`) road network file, traffic signals carry at
 <signal type="1000001" subtype="-1" country="OpenDRIVE" s="10.5" t="2.0" zOffset="4.5" ... />
 ```
 
+OpenDRIVE `object` elements carry their own attributes (`type`, `subtype`, `name`):
+
+```xml
+<object type="roadMark" name="StopLine" s="12.0" t="0.0" ... />
+```
+
 A parser uses this database to:
 
-1. **Match the signal** against an `odr_representation` entry using `type`, `subtype`, `country`, and `country_revision`
-2. **Determine the device category** from `device_type` — either `traffic_light` or `traffic_sign`
-3. **Create a maliput `TrafficLight` or `TrafficSign`** — for traffic signs, `device_semantics` is mapped to a `TrafficSignType`
-4. **Link to affected lanes** using the signal's validity information from the XODR file
+1. **Match the signal or object** against an `odr_representation` entry.
+2. **Determine the device category** from `device_type` — `traffic_light`, `traffic_sign`, `road_marking`, or `road_object`.
+3. **Create the corresponding maliput object** — for traffic signs, `device_semantics` is mapped to a `TrafficSignType`.
+4. **Link to affected lanes** using the signal's validity information from the XODR file.
 
 ## YAML Structure
 
-Each YAML file in this directory should define a list of signal types under the top-level key `odr_signal_types`. Each entry uses a two-level structure:
+### `odr_signal_types`
 
-### Signal Type Header
+Each entry uses a two-level structure:
 
 ```yaml
-- odr_representation:
-    type: "1000001"           # Signal type identifier (must match XODR signal type)
-    subtype: "-1"             # Optional: signal subtype ("-1" / "none" treated as absent)
-    country: "OpenDRIVE"      # Optional: country code or standard
-    country_revision: null     # Optional: country standard revision
-  properties:
-    device_type: traffic_light  # Required: "traffic_light" or "traffic_sign"
-    device_semantics: stop      # Optional: semantic meaning for traffic signs
-    description: "..."          # Optional: Human-readable description
-    is_position_dynamic: false  # Optional: whether position may change at runtime
-    default_bounding_box:       # Optional: device-level bounding box
-      p_min: [x, y, z]
-      p_max: [x, y, z]
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"           # Signal type identifier (must match XODR signal type)
+      subtype: "-1"             # Optional: signal subtype ("-1" / "none" treated as absent)
+      country: "OpenDRIVE"      # Optional: country code or standard
+      country_revision: null    # Optional: country standard revision
+    properties:
+      device_type: traffic_light  # Required: "traffic_light" or "traffic_sign"
+      device_semantics: stop      # Optional: semantic meaning for traffic signs
+      description: "..."          # Optional: Human-readable description
+      is_position_dynamic: false  # Optional: whether position may change at runtime
+      default_bounding_box:       # Optional: device-level bounding box
+        length: length            # Required: defined in the local coordinate system u/v along the u-axis
+        width: width              # Required: defined in the local coordinate system u/v along the v-axis
+        height: height            # Required: defined in the local coordinate system u/v along the z-axis
+      bulbs: [...]                # Optional: only meaningful for traffic_light
+      rule_states: [...]          # Optional: only meaningful for traffic_light
 ```
+
+For signals, `device_type` MUST be `traffic_light` or `traffic_sign`. Using `road_marking` or `road_object` in a signal entry is rejected with a parser error.
+
+### `odr_object_types`
+
+Object entries follow a **stricter** schema than signal entries:
+
+```yaml
+odr_object_types:
+  - odr_representation:
+      type: roadMark            # Required: OpenDRIVE object type
+      subtype: null             # Optional: object subtype
+      name: "StopLine"          # Optional: OpenDRIVE name attribute
+    properties:
+      device_type: road_marking # Required: "road_marking" or "road_object"
+      device_semantics: stop_line  # Optional
+      description: "..."        # Optional
+      is_position_dynamic: false   # Optional
+      default_bounding_box:       # Optional: device-level bounding box
+        length: length            # Required: defined in the local coordinate system u/v along the u-axis
+        width: width              # Required: defined in the local coordinate system u/v along the v-axis
+        height: height            # Required: defined in the local coordinate system u/v along the z-axis
+```
+
+The following fields are **not allowed** in `odr_object_types` entries and are rejected by the parser:
+
+- `country` and `country_revision` in `odr_representation` (objects don't use them in OpenDRIVE).
+- `bulbs` and `rule_states` in `properties` (objects don't carry bulbs or rule logic).
+
+For objects, `device_type` MUST be `road_marking` or `road_object`. Using `traffic_light` or `traffic_sign` in an object entry is rejected with a parser error.
 
 #### `device_type`
 
-Required string that identifies the signal category. Used to route signals to the right maliput book:
+Required string that identifies the device category. Used to route entries to the right maliput book:
 
-| `device_type` value  | Result                                              |
-|----------------------|-----------------------------------------------------|
-| `"traffic_light"`    | Creates a `maliput::api::rules::TrafficLight`       |
-| `"traffic_sign"`     | Creates a `maliput::api::rules::TrafficSign`        |
+| `device_type` value  | Valid root             | Result                                              |
+|----------------------|------------------------|-----------------------------------------------------|
+| `"traffic_light"`    | `odr_signal_types`     | Creates a `maliput::api::rules::TrafficLight`       |
+| `"traffic_sign"`     | `odr_signal_types`     | Creates a `maliput::api::rules::TrafficSign`        |
+| `"road_marking"`     | `odr_object_types`     | Creates a `maliput::api::object::RoadMarking`       |
+| `"road_object"`      | `odr_object_types`     | Creates a `maliput::api::object::RoadObject`        |
+
+The `device_type` matching is **case-insensitive**: `"Road_Marking"`, `"ROAD_MARKING"`, and `"road_marking"` are all equivalent.
 
 #### `device_semantics`
 
@@ -87,35 +138,33 @@ The `device_semantics` matching is **case-insensitive**: `"No_Entry"`, `"NO_ENTR
 
 #### Signal Fingerprint Matching
 
-Each signal definition in the database is uniquely identified by a **fingerprint** composed of the following fields:
+Each entry in the database is uniquely identified by a **fingerprint** composed of the following fields:
 
-| Field              | Required | Description                                |
-| ------------------ | -------- | ------------------------------------------ |
-| `type`             | Yes      | Signal type identifier (e.g., `"1000001"`) |
-| `subtype`          | No       | Signal subtype for finer matching          |
-| `country`          | No       | Country code or standard                   |
-| `country_revision` | No       | Country standard revision                  |
+| Field              | Required in Signals | Required in Objects | Description                                |
+| ------------------ | :-----: | :-----: | ------------------------------------------ |
+| `type`             | Yes     | Yes     | Signal/object type identifier              |
+| `subtype`          | No      | No      | Subtype for finer matching                 |
+| `country`          | No      | —       | Country code or standard (signals only)    |
+| `country_revision` | No      | —       | Country standard revision (signals only)   |
+| `name`             | No      | No      | OpenDRIVE `name` attribute                 |
 
-Only `type` is mandatory; `subtype`, `country`, and `country_revision` may be omitted (treated as null). When the parser looks up an XODR signal in the database, all fields are compared — omitted fields match only when the corresponding database entry also leaves them unset. This means two entries that share the same `type` but differ in any optional field (present vs. absent, or different values) are considered distinct definitions.
+Only `type` is mandatory. Omitted optional fields are treated as null. When the parser looks up an XODR signal/object in the database, all fields are compared — omitted fields match only when the corresponding database entry also leaves them unset.
+
+The wildcard character `"*"` may be used for any optional field to match any value, including null. Specificity ranking is used to break ties when multiple entries match: the entry with the most non-wildcard fields wins.
+
+#### Per-root conflict validation
+
+Equal-specificity conflicts are detected **per root**:
+
+- Two `odr_signal_types` entries that can match the same input and have equal specificity → rejected.
+- Two `odr_object_types` entries that can match the same input and have equal specificity → rejected.
+- A signal and an object entry sharing the same fingerprint do **NOT** conflict — OpenDRIVE signals and objects live in disjoint namespaces, so they are validated independently.
+
+Object specificity counts only the three object fields (`type`, `subtype`, `name`) — `country`/`country_revision` do not apply.
 
 ### Bulbs
 
-Each signal type contains a list of `bulbs`:
-
-```yaml
-  bulbs:                     # List of bulbs
-    - id: "BulbName"
-      position_traffic_light: [x, y, z]          # Position relative to traffic light frame
-      orientation_traffic_light: [w, x, y, z]    # Orientation relative to traffic light frame
-      color: "Red"           # One of: Red, Yellow, Green
-      type: "Round"          # One of: Round, Arrow, ArrowLeft, ArrowRight, ArrowUp, ArrowUpperLeft, ArrowUpperRight, UTurnLeft, UTurnRight, Walk, DontWalk
-      states: ["Off", "On", "Blinking"]  # Possible states for this bulb
-      bounding_box: (optional)  # Custom bounding box if needed
-        p_min: [x, y, z]
-        p_max: [x, y, z]
-## Bulbs
-
-Traffic light definitions may contain a `bulbs` list:
+Traffic light definitions may contain a `bulbs` list (only valid under `odr_signal_types` with `device_type: traffic_light`):
 
 ```yaml
 bulbs:
@@ -191,12 +240,57 @@ The preferred snake_case values include the newer aliases `arrow_left`, `arrow_r
 
 ## Examples
 
-See:
+A combined database with both roots:
+
+```yaml
+odr_signal_types:
+  - odr_representation:
+      type: "206"
+      subtype: "-1"
+    properties:
+      device_type: traffic_sign
+      device_semantics: give_way
+      description: "Give way sign"
+      default_bounding_box:
+        length: 0.001
+        width: 1.0
+        height: 1.0
+      rule_states:
+        - conditions: []
+          value: "StopIfSafe"
+
+odr_object_types:
+  # Stop line matched by name (e.g., RoadRunner output)
+  - odr_representation:
+      type: roadMark
+      name: "StopLine"
+    properties:
+      device_type: road_marking
+      device_semantics: stop_line
+      description: "Stop line road marking"
+
+  # Generic crosswalk
+  - odr_representation:
+      type: crosswalk
+    properties:
+      device_type: road_marking
+      device_semantics: crosswalk
+      description: "Generic OpenDRIVE crosswalk object"
+
+  # Generic pole
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      description: "Generic OpenDRIVE pole object"
+```
+
+See also:
 
 - `resources/traffic_control_device_db/traffic_control_device_db_example.yaml`
 
 ## Notes
 
-- If `bounding_box` is omitted, maliput uses its default bulb dimensions.
+- If bulb's `bounding_box` is omitted, maliput uses its default bulb dimensions.
 - OpenDRIVE `length`, `width`, and `height` may override `default_bounding_box` values.
 - The OpenDRIVE `name` field is supported for matching because some authoring tools encode object meaning there.

--- a/src/maliput_malidrive/traffic_control_device/device_type.cc
+++ b/src/maliput_malidrive/traffic_control_device/device_type.cc
@@ -42,6 +42,8 @@ TrafficControlDeviceType StringToTrafficControlDeviceType(const std::string& dev
   static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper{
       {"traffic_light", T::kTrafficLight},
       {"traffic_sign", T::kTrafficSign},
+      {"road_marking", T::kRoadMarking},
+      {"road_object", T::kRoadObject},
   };
   std::string lower = device_type_str;
   std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
@@ -55,6 +57,10 @@ const char* TrafficControlDeviceTypeToString(TrafficControlDeviceType device_typ
       return "traffic_light";
     case TrafficControlDeviceType::kTrafficSign:
       return "traffic_sign";
+    case TrafficControlDeviceType::kRoadMarking:
+      return "road_marking";
+    case TrafficControlDeviceType::kRoadObject:
+      return "road_object";
     default:
       return "unknown";
   }

--- a/src/maliput_malidrive/traffic_control_device/device_type.h
+++ b/src/maliput_malidrive/traffic_control_device/device_type.h
@@ -39,6 +39,8 @@ namespace traffic_control_device {
 enum class TrafficControlDeviceType {
   kTrafficLight,  ///< Device is a traffic light ("traffic_light").
   kTrafficSign,   ///< Device is a traffic sign ("traffic_sign").
+  kRoadMarking,   ///< Device is a road marking ("road_marking").
+  kRoadObject,    ///< Device is a road object ("road_object").
   kUnknown,       ///< Unrecognized or missing device_type value.
 };
 
@@ -48,6 +50,8 @@ enum class TrafficControlDeviceType {
 /// Recognized values (case-insensitive):
 ///   - `"traffic_light"` → `kTrafficLight`
 ///   - `"traffic_sign"`  → `kTrafficSign`
+///   - `"road_marking"`  → `kRoadMarking`
+///   - `"road_object"`   → `kRoadObject`
 ///
 /// Any other string maps to `kUnknown`.
 ///
@@ -60,6 +64,8 @@ TrafficControlDeviceType StringToTrafficControlDeviceType(const std::string& dev
 ///
 ///   - `kTrafficLight` → `"traffic_light"`
 ///   - `kTrafficSign`  → `"traffic_sign"`
+///   - `kRoadMarking`  → `"road_marking"`
+///   - `kRoadObject`   → `"road_object"`
 ///   - `kUnknown`      → `"unknown"`
 ///
 /// @param device_type  The @ref TrafficControlDeviceType to convert.

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -578,15 +578,14 @@ std::vector<TrafficControlDeviceDefinition> TrafficControlDeviceParser::BuildFro
         const auto& fp_i = entries[i].fingerprint;
         const auto& fp_j = entries[j].fingerprint;
         if (CanOverlap(fp_i, fp_j) && specificity(fp_i) == specificity(fp_j)) {
-          MALIDRIVE_THROW_MESSAGE(
-              "Conflicting " + root_key +
-                  " entries with equal specificity: "
-                  "entry '" +
-                  entries[i].description + "' (type='" + fp_i.type +
-                  "') conflicts with "
-                  "entry '" +
-                  entries[j].description + "' (type='" + fp_j.type + "').",
-              maliput::common::road_network_description_parser_error);
+          MALIDRIVE_THROW_MESSAGE("Conflicting " + root_key +
+                                      " entries with equal specificity: "
+                                      "entry '" +
+                                      entries[i].description + "' (type='" + fp_i.type +
+                                      "') conflicts with "
+                                      "entry '" +
+                                      entries[j].description + "' (type='" + fp_j.type + "').",
+                                  maliput::common::road_network_description_parser_error);
         }
       }
     }

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -61,6 +61,15 @@ int TrafficControlDeviceParser::Specificity(const TrafficControlDeviceFingerprin
   return score;
 }
 
+int TrafficControlDeviceParser::SpecificityForObject(const TrafficControlDeviceFingerprint& fp) {
+  // Object entries only carry type, subtype and name.
+  int score = 0;
+  if (!IsWildcard(fp.type)) ++score;
+  if (!IsWildcard(fp.subtype)) ++score;
+  if (!IsWildcard(fp.name)) ++score;
+  return score;
+}
+
 bool TrafficControlDeviceParser::Matches(const TrafficControlDeviceFingerprint& db_entry,
                                          const TrafficControlDeviceFingerprint& query) {
   // For each field: db_entry matches if it is the wildcard OR equals the query field.
@@ -338,8 +347,12 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
   // --- Parse properties ---
   const std::string device_type_str = GetRequiredStringField(props_node, TrafficControlDeviceConstants::kDeviceType);
   tcd_definition.device_type = StringToTrafficControlDeviceType(device_type_str);
-  MALIDRIVE_VALIDATE(tcd_definition.device_type != TrafficControlDeviceType::kUnknown,
-                     maliput::common::road_network_description_parser_error, "Invalid device type: " + device_type_str);
+  MALIDRIVE_VALIDATE(tcd_definition.device_type == TrafficControlDeviceType::kTrafficLight ||
+                         tcd_definition.device_type == TrafficControlDeviceType::kTrafficSign,
+                     maliput::common::road_network_description_parser_error,
+                     "device_type '" + device_type_str +
+                         "' is not allowed for odr_signal_types entries; "
+                         "expected 'traffic_light' or 'traffic_sign'.");
 
   tcd_definition.device_semantics = GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDeviceSemantics);
 
@@ -381,40 +394,167 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
   return tcd_definition;
 }
 
+// Helper function to parse a TrafficControlDeviceDefinition from a YAML map representing
+// an entry under `odr_object_types`. Object entries have a stricter schema than signal
+// entries:
+//   - `odr_representation` carries only `type`, `subtype`, and `name`. `country` and
+//     `country_revision` are not allowed.
+//   - `properties` does not allow `bulbs` or `rule_states`.
+//   - `device_type` must be `road_marking` or `road_object`.
+// @return A TrafficControlDeviceDefinition with the parsed values. country and
+//         country_revision in the fingerprint are left as std::nullopt; bulbs and
+//         rule_states are left empty.
+TrafficControlDeviceDefinition ParseObjectDefinition(const YAML::Node& entry_node) {
+  MALIDRIVE_THROW_UNLESS(entry_node.IsMap(), maliput::common::road_network_description_parser_error);
+
+  // Validate and extract the odr_representation sub-node.
+  MALIDRIVE_THROW_UNLESS(entry_node[TrafficControlDeviceConstants::kOdrRepresentation].IsDefined(),
+                         maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(entry_node[TrafficControlDeviceConstants::kOdrRepresentation].IsMap(),
+                         maliput::common::road_network_description_parser_error);
+  const YAML::Node& repr_node = entry_node[TrafficControlDeviceConstants::kOdrRepresentation];
+
+  // Reject fields not allowed in odr_object_types entries.
+  MALIDRIVE_VALIDATE(!repr_node[TrafficControlDeviceConstants::kCountry].IsDefined(),
+                     maliput::common::road_network_description_parser_error,
+                     "Field 'country' is not allowed in odr_object_types entries.");
+  MALIDRIVE_VALIDATE(!repr_node[TrafficControlDeviceConstants::kCountryRevision].IsDefined(),
+                     maliput::common::road_network_description_parser_error,
+                     "Field 'country_revision' is not allowed in odr_object_types entries.");
+
+  // Validate and extract the properties sub-node.
+  MALIDRIVE_THROW_UNLESS(entry_node[TrafficControlDeviceConstants::kProperties].IsDefined(),
+                         maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(entry_node[TrafficControlDeviceConstants::kProperties].IsMap(),
+                         maliput::common::road_network_description_parser_error);
+  const YAML::Node& props_node = entry_node[TrafficControlDeviceConstants::kProperties];
+
+  // Reject bulbs / rule_states in object entries.
+  MALIDRIVE_VALIDATE(!props_node[TrafficControlDeviceConstants::kBulbs].IsDefined(),
+                     maliput::common::road_network_description_parser_error,
+                     "Field 'bulbs' is not allowed in odr_object_types entries.");
+  MALIDRIVE_VALIDATE(!props_node[TrafficControlDeviceConstants::kRuleStates].IsDefined(),
+                     maliput::common::road_network_description_parser_error,
+                     "Field 'rule_states' is not allowed in odr_object_types entries.");
+
+  // device_type is required.
+  MALIDRIVE_THROW_UNLESS(props_node[TrafficControlDeviceConstants::kDeviceType].IsDefined(),
+                         maliput::common::road_network_description_parser_error);
+
+  TrafficControlDeviceDefinition tcd_definition;
+
+  // --- Parse fingerprint from odr_representation ---
+  tcd_definition.fingerprint.type = GetRequiredStringField(repr_node, TrafficControlDeviceConstants::kType);
+
+  if (const auto subtype = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kSubtype)) {
+    if (subtype.value() == "-1" || subtype.value() == "none") {
+      tcd_definition.fingerprint.subtype = std::nullopt;
+    } else {
+      tcd_definition.fingerprint.subtype = subtype;
+    }
+  }
+
+  if (const auto name = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kName)) {
+    tcd_definition.fingerprint.name = name;
+  }
+
+  // country and country_revision left as std::nullopt by construction.
+
+  // --- Parse properties ---
+  const std::string device_type_str = GetRequiredStringField(props_node, TrafficControlDeviceConstants::kDeviceType);
+  tcd_definition.device_type = StringToTrafficControlDeviceType(device_type_str);
+  MALIDRIVE_VALIDATE(tcd_definition.device_type == TrafficControlDeviceType::kRoadMarking ||
+                         tcd_definition.device_type == TrafficControlDeviceType::kRoadObject,
+                     maliput::common::road_network_description_parser_error,
+                     "device_type '" + device_type_str +
+                         "' is not allowed for odr_object_types entries; "
+                         "expected 'road_marking' or 'road_object'.");
+
+  tcd_definition.device_semantics = GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDeviceSemantics);
+
+  // is_position_dynamic (optional bool, defaults to false).
+  if (props_node[TrafficControlDeviceConstants::kIsPositionDynamic].IsDefined() &&
+      !props_node[TrafficControlDeviceConstants::kIsPositionDynamic].IsNull()) {
+    tcd_definition.is_position_dynamic = props_node[TrafficControlDeviceConstants::kIsPositionDynamic].as<bool>();
+  }
+
+  // description (optional).
+  if (const auto desc = GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDescription)) {
+    tcd_definition.description = desc.value();
+  }
+
+  // default_bounding_box at device level (optional).
+  if (props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsDefined() &&
+      !props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsNull()) {
+    tcd_definition.default_bounding_box =
+        ParseBoundingBox(props_node[TrafficControlDeviceConstants::kDefaultBoundingBox]);
+  }
+
+  return tcd_definition;
+}
+
 }  // namespace
 
 std::vector<TrafficControlDeviceDefinition> TrafficControlDeviceParser::BuildFrom(const YAML::Node& root) {
   MALIDRIVE_THROW_UNLESS(root.IsMap(), maliput::common::road_network_description_parser_error);
 
-  // Get odr_signal_types array.
   const YAML::Node& signals_node = root[TrafficControlDeviceConstants::kOdrSignalTypes];
-  MALIDRIVE_THROW_UNLESS(signals_node.IsDefined(), maliput::common::road_network_description_parser_error);
-  MALIDRIVE_THROW_UNLESS(signals_node.IsSequence(), maliput::common::road_network_description_parser_error);
+  const YAML::Node& objects_node = root[TrafficControlDeviceConstants::kOdrObjectTypes];
 
-  std::vector<TrafficControlDeviceDefinition> result;
-  // Parse each signal definition.
-  for (const auto& signal_node : signals_node) {
-    result.push_back(ParseSignalDefinition(signal_node));
-  }
+  // At least one of the two root keys must be present.
+  MALIDRIVE_VALIDATE(signals_node.IsDefined() || objects_node.IsDefined(),
+                     maliput::common::road_network_description_parser_error,
+                     "Database must contain at least one of 'odr_signal_types' or 'odr_object_types'.");
 
-  // Pairwise conflict validation: two entries conflict when they can overlap AND have equal specificity.
-  for (std::size_t i = 0; i < result.size(); ++i) {
-    for (std::size_t j = i + 1; j < result.size(); ++j) {
-      const auto& fp_i = result[i].fingerprint;
-      const auto& fp_j = result[j].fingerprint;
-      if (CanOverlap(fp_i, fp_j) && Specificity(fp_i) == Specificity(fp_j)) {
-        MALIDRIVE_THROW_MESSAGE(
-            "Conflicting traffic control device database entries with equal specificity: "
-            "entry '" +
-                result[i].description + "' (type='" + fp_i.type +
-                "') conflicts with "
-                "entry '" +
-                result[j].description + "' (type='" + fp_j.type + "').",
-            maliput::common::road_network_description_parser_error);
-      }
+  std::vector<TrafficControlDeviceDefinition> signals;
+  if (signals_node.IsDefined()) {
+    MALIDRIVE_THROW_UNLESS(signals_node.IsSequence(), maliput::common::road_network_description_parser_error);
+    for (const auto& signal_node : signals_node) {
+      signals.push_back(ParseSignalDefinition(signal_node));
     }
   }
 
+  std::vector<TrafficControlDeviceDefinition> objects;
+  if (objects_node.IsDefined()) {
+    MALIDRIVE_THROW_UNLESS(objects_node.IsSequence(), maliput::common::road_network_description_parser_error);
+    for (const auto& object_node : objects_node) {
+      objects.push_back(ParseObjectDefinition(object_node));
+    }
+  }
+
+  // Per-root pairwise conflict validation: two entries conflict when they can overlap AND
+  // have equal specificity. Signals and objects live in disjoint namespaces in OpenDRIVE,
+  // so we never compare across roots.
+  auto validate_conflicts = [](const std::vector<TrafficControlDeviceDefinition>& entries,
+                               int (*specificity)(const TrafficControlDeviceFingerprint&),
+                               const std::string& root_key) {
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+      for (std::size_t j = i + 1; j < entries.size(); ++j) {
+        const auto& fp_i = entries[i].fingerprint;
+        const auto& fp_j = entries[j].fingerprint;
+        if (CanOverlap(fp_i, fp_j) && specificity(fp_i) == specificity(fp_j)) {
+          MALIDRIVE_THROW_MESSAGE(
+              "Conflicting " + root_key +
+                  " entries with equal specificity: "
+                  "entry '" +
+                  entries[i].description + "' (type='" + fp_i.type +
+                  "') conflicts with "
+                  "entry '" +
+                  entries[j].description + "' (type='" + fp_j.type + "').",
+              maliput::common::road_network_description_parser_error);
+        }
+      }
+    }
+  };
+
+  validate_conflicts(signals, &TrafficControlDeviceParser::Specificity, "odr_signal_types");
+  validate_conflicts(objects, &TrafficControlDeviceParser::SpecificityForObject, "odr_object_types");
+
+  // Merge into a single flat vector. Downstream code discriminates entries by device_type.
+  std::vector<TrafficControlDeviceDefinition> result;
+  result.reserve(signals.size() + objects.size());
+  result.insert(result.end(), std::make_move_iterator(signals.begin()), std::make_move_iterator(signals.end()));
+  result.insert(result.end(), std::make_move_iterator(objects.begin()), std::make_move_iterator(objects.end()));
   return result;
 }
 

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -170,28 +170,73 @@ maliput::api::rules::BulbState StringToBulbState(const std::string& state_str) {
   MALIDRIVE_THROW_MESSAGE("Invalid bulb state: " + state_str, maliput::common::road_network_description_parser_error);
 }
 
-// Helper function to parse a bounding box from a YAML map.
+// Helper function to parse a bulb's axis-aligned bounding box from a YAML map.
 // @param node The YAML node containing p_min and p_max keys.
-// @return A Bulb::BoundingBox with the parsed values.
-maliput::api::rules::Bulb::BoundingBox ParseBoundingBox(const YAML::Node& node) {
-  auto bounding_box = maliput::api::rules::Bulb::BoundingBox();
+// @return A Bulb::BoundingBox with the parsed values, or the default Bulb::BoundingBox
+//         when @p node is not defined.
+maliput::api::rules::Bulb::BoundingBox ParseBulbBoundingBox(const YAML::Node& node) {
+  maliput::api::rules::Bulb::BoundingBox bounding_box;
   if (!node.IsDefined()) {
     // If not defined, return the default bounding box.
     return bounding_box;
   }
   MALIDRIVE_THROW_UNLESS(node.IsMap(), maliput::common::road_network_description_parser_error);
-  MALIDRIVE_THROW_UNLESS(node[BoundingBoxConstants::kPMin].IsDefined(),
+  MALIDRIVE_THROW_UNLESS(node[BulbBoundingBoxConstants::kPMin].IsDefined(),
                          maliput::common::road_network_description_parser_error);
-  MALIDRIVE_THROW_UNLESS(node[BoundingBoxConstants::kPMax].IsDefined(),
+  MALIDRIVE_THROW_UNLESS(node[BulbBoundingBoxConstants::kPMax].IsDefined(),
                          maliput::common::road_network_description_parser_error);
 
-  const auto p_min = GetVector3(node[BoundingBoxConstants::kPMin], BoundingBoxConstants::kPMin);
-  const auto p_max = GetVector3(node[BoundingBoxConstants::kPMax], BoundingBoxConstants::kPMax);
+  const auto p_min = GetVector3(node[BulbBoundingBoxConstants::kPMin], BulbBoundingBoxConstants::kPMin);
+  const auto p_max = GetVector3(node[BulbBoundingBoxConstants::kPMax], BulbBoundingBoxConstants::kPMax);
 
   bounding_box.p_BMin = p_min;
   bounding_box.p_BMax = p_max;
 
   return bounding_box;
+}
+
+// Helper function to parse a device-level bounding box from a YAML map.
+//
+// Expected schema (all three fields required when the node is present):
+//   default_bounding_box:
+//     length: <number>  # >= 0, local u-axis
+//     width:  <number>  # >= 0, local v-axis
+//     height: <number>  # >= 0, local z-axis
+//
+// @return A BoundingBoxDimensions with the parsed values.
+// @throws maliput::common::assertion_error When required fields are missing, when unknown keys
+//         are present, or when any dimension is negative.
+BoundingBoxDimensions ParseDeviceBoundingBox(const YAML::Node& node) {
+  MALIDRIVE_THROW_UNLESS(node.IsDefined(), maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(node.IsMap(), maliput::common::road_network_description_parser_error);
+
+  // Reject unknown keys to surface typos early.
+  for (const auto& kv : node) {
+    const auto key = kv.first.as<std::string>();
+    if (key != DeviceBoundingBoxConstants::kLength && key != DeviceBoundingBoxConstants::kWidth &&
+        key != DeviceBoundingBoxConstants::kHeight) {
+      MALIDRIVE_THROW_MESSAGE("Unknown field in default_bounding_box: '" + key + "'",
+                              maliput::common::road_network_description_parser_error);
+    }
+  }
+
+  MALIDRIVE_THROW_UNLESS(node[DeviceBoundingBoxConstants::kLength].IsDefined(),
+                         maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(node[DeviceBoundingBoxConstants::kWidth].IsDefined(),
+                         maliput::common::road_network_description_parser_error);
+  MALIDRIVE_THROW_UNLESS(node[DeviceBoundingBoxConstants::kHeight].IsDefined(),
+                         maliput::common::road_network_description_parser_error);
+
+  const double length = node[DeviceBoundingBoxConstants::kLength].as<double>();
+  const double width = node[DeviceBoundingBoxConstants::kWidth].as<double>();
+  const double height = node[DeviceBoundingBoxConstants::kHeight].as<double>();
+
+  if (length < 0.0 || width < 0.0 || height < 0.0) {
+    MALIDRIVE_THROW_MESSAGE("default_bounding_box dimensions must be non-negative",
+                            maliput::common::road_network_description_parser_error);
+  }
+
+  return BoundingBoxDimensions{length, width, height};
 }
 
 // Helper function to parse a BulbDefinition from a YAML map.
@@ -242,7 +287,7 @@ BulbDefinition ParseBulb(const YAML::Node& bulb_node) {
   }
 
   // Parse bounding box (optional).
-  bulb.bounding_box = ParseBoundingBox(bulb_node[BulbConstants::kBoundingBox]);
+  bulb.bounding_box = ParseBulbBoundingBox(bulb_node[BulbConstants::kBoundingBox]);
 
   return bulb;
 }
@@ -371,7 +416,7 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
   if (props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsDefined() &&
       !props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsNull()) {
     tcd_definition.default_bounding_box =
-        ParseBoundingBox(props_node[TrafficControlDeviceConstants::kDefaultBoundingBox]);
+        ParseDeviceBoundingBox(props_node[TrafficControlDeviceConstants::kDefaultBoundingBox]);
   }
 
   // Parse bulbs (optional sequence).
@@ -487,7 +532,7 @@ TrafficControlDeviceDefinition ParseObjectDefinition(const YAML::Node& entry_nod
   if (props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsDefined() &&
       !props_node[TrafficControlDeviceConstants::kDefaultBoundingBox].IsNull()) {
     tcd_definition.default_bounding_box =
-        ParseBoundingBox(props_node[TrafficControlDeviceConstants::kDefaultBoundingBox]);
+        ParseDeviceBoundingBox(props_node[TrafficControlDeviceConstants::kDefaultBoundingBox]);
   }
 
   return tcd_definition;

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -158,15 +158,25 @@ struct TrafficControlDeviceDefinition {
   bool operator!=(const TrafficControlDeviceDefinition& other) const { return !(*this == other); }
 };
 
-/// Parser that loads traffic control device definitions from a YAML database using the `odr_signal_types`
-/// schema. The resulting definitions are used in tandem with XODR signal data to create maliput
-/// `TrafficLight` and `TrafficSign` objects.
+/// Parser that loads traffic control device definitions from a YAML database using the
+/// `odr_signal_types` and `odr_object_types` schemas. The resulting definitions are used in
+/// tandem with XODR signal/object data to create maliput `TrafficLight`, `TrafficSign`,
+/// `RoadMarking`, and `RoadObject` representations.
 ///
 /// Design:
-/// - Each definition carries a `device_type` field that determines whether a `TrafficLight` or
-///   `TrafficSign` is created for a given XODR signal.
-/// - For traffic lights: `TrafficLight` is created with its bulbs and associated rule states.
-/// - For traffic signs: a `TrafficSign` is created with its type derived from the `device_semantics` field.
+/// - Each definition carries a `device_type` field that determines whether the entry is a
+///   traffic light, traffic sign, road marking, or road object.
+/// - For signals (`odr_signal_types`): `device_type` must be `traffic_light` or
+///   `traffic_sign`.
+/// - For objects (`odr_object_types`): `device_type` must be `road_marking` or
+///   `road_object`. Object entries' `odr_representation` only carries `type`, `subtype`,
+///   and `name`; `country`/`country_revision` are not permitted. Object entries'
+///   `properties` may not include `bulbs` or `rule_states`.
+///
+/// The two root keys are independently validated for equal-specificity conflicts: a signal
+/// and an object sharing a fingerprint do NOT conflict, because OpenDRIVE signals and
+/// objects live in disjoint namespaces. Both vectors are merged into a single flat result
+/// returned to the caller; downstream code discriminates entries by `device_type`.
 ///
 /// Workflow:
 /// 1. Load the device database: `TrafficControlDeviceParser::LoadFromFile()` or `LoadFromString()`.
@@ -222,6 +232,17 @@ class TrafficControlDeviceParser {
   /// @param fp The fingerprint to evaluate.
   /// @return Integer in [0, 5] representing the number of non-wildcard fields.
   static int Specificity(const TrafficControlDeviceFingerprint& fp);
+
+  /// Computes the specificity score of @p fp for an object entry.
+  ///
+  /// Object entries only carry `type`, `subtype`, and `name` in their `odr_representation`
+  /// (no `country` / `country_revision`), so only those three fields contribute. Counting
+  /// rules are identical to @ref Specificity: only the literal `"*"` is non-specific.
+  ///
+  /// @param fp The fingerprint to evaluate.
+  /// @return Integer in [0, 3] representing the number of non-wildcard fields among
+  ///         `type`, `subtype`, and `name`.
+  static int SpecificityForObject(const TrafficControlDeviceFingerprint& fp);
 
   /// Returns true if @p db_entry matches @p query for lookup purposes.
   ///

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -103,6 +103,23 @@ struct BulbDefinition {
   bool operator!=(const BulbDefinition& other) const { return !(*this == other); }
 };
 
+/// Holds the device-level bounding box dimensions parsed from the YAML database.
+/// Builders use these values to construct a `maliput::math::BoundingBox` at device
+/// builder time (centred at the device bottom position, with appropriate orientation).
+struct BoundingBoxDimensions {
+  /// Length of the bounding box along the local u-axis (must be >= 0).
+  double length{0.0};
+  /// Width of the bounding box along the local v-axis (must be >= 0).
+  double width{0.0};
+  /// Height of the bounding box along the local z-axis (must be >= 0).
+  double height{0.0};
+
+  bool operator==(const BoundingBoxDimensions& other) const {
+    return length == other.length && width == other.width && height == other.height;
+  }
+  bool operator!=(const BoundingBoxDimensions& other) const { return !(*this == other); }
+};
+
 /// Unique identifier for a traffic signal definition.
 struct TrafficControlDeviceFingerprint {
   /// Signal type identifier. Matches XODR signal type attribute.
@@ -138,22 +155,20 @@ struct TrafficControlDeviceDefinition {
   std::optional<std::string> device_semantics;
   /// Whether the device position is dynamic (moveable). Defaults to false.
   bool is_position_dynamic{false};
-  /// Optional device-level bounding box. When set, represents the overall device dimensions.
+  /// Optional device-level bounding box dimensions (length, width, height).
+  /// Builders use these to construct a `maliput::math::BoundingBox` at builder time.
   /// Individual bulbs may still carry their own per-bulb bounding boxes.
-  std::optional<maliput::api::rules::Bulb::BoundingBox> default_bounding_box;
+  std::optional<BoundingBoxDimensions> default_bounding_box;
   /// Bulbs in this traffic signal (only relevant when device_type == "traffic_light").
   std::vector<BulbDefinition> bulbs;
   /// Rule conditions mapping bulb state combinations to Right-Of-Way rule values.
   std::vector<RuleState> rule_states;
 
   bool operator==(const TrafficControlDeviceDefinition& other) const {
-    const bool bbox_equal =
-        (default_bounding_box.has_value() == other.default_bounding_box.has_value()) &&
-        (!default_bounding_box.has_value() || (default_bounding_box->p_BMin == other.default_bounding_box->p_BMin &&
-                                               default_bounding_box->p_BMax == other.default_bounding_box->p_BMax));
     return fingerprint == other.fingerprint && description == other.description && device_type == other.device_type &&
            device_semantics == other.device_semantics && is_position_dynamic == other.is_position_dynamic &&
-           bbox_equal && bulbs == other.bulbs && rule_states == other.rule_states;
+           default_bounding_box == other.default_bounding_box && bulbs == other.bulbs &&
+           rule_states == other.rule_states;
   }
   bool operator!=(const TrafficControlDeviceDefinition& other) const { return !(*this == other); }
 };

--- a/src/maliput_malidrive/traffic_control_device/yaml_helper.h
+++ b/src/maliput_malidrive/traffic_control_device/yaml_helper.h
@@ -75,10 +75,19 @@ struct BulbConstants {
   static constexpr const char* kBoundingBox = "bounding_box";
 };
 
-/// Constants for bounding box YAML fields.
-struct BoundingBoxConstants {
+/// Constants for bulb bounding box YAML fields (axis-aligned, two-corner form).
+/// Used by `bulbs[i].bounding_box`, which maps to `maliput::api::rules::Bulb::BoundingBox`.
+struct BulbBoundingBoxConstants {
   static constexpr const char* kPMin = "p_min";
   static constexpr const char* kPMax = "p_max";
+};
+
+/// Constants for device-level bounding box YAML fields (dimensions form).
+/// Used by `properties.default_bounding_box`, parsed into `BoundingBoxDimensions`.
+struct DeviceBoundingBoxConstants {
+  static constexpr const char* kLength = "length";
+  static constexpr const char* kWidth = "width";
+  static constexpr const char* kHeight = "height";
 };
 
 /// Constants for rule state YAML fields.

--- a/src/maliput_malidrive/traffic_control_device/yaml_helper.h
+++ b/src/maliput_malidrive/traffic_control_device/yaml_helper.h
@@ -42,6 +42,7 @@ namespace traffic_control_device {
 struct TrafficControlDeviceConstants {
   // Root-level keys.
   static constexpr const char* kOdrSignalTypes = "odr_signal_types";
+  static constexpr const char* kOdrObjectTypes = "odr_object_types";
   // Entry-level structural keys.
   static constexpr const char* kOdrRepresentation = "odr_representation";
   static constexpr const char* kProperties = "properties";

--- a/test/regression/traffic_control_device/device_type_test.cc
+++ b/test/regression/traffic_control_device/device_type_test.cc
@@ -57,22 +57,27 @@ INSTANTIATE_TEST_CASE_P(KnownValues, StringToTrafficControlDeviceTypeTest,
                         ::testing::Values(
                             // Canonical lower-case forms.
                             StringToTypeTestCase{"traffic_light", TrafficControlDeviceType::kTrafficLight},
-                            StringToTypeTestCase{"traffic_sign", TrafficControlDeviceType::kTrafficSign}));
+                            StringToTypeTestCase{"traffic_sign", TrafficControlDeviceType::kTrafficSign},
+                            StringToTypeTestCase{"road_marking", TrafficControlDeviceType::kRoadMarking},
+                            StringToTypeTestCase{"road_object", TrafficControlDeviceType::kRoadObject}));
 
 INSTANTIATE_TEST_CASE_P(CaseInsensitive, StringToTrafficControlDeviceTypeTest,
                         ::testing::Values(
                             // Upper-case variants.
                             StringToTypeTestCase{"TRAFFIC_LIGHT", TrafficControlDeviceType::kTrafficLight},
                             StringToTypeTestCase{"TRAFFIC_SIGN", TrafficControlDeviceType::kTrafficSign},
+                            StringToTypeTestCase{"ROAD_MARKING", TrafficControlDeviceType::kRoadMarking},
+                            StringToTypeTestCase{"ROAD_OBJECT", TrafficControlDeviceType::kRoadObject},
                             // Mixed-case variants.
                             StringToTypeTestCase{"Traffic_Light", TrafficControlDeviceType::kTrafficLight},
-                            StringToTypeTestCase{"Traffic_Sign", TrafficControlDeviceType::kTrafficSign}));
+                            StringToTypeTestCase{"Traffic_Sign", TrafficControlDeviceType::kTrafficSign},
+                            StringToTypeTestCase{"Road_Marking", TrafficControlDeviceType::kRoadMarking},
+                            StringToTypeTestCase{"Road_Object", TrafficControlDeviceType::kRoadObject}));
 
 INSTANTIATE_TEST_CASE_P(UnknownValues, StringToTrafficControlDeviceTypeTest,
                         ::testing::Values(
                             // Unrecognized strings map to kUnknown.
                             StringToTypeTestCase{"", TrafficControlDeviceType::kUnknown},
-                            StringToTypeTestCase{"road_marking", TrafficControlDeviceType::kUnknown},
                             StringToTypeTestCase{"other", TrafficControlDeviceType::kUnknown},
                             StringToTypeTestCase{"unknown_value", TrafficControlDeviceType::kUnknown}));
 

--- a/test/regression/traffic_control_device/device_type_test.cc
+++ b/test/regression/traffic_control_device/device_type_test.cc
@@ -100,6 +100,8 @@ INSTANTIATE_TEST_CASE_P(AllValues, TrafficControlDeviceTypeToStringTest,
                         ::testing::Values(TypeToStringTestCase{TrafficControlDeviceType::kTrafficLight,
                                                                "traffic_light"},
                                           TypeToStringTestCase{TrafficControlDeviceType::kTrafficSign, "traffic_sign"},
+                                          TypeToStringTestCase{TrafficControlDeviceType::kRoadMarking, "road_marking"},
+                                          TypeToStringTestCase{TrafficControlDeviceType::kRoadObject, "road_object"},
                                           TypeToStringTestCase{TrafficControlDeviceType::kUnknown, "unknown"}));
 
 // ---------------------------------------------------------------------------
@@ -113,6 +115,16 @@ TEST(TrafficControlDeviceTypeRoundTripTest, TrafficLight) {
 
 TEST(TrafficControlDeviceTypeRoundTripTest, TrafficSign) {
   const auto type = TrafficControlDeviceType::kTrafficSign;
+  EXPECT_EQ(type, StringToTrafficControlDeviceType(TrafficControlDeviceTypeToString(type)));
+}
+
+TEST(TrafficControlDeviceTypeRoundTripTest, RoadMarking) {
+  const auto type = TrafficControlDeviceType::kRoadMarking;
+  EXPECT_EQ(type, StringToTrafficControlDeviceType(TrafficControlDeviceTypeToString(type)));
+}
+
+TEST(TrafficControlDeviceTypeRoundTripTest, RoadObject) {
+  const auto type = TrafficControlDeviceType::kRoadObject;
   EXPECT_EQ(type, StringToTrafficControlDeviceType(TrafficControlDeviceTypeToString(type)));
 }
 

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -1636,8 +1636,8 @@ odr_signal_types:
 // ============================================================================
 
 // Helper that filters `defs` by device_type for assertions on object/signal subsets.
-std::vector<TrafficControlDeviceDefinition> FilterByDeviceType(
-    const std::vector<TrafficControlDeviceDefinition>& defs, TrafficControlDeviceType type) {
+std::vector<TrafficControlDeviceDefinition> FilterByDeviceType(const std::vector<TrafficControlDeviceDefinition>& defs,
+                                                               TrafficControlDeviceType type) {
   std::vector<TrafficControlDeviceDefinition> out;
   std::copy_if(defs.begin(), defs.end(), std::back_inserter(out),
                [type](const TrafficControlDeviceDefinition& d) { return d.device_type == type; });
@@ -1737,8 +1737,7 @@ GTEST_TEST(OdrObjectTypesParserTest, MissingBothRootsIsRejected) {
   const char kDb[] = R"(
 some_unrelated_key: 42
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
-               maliput::common::road_network_description_parser_error);
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, RejectsCountryInObject) {
@@ -1751,8 +1750,7 @@ odr_object_types:
       device_type: road_marking
       description: "Should fail"
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
-               maliput::common::road_network_description_parser_error);
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, RejectsCountryRevisionInObject) {
@@ -1765,8 +1763,7 @@ odr_object_types:
       device_type: road_marking
       description: "Should fail"
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
-               maliput::common::road_network_description_parser_error);
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, RejectsBulbsInObject) {
@@ -1784,8 +1781,7 @@ odr_object_types:
           color: red
           type: round
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
-               maliput::common::road_network_description_parser_error);
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, RejectsRuleStatesInObject) {
@@ -1800,8 +1796,7 @@ odr_object_types:
         - conditions: []
           value: "Stop"
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
-               maliput::common::road_network_description_parser_error);
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, RejectsSignalDeviceTypeInObject) {
@@ -1813,8 +1808,7 @@ odr_object_types:
       device_type: traffic_light
       description: "Should fail"
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
-               maliput::common::road_network_description_parser_error);
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, RejectsTrafficSignDeviceTypeInObject) {
@@ -1826,8 +1820,7 @@ odr_object_types:
       device_type: traffic_sign
       description: "Should fail"
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
-               maliput::common::road_network_description_parser_error);
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, RejectsObjectDeviceTypeInSignal) {
@@ -1869,8 +1862,7 @@ odr_object_types:
       device_type: road_marking
       description: "Second wildcard"
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
-               maliput::common::road_network_description_parser_error);
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, SignalAndObjectWithSameFingerprintDoNotConflict) {

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -1631,6 +1631,488 @@ odr_signal_types:
   EXPECT_EQ(result->device_semantics, "concrete_name");
 }
 
+// ============================================================================
+// odr_object_types parsing
+// ============================================================================
+
+// Helper that filters `defs` by device_type for assertions on object/signal subsets.
+std::vector<TrafficControlDeviceDefinition> FilterByDeviceType(
+    const std::vector<TrafficControlDeviceDefinition>& defs, TrafficControlDeviceType type) {
+  std::vector<TrafficControlDeviceDefinition> out;
+  std::copy_if(defs.begin(), defs.end(), std::back_inserter(out),
+               [type](const TrafficControlDeviceDefinition& d) { return d.device_type == type; });
+  return out;
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, LoadObjectsOnlyDatabase) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+      name: "StopLine"
+    properties:
+      device_type: road_marking
+      device_semantics: stop_line
+      description: "Stop line road marking"
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      description: "Generic pole"
+      is_position_dynamic: false
+      default_bounding_box:
+        length: 0.2
+        width: 0.2
+        height: 2.0
+)";
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  EXPECT_EQ(defs.size(), 2);
+
+  const auto road_markings = FilterByDeviceType(defs, TrafficControlDeviceType::kRoadMarking);
+  ASSERT_EQ(road_markings.size(), 1);
+  EXPECT_EQ(road_markings[0].fingerprint.type, "roadMark");
+  ASSERT_TRUE(road_markings[0].fingerprint.name.has_value());
+  EXPECT_EQ(road_markings[0].fingerprint.name.value(), "StopLine");
+  EXPECT_FALSE(road_markings[0].fingerprint.country.has_value());
+  EXPECT_FALSE(road_markings[0].fingerprint.country_revision.has_value());
+  ASSERT_TRUE(road_markings[0].device_semantics.has_value());
+  EXPECT_EQ(road_markings[0].device_semantics.value(), "stop_line");
+  EXPECT_TRUE(road_markings[0].bulbs.empty());
+  EXPECT_TRUE(road_markings[0].rule_states.empty());
+
+  const auto road_objects = FilterByDeviceType(defs, TrafficControlDeviceType::kRoadObject);
+  ASSERT_EQ(road_objects.size(), 1);
+  EXPECT_EQ(road_objects[0].fingerprint.type, "pole");
+  EXPECT_FALSE(road_objects[0].fingerprint.subtype.has_value());
+  EXPECT_FALSE(road_objects[0].fingerprint.name.has_value());
+  ASSERT_TRUE(road_objects[0].default_bounding_box.has_value());
+  EXPECT_NEAR(road_objects[0].default_bounding_box->length, 0.2, kTolerance);
+  EXPECT_NEAR(road_objects[0].default_bounding_box->width, 0.2, kTolerance);
+  EXPECT_NEAR(road_objects[0].default_bounding_box->height, 2.0, kTolerance);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, LoadBothRootsDatabase) {
+  const char kDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "206"
+      subtype: "-1"
+    properties:
+      device_type: traffic_sign
+      device_semantics: give_way
+      description: "Give way sign"
+      rule_states:
+        - conditions: []
+          value: "StopIfSafe"
+odr_object_types:
+  - odr_representation:
+      type: crosswalk
+    properties:
+      device_type: road_marking
+      device_semantics: crosswalk
+      description: "Generic crosswalk"
+)";
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  ASSERT_EQ(defs.size(), 2);
+  EXPECT_EQ(FilterByDeviceType(defs, TrafficControlDeviceType::kTrafficSign).size(), 1);
+  EXPECT_EQ(FilterByDeviceType(defs, TrafficControlDeviceType::kRoadMarking).size(), 1);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, EmptyObjectArrayIsValid) {
+  const char kDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "206"
+    properties:
+      device_type: traffic_sign
+      description: "Sign"
+odr_object_types: []
+)";
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  ASSERT_EQ(defs.size(), 1);
+  EXPECT_EQ(defs[0].device_type, TrafficControlDeviceType::kTrafficSign);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, MissingBothRootsIsRejected) {
+  const char kDb[] = R"(
+some_unrelated_key: 42
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, RejectsCountryInObject) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+      country: "DE"
+    properties:
+      device_type: road_marking
+      description: "Should fail"
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, RejectsCountryRevisionInObject) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+      country_revision: "2017"
+    properties:
+      device_type: road_marking
+      description: "Should fail"
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, RejectsBulbsInObject) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+    properties:
+      device_type: road_marking
+      description: "Should fail"
+      bulbs:
+        - id: "Bulb"
+          position_traffic_light: [0.0, 0.0, 0.0]
+          orientation_traffic_light: [1.0, 0.0, 0.0, 0.0]
+          color: red
+          type: round
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, RejectsRuleStatesInObject) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+    properties:
+      device_type: road_marking
+      description: "Should fail"
+      rule_states:
+        - conditions: []
+          value: "Stop"
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, RejectsSignalDeviceTypeInObject) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+    properties:
+      device_type: traffic_light
+      description: "Should fail"
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, RejectsTrafficSignDeviceTypeInObject) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+    properties:
+      device_type: traffic_sign
+      description: "Should fail"
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, RejectsObjectDeviceTypeInSignal) {
+  const char kRoadMarkingInSignal[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+    properties:
+      device_type: road_marking
+      description: "Should fail"
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kRoadMarkingInSignal),
+               maliput::common::road_network_description_parser_error);
+  const char kRoadObjectInSignal[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+    properties:
+      device_type: road_object
+      description: "Should fail"
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kRoadObjectInSignal),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, EqualSpecificityObjectConflictIsRejected) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+      name: "*"
+    properties:
+      device_type: road_marking
+      description: "First wildcard"
+  - odr_representation:
+      type: roadMark
+      name: "*"
+    properties:
+      device_type: road_marking
+      description: "Second wildcard"
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb),
+               maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, SignalAndObjectWithSameFingerprintDoNotConflict) {
+  // The two entries share `type = "roadMark"` and have equal specificity. Per the per-root
+  // validation rule, they MUST NOT be flagged as conflicting because signals and objects
+  // live in disjoint namespaces.
+  const char kDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "roadMark"
+    properties:
+      device_type: traffic_sign
+      description: "Signal entry"
+      rule_states: []
+odr_object_types:
+  - odr_representation:
+      type: "roadMark"
+    properties:
+      device_type: road_marking
+      description: "Object entry"
+)";
+  EXPECT_NO_THROW({
+    const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+    EXPECT_EQ(defs.size(), 2);
+  });
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, WildcardWorksForObjectFields) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: roadMark
+      name: "*"
+    properties:
+      device_type: road_marking
+      description: "Wildcard name catch-all"
+  - odr_representation:
+      type: roadMark
+      name: "StopLine"
+    properties:
+      device_type: road_marking
+      device_semantics: stop_line
+      description: "Specific stop line"
+)";
+  // Two roadMark entries, one with wildcard name and one with concrete name —
+  // different specificities, so no conflict.
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  ASSERT_EQ(defs.size(), 2);
+}
+
+GTEST_TEST(OdrObjectTypesParserTest, TypeOnlyObjectEntryParses) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      description: "Minimal object entry"
+)";
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  ASSERT_EQ(defs.size(), 1);
+  EXPECT_EQ(defs[0].fingerprint.type, "pole");
+  EXPECT_FALSE(defs[0].fingerprint.subtype.has_value());
+  EXPECT_FALSE(defs[0].fingerprint.name.has_value());
+  EXPECT_FALSE(defs[0].fingerprint.country.has_value());
+  EXPECT_FALSE(defs[0].fingerprint.country_revision.has_value());
+}
+
+// ============================================================================
+// SpecificityForObject — direct unit tests
+// ============================================================================
+
+GTEST_TEST(SpecificityForObjectTest, CountsOnlyTypeSubtypeName) {
+  const TrafficControlDeviceFingerprint all_wildcards{
+      .type = "*", .subtype = "*", .country = std::nullopt, .country_revision = std::nullopt, .name = "*"};
+  EXPECT_EQ(TrafficControlDeviceParser::SpecificityForObject(all_wildcards), 0);
+
+  const TrafficControlDeviceFingerprint type_only{
+      .type = "roadMark", .subtype = "*", .country = std::nullopt, .country_revision = std::nullopt, .name = "*"};
+  EXPECT_EQ(TrafficControlDeviceParser::SpecificityForObject(type_only), 1);
+
+  const TrafficControlDeviceFingerprint all_three{.type = "roadMark",
+                                                  .subtype = "10",
+                                                  .country = std::nullopt,
+                                                  .country_revision = std::nullopt,
+                                                  .name = "StopLine"};
+  EXPECT_EQ(TrafficControlDeviceParser::SpecificityForObject(all_three), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Device-level default_bounding_box (BoundingBoxDimensions) parsing.
+// ---------------------------------------------------------------------------
+
+GTEST_TEST(DefaultBoundingBoxParserTest, FullySpecifiedFields) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      default_bounding_box:
+        length: 0.5
+        width: 0.6
+        height: 2.4
+)";
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  ASSERT_EQ(defs.size(), 1);
+  ASSERT_TRUE(defs[0].default_bounding_box.has_value());
+  const auto& bbox = *defs[0].default_bounding_box;
+  EXPECT_NEAR(bbox.length, 0.5, kTolerance);
+  EXPECT_NEAR(bbox.width, 0.6, kTolerance);
+  EXPECT_NEAR(bbox.height, 2.4, kTolerance);
+}
+
+GTEST_TEST(DefaultBoundingBoxParserTest, WorksOnSignalEntries) {
+  const char kDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "206"
+    properties:
+      device_type: traffic_sign
+      device_semantics: stop
+      default_bounding_box:
+        length: 0.05
+        width: 0.6
+        height: 0.6
+)";
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  ASSERT_EQ(defs.size(), 1);
+  ASSERT_TRUE(defs[0].default_bounding_box.has_value());
+  EXPECT_NEAR(defs[0].default_bounding_box->length, 0.05, kTolerance);
+  EXPECT_NEAR(defs[0].default_bounding_box->width, 0.6, kTolerance);
+  EXPECT_NEAR(defs[0].default_bounding_box->height, 0.6, kTolerance);
+}
+
+GTEST_TEST(DefaultBoundingBoxParserTest, MissingLengthRejected) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      default_bounding_box:
+        width: 1.0
+        height: 1.0
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(DefaultBoundingBoxParserTest, MissingWidthRejected) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      default_bounding_box:
+        length: 1.0
+        height: 1.0
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(DefaultBoundingBoxParserTest, MissingHeightRejected) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      default_bounding_box:
+        length: 1.0
+        width: 1.0
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(DefaultBoundingBoxParserTest, NegativeDimensionRejected) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      default_bounding_box:
+        length: 1.0
+        width: -1.0
+        height: 1.0
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(DefaultBoundingBoxParserTest, UnknownFieldRejected) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      default_bounding_box:
+        length: 1.0
+        width: 1.0
+        height: 1.0
+        p_min: [0.0, 0.0, 0.0]
+)";
+  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
+}
+
+GTEST_TEST(DefaultBoundingBoxParserTest, NullDefaultBoundingBoxLeavesItUnset) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      default_bounding_box: null
+)";
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  ASSERT_EQ(defs.size(), 1);
+  EXPECT_FALSE(defs[0].default_bounding_box.has_value());
+}
+
+GTEST_TEST(DefaultBoundingBoxParserTest, ZeroDimensionsAllowed) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: pole
+    properties:
+      device_type: road_object
+      default_bounding_box:
+        length: 0.0
+        width: 0.0
+        height: 0.0
+)";
+  const auto defs = TrafficControlDeviceParser::LoadFromString(kDb);
+  ASSERT_EQ(defs.size(), 1);
+  ASSERT_TRUE(defs[0].default_bounding_box.has_value());
+  EXPECT_NEAR(defs[0].default_bounding_box->length, 0.0, kTolerance);
+  EXPECT_NEAR(defs[0].default_bounding_box->width, 0.0, kTolerance);
+  EXPECT_NEAR(defs[0].default_bounding_box->height, 0.0, kTolerance);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace traffic_control_device


### PR DESCRIPTION
# 🎉 New feature

Closes #448 

## Summary
* New odr_object_types entry in database supporting both `RoadObjects` and `RoadMarkings`.
* Change bounding box min and max points for length/width/height dimensions.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
