### PR TITLE
Empty RoadMarkingBook and RoadObjectType deprecation

### DIFF
--- a/resources/TwoRoadsWithRoadObjects.xodr
+++ b/resources/TwoRoadsWithRoadObjects.xodr
@@ -36,7 +36,7 @@
    - obj_vegetation: vegetation at s=0, t=4, hdg=pi/3, with star-shaped outline (cornerLocal)
    - obj_barrier:    barrier at s=20, t=3 (right shoulder), with validity toLane=-1
    - obj_building:   building at s=50, t=-5, with radius instead of length/width
-   - obj_crosswalk:  crosswalk at s=100, t=0, spanning both lanes, with outline (cornerRoad)
+   - obj_obstacle:  obstacle at s=100, t=0, spanning both lanes, with outline (cornerRoad)
 -->
 <OpenDRIVE>
     <header revMajor="1" revMinor="1" name="TwoRoadsWithRoadObjects" version="1.00" date="Tue Apr 08 12:00:00 2026" north="0.0" south="0.0" east="0.0" west="0.0" maxRoad="2" maxJunc="0" maxPrg="0">
@@ -113,14 +113,14 @@
                     dynamic="no">
             </object>
 
-            <!-- Object 4: Crosswalk spanning both lanes, with an outline. -->
-            <object id="obj_crosswalk" name="PedestrianCrossing" type="crosswalk"
+            <!-- Object 4: Obstacle spanning both lanes, with an outline. -->
+            <object id="obj_obstacle" name="RoadObstacle" type="obstacle"
                     s="100.0" t="0.0" zOffset="0.0"
                     length="4.0" width="7.0" height="0.05"
                     orientation="none" dynamic="no">
                 <validity fromLane="-1" toLane="1"/>
                 <outlines>
-                    <outline id="crosswalk_outline" closed="true">
+                    <outline id="obstacle_outline" closed="true">
                         <cornerRoad s="96.0" t="-3.5" dz="0.0" height="0.05"/>
                         <cornerRoad s="96.0" t="3.5" dz="0.0" height="0.05"/>
                         <cornerRoad s="100.0" t="3.5" dz="0.0" height="0.05"/>

--- a/src/maliput_malidrive/builder/road_network_builder.cc
+++ b/src/maliput_malidrive/builder/road_network_builder.cc
@@ -42,6 +42,7 @@
 #include <maliput/base/manual_rulebook.h>
 #include <maliput/base/phase_based_right_of_way_rule_state_provider.h>
 #include <maliput/base/phase_ring_book_loader.h>
+#include <maliput/base/road_marking_book.h>
 #include <maliput/base/road_object_book.h>
 #include <maliput/base/rule_registry.h>
 #include <maliput/base/traffic_light_book.h>
@@ -153,7 +154,8 @@ std::unique_ptr<maliput::api::RoadNetwork> RoadNetworkBuilder::operator()() cons
       std::move(rg), std::move(rule_book), std::move(traffic_light_book), std::move(intersection_book),
       std::move(phase_ring_book), std::move(state_provider), std::move(manual_phase_provider), std::move(rule_registry),
       std::move(discrete_value_rule_state_provider), std::move(range_value_rule_state_provider),
-      std::move(road_object_book), std::move(traffic_sign_book));
+      std::move(road_object_book), std::move(traffic_sign_book),
+      std::unique_ptr<maliput::api::objects::RoadMarkingBook>());
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/road_object_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.cc
@@ -99,7 +99,7 @@ maliput::api::objects::RoadObjectType MapXodrObjectType(
     case XodrType::kVan:
     case XodrType::kNone:
       return MaliputType::kUnknown;
-    // @}
+      // @}
   }
   return MaliputType::kUnknown;  // Fallback for any future additions.
 }

--- a/src/maliput_malidrive/builder/road_object_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.cc
@@ -42,39 +42,52 @@ maliput::api::objects::RoadObjectType MapXodrObjectType(
   }
 
   switch (xodr_type.value()) {
+    // @{
     case XodrType::kBarrier:
     case XodrType::kSoundBarrier:
     case XodrType::kRailing:
       return MaliputType::kBarrier;
+    // @}
+    // @{
     case XodrType::kBuilding:
       return MaliputType::kBuilding;
-    case XodrType::kCrosswalk:
-      return MaliputType::kCrosswalk;
+    // @}
     case XodrType::kGantry:
       return MaliputType::kGantry;
+    // @}
+    // @{
     case XodrType::kObstacle:
       return MaliputType::kObstacle;
-    case XodrType::kParkingSpace:
-      return MaliputType::kParkingSpace;
+    // @}
+    // @{
     case XodrType::kPole:
     case XodrType::kWind:
     case XodrType::kStreetLamp:
       return MaliputType::kPole;
-    case XodrType::kRoadMark:
-      if ((name.has_value() && name.value() == "stopLine") || (subtype.has_value() && subtype.value() == "stopLine")) {
-        return MaliputType::kStopLine;
-      }
-      return MaliputType::kRoadMark;
+    // @}
+    // @{
     case XodrType::kRoadSurface:
-    case XodrType::kPatch:
-      return MaliputType::kRoadSurface;
     case XodrType::kTrafficIsland:
       return MaliputType::kTrafficIsland;
+    // @}
+    // @{
     case XodrType::kTree:
       return MaliputType::kTree;
+    // @}
+    // @{
     case XodrType::kVegetation:
       return MaliputType::kVegetation;
+    // @}
+    // These types are now covered by RoadMarkingTypes, so we map them to kUnknown to avoid misclassification.
+    // @{
+    case XodrType::kCrosswalk:
+    case XodrType::kPatch:
+    case XodrType::kParkingSpace:
+    case XodrType::kRoadMark:
+      return MaliputType::kUnknown;
+    // @}
     // Deprecated types map to kUnknown.
+    // @{
     case XodrType::kBike:
     case XodrType::kBus:
     case XodrType::kCar:
@@ -86,6 +99,7 @@ maliput::api::objects::RoadObjectType MapXodrObjectType(
     case XodrType::kVan:
     case XodrType::kNone:
       return MaliputType::kUnknown;
+    // @}
   }
   return MaliputType::kUnknown;  // Fallback for any future additions.
 }

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -1534,7 +1534,7 @@ TEST_F(RoadObjectBookBuilderTest, GetRoadObjectById) {
   using Id = maliput::api::objects::RoadObject::Id;
   EXPECT_NE(rob_->GetRoadObject(Id("obj_barrier")), nullptr);
   EXPECT_NE(rob_->GetRoadObject(Id("obj_building")), nullptr);
-  EXPECT_NE(rob_->GetRoadObject(Id("obj_crosswalk")), nullptr);
+  EXPECT_NE(rob_->GetRoadObject(Id("obj_obstacle")), nullptr);
   EXPECT_NE(rob_->GetRoadObject(Id("obj_vegetation")), nullptr);
   EXPECT_EQ(rob_->GetRoadObject(Id("nonexistent")), nullptr);
 }
@@ -1547,8 +1547,8 @@ TEST_F(RoadObjectBookBuilderTest, FindByType) {
   const auto buildings = rob_->FindByType(RoadObjectType::kBuilding);
   EXPECT_EQ(1u, buildings.size());
 
-  const auto crosswalks = rob_->FindByType(RoadObjectType::kCrosswalk);
-  EXPECT_EQ(1u, crosswalks.size());
+  const auto obstacles = rob_->FindByType(RoadObjectType::kObstacle);
+  EXPECT_EQ(1u, obstacles.size());
 
   const auto vegetation = rob_->FindByType(RoadObjectType::kVegetation);
   EXPECT_EQ(1u, vegetation.size());

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -68,13 +68,9 @@ TEST_F(RoadObjectTypeMapperTest, DirectMappings) {
 
   EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kBarrier));
   EXPECT_EQ(MaliputType::kBuilding, MapXodrObjectType(XodrType::kBuilding));
-  EXPECT_EQ(MaliputType::kCrosswalk, MapXodrObjectType(XodrType::kCrosswalk));
   EXPECT_EQ(MaliputType::kGantry, MapXodrObjectType(XodrType::kGantry));
   EXPECT_EQ(MaliputType::kObstacle, MapXodrObjectType(XodrType::kObstacle));
-  EXPECT_EQ(MaliputType::kParkingSpace, MapXodrObjectType(XodrType::kParkingSpace));
   EXPECT_EQ(MaliputType::kPole, MapXodrObjectType(XodrType::kPole));
-  EXPECT_EQ(MaliputType::kRoadMark, MapXodrObjectType(XodrType::kRoadMark));
-  EXPECT_EQ(MaliputType::kRoadSurface, MapXodrObjectType(XodrType::kRoadSurface));
   EXPECT_EQ(MaliputType::kTrafficIsland, MapXodrObjectType(XodrType::kTrafficIsland));
   EXPECT_EQ(MaliputType::kTree, MapXodrObjectType(XodrType::kTree));
   EXPECT_EQ(MaliputType::kVegetation, MapXodrObjectType(XodrType::kVegetation));
@@ -88,32 +84,16 @@ TEST_F(RoadObjectTypeMapperTest, CloseMappings) {
   EXPECT_EQ(MaliputType::kPole, MapXodrObjectType(XodrType::kWind));
   EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kRailing));
   EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kSoundBarrier));
-  EXPECT_EQ(MaliputType::kRoadSurface, MapXodrObjectType(XodrType::kPatch));
-}
-
-TEST_F(RoadObjectTypeMapperTest, StopLineMappings) {
-  using XodrType = xodr::object::Object::ObjectType;
-  using MaliputType = maliput::api::objects::RoadObjectType;
-
-  // roadMark with name "stopLine" → kStopLine.
-  EXPECT_EQ(MaliputType::kStopLine, MapXodrObjectType(XodrType::kRoadMark, std::string("stopLine"), std::nullopt));
-  // roadMark with subtype "stopLine" → kStopLine.
-  EXPECT_EQ(MaliputType::kStopLine, MapXodrObjectType(XodrType::kRoadMark, std::nullopt, std::string("stopLine")));
-  // roadMark with both name and subtype "stopLine" → kStopLine.
-  EXPECT_EQ(MaliputType::kStopLine,
-            MapXodrObjectType(XodrType::kRoadMark, std::string("stopLine"), std::string("stopLine")));
-  // roadMark without stop-line indicators → kRoadMark.
-  EXPECT_EQ(MaliputType::kRoadMark, MapXodrObjectType(XodrType::kRoadMark, std::nullopt, std::nullopt));
-  EXPECT_EQ(MaliputType::kRoadMark,
-            MapXodrObjectType(XodrType::kRoadMark, std::string("arrow"), std::string("turnLeft")));
-  // Non-roadMark type with "stopLine" name → still maps by type, not to kStopLine.
-  EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kBarrier, std::string("stopLine"), std::nullopt));
 }
 
 TEST_F(RoadObjectTypeMapperTest, UnknownMappings) {
   using XodrType = xodr::object::Object::ObjectType;
   using MaliputType = maliput::api::objects::RoadObjectType;
 
+  EXPECT_EQ(MaliputType::kUnknown, MapXodrObjectType(XodrType::kCrosswalk));
+  EXPECT_EQ(MaliputType::kUnknown, MapXodrObjectType(XodrType::kPatch));
+  EXPECT_EQ(MaliputType::kUnknown, MapXodrObjectType(XodrType::kParkingSpace));
+  EXPECT_EQ(MaliputType::kUnknown, MapXodrObjectType(XodrType::kRoadMark));
   EXPECT_EQ(MaliputType::kUnknown, MapXodrObjectType(XodrType::kBike));
   EXPECT_EQ(MaliputType::kUnknown, MapXodrObjectType(XodrType::kCar));
   EXPECT_EQ(MaliputType::kUnknown, MapXodrObjectType(XodrType::kVan));

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -197,15 +197,15 @@ TEST_F(RoadObjectBuilderTest, BuildingObjectWithRadius) {
   EXPECT_EQ(0, road_object->num_outlines());
 }
 
-TEST_F(RoadObjectBuilderTest, CrosswalkObjectWithOutline) {
-  // obj_crosswalk: crosswalk at s=100, t=0, with outlines.
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_crosswalk"));
+TEST_F(RoadObjectBuilderTest, ObstacleObjectWithOutline) {
+  // obj_obstacle: obstacle at s=100, t=0, with outlines.
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
   ASSERT_NE(road_object, nullptr);
 
-  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_crosswalk"));
-  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kCrosswalk);
+  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_obstacle"));
+  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kObstacle);
 
-  // The crosswalk has one outline with 4 corners.
+  // The obstacle has one outline with 4 corners.
   ASSERT_EQ(1, road_object->num_outlines());
   const auto* outline = road_object->outline(0);
   ASSERT_NE(outline, nullptr);
@@ -321,12 +321,12 @@ TEST_F(RoadObjectBuilderTest, VegetationOrientation) {
 }
 
 TEST_F(RoadObjectBuilderTest, OutlinesVectorAccessor) {
-  // obj_crosswalk has 1 outline; obj_building has 0.
-  const auto* crosswalk = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_crosswalk"));
-  ASSERT_NE(crosswalk, nullptr);
-  const auto& crosswalk_outlines = crosswalk->outlines();
-  ASSERT_EQ(1u, crosswalk_outlines.size());
-  EXPECT_NE(crosswalk_outlines[0], nullptr);
+  // obj_obstacle has 1 outline; obj_building has 0.
+  const auto* obstacle = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
+  ASSERT_NE(obstacle, nullptr);
+  const auto& obstacle_outlines = obstacle->outlines();
+  ASSERT_EQ(1u, obstacle_outlines.size());
+  EXPECT_NE(obstacle_outlines[0], nullptr);
 
   const auto* building = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_building"));
   ASSERT_NE(building, nullptr);
@@ -349,8 +349,8 @@ TEST_F(RoadObjectBuilderTest, RoadObjectPositionHasLanePosition) {
 }
 
 TEST_F(RoadObjectBuilderTest, OutlineCornerHeight) {
-  // obj_crosswalk outline corners have height = 0.05.
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_crosswalk"));
+  // obj_obstacle outline corners have height = 0.05.
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
   ASSERT_NE(road_object, nullptr);
   ASSERT_EQ(1, road_object->num_outlines());
 
@@ -377,14 +377,14 @@ TEST_F(RoadObjectBuilderTest, VegetationOutlineCornerHeight) {
 }
 
 TEST_F(RoadObjectBuilderTest, OutlineId) {
-  // obj_crosswalk outline has id "crosswalk_outline" from the XODR.
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_crosswalk"));
+  // obj_obstacle outline has id "obstacle_outline" from the XODR.
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
   ASSERT_NE(road_object, nullptr);
   ASSERT_EQ(1, road_object->num_outlines());
 
   const auto* outline = road_object->outline(0);
   ASSERT_NE(outline, nullptr);
-  EXPECT_EQ(outline->id(), maliput::api::objects::Outline::Id("crosswalk_outline"));
+  EXPECT_EQ(outline->id(), maliput::api::objects::Outline::Id("obstacle_outline"));
 }
 
 TEST_F(RoadObjectBuilderTest, VegetationOutlineId) {
@@ -410,15 +410,15 @@ TEST_F(RoadObjectBuilderTest, FindByLane) {
   }
   EXPECT_TRUE(found_barrier);
 
-  // obj_crosswalk spans both lanes (fromLane=-1 toLane=1).
+  // obj_obstacle spans both lanes (fromLane=-1 toLane=1).
   const auto objects_lane_1 = road_object_book_->FindByLane(maliput::api::LaneId("1_0_1"));
-  bool found_crosswalk = false;
+  bool found_obstacle = false;
   for (const auto* obj : objects_lane_1) {
-    if (obj->id() == maliput::api::objects::RoadObject::Id("obj_crosswalk")) {
-      found_crosswalk = true;
+    if (obj->id() == maliput::api::objects::RoadObject::Id("obj_obstacle")) {
+      found_obstacle = true;
     }
   }
-  EXPECT_TRUE(found_crosswalk);
+  EXPECT_TRUE(found_obstacle);
 
   // No objects on road 2's lanes.
   const auto objects_road2 = road_object_book_->FindByLane(maliput::api::LaneId("2_0_1"));
@@ -440,114 +440,6 @@ TEST_F(RoadObjectBuilderTest, FindInRadius) {
   // Search far from any object should return empty.
   const auto far_away = road_object_book_->FindInRadius(maliput::api::InertialPosition(500.0, 500.0, 0.0), 1.0);
   EXPECT_TRUE(far_away.empty());
-}
-
-// ---------------------------------------------------------------------------
-// StopLine integration tests.
-// Uses the RoadWithStopLine.xodr resource.
-// ---------------------------------------------------------------------------
-
-class StopLineBuilderTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    const std::string xodr_file_path = utility::FindResourceInPath("RoadWithStopLine.xodr", kMalidriveResourceFolder);
-
-    road_network_ = RoadNetworkBuilder(
-        RoadNetworkConfiguration::FromMap({
-                                              {params::kOpendriveFile, xodr_file_path},
-                                              {params::kOmitNonDrivableLanes, "false"},
-                                              {params::kLinearTolerance, std::to_string(kLinearTolerance)},
-                                          })
-            .ToStringMap())();
-    ASSERT_NE(road_network_, nullptr);
-    road_object_book_ = road_network_->road_object_book();
-    ASSERT_NE(road_object_book_, nullptr);
-  }
-
-  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
-  const maliput::api::objects::RoadObjectBook* road_object_book_{};
-  constexpr static double kLinearTolerance = 1e-5;
-};
-
-TEST_F(StopLineBuilderTest, RoadObjectBookIsPopulated) {
-  const auto all_objects = road_object_book_->RoadObjects();
-  EXPECT_EQ(3u, all_objects.size());
-}
-
-TEST_F(StopLineBuilderTest, StopLineObjectFromName) {
-  const auto* road_object =
-      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line_name"));
-  ASSERT_NE(road_object, nullptr);
-
-  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_stop_line_name"));
-  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kStopLine);
-  EXPECT_EQ(road_object->name(), "stopLine");
-  EXPECT_FALSE(road_object->is_dynamic());
-
-  // Position: straight road at hdg=0, s=50, t=0 → inertial x≈50, y≈0.
-  const auto& pos = road_object->position().inertial_position();
-  EXPECT_NEAR(pos.x(), 50.0, 0.5);
-  EXPECT_NEAR(pos.y(), 0.0, 0.5);
-
-  // Bounding box: length=7, width=0.3, height=0.01.
-  const auto& bb = road_object->bounding_box();
-  EXPECT_NEAR(bb.box_size().x(), 7.0, 1e-3);
-  EXPECT_NEAR(bb.box_size().y(), 0.3, 1e-3);
-  EXPECT_NEAR(bb.box_size().z(), 0.01, 1e-3);
-
-  // Related lanes: spans both lanes via validity.
-  EXPECT_GE(road_object->related_lanes().size(), 2u);
-}
-
-TEST_F(StopLineBuilderTest, StopLineObjectFromSubtype) {
-  const auto* road_object =
-      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_stop_line_subtype"));
-  ASSERT_NE(road_object, nullptr);
-
-  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_stop_line_subtype"));
-  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kStopLine);
-  EXPECT_EQ(road_object->subtype(), "stopLine");
-  EXPECT_FALSE(road_object->is_dynamic());
-
-  // Position: straight road at hdg=0, s=80, t=0 → inertial x≈80, y≈0.
-  const auto& pos = road_object->position().inertial_position();
-  EXPECT_NEAR(pos.x(), 80.0, 0.5);
-  EXPECT_NEAR(pos.y(), 0.0, 0.5);
-
-  // Bounding box: length=7, width=0.3, height=0.01.
-  const auto& bb = road_object->bounding_box();
-  EXPECT_NEAR(bb.box_size().x(), 7.0, 1e-3);
-  EXPECT_NEAR(bb.box_size().y(), 0.3, 1e-3);
-  EXPECT_NEAR(bb.box_size().z(), 0.01, 1e-3);
-
-  // Related lanes: spans both lanes via validity.
-  EXPECT_GE(road_object->related_lanes().size(), 2u);
-}
-
-TEST_F(StopLineBuilderTest, RegularRoadMarkObject) {
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_road_mark"));
-  ASSERT_NE(road_object, nullptr);
-
-  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_road_mark"));
-  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kRoadMark);
-  EXPECT_EQ(road_object->name(), "TurnArrow");
-}
-
-TEST_F(StopLineBuilderTest, FindByTypeStopLine) {
-  const auto stop_lines = road_object_book_->FindByType(maliput::api::objects::RoadObjectType::kStopLine);
-  ASSERT_EQ(2u, stop_lines.size());
-  const auto has_id = [&](const std::string& id) {
-    return std::any_of(stop_lines.begin(), stop_lines.end(),
-                       [&](const auto* obj) { return obj->id() == maliput::api::objects::RoadObject::Id(id); });
-  };
-  EXPECT_TRUE(has_id("obj_stop_line_name"));
-  EXPECT_TRUE(has_id("obj_stop_line_subtype"));
-}
-
-TEST_F(StopLineBuilderTest, FindByTypeRoadMark) {
-  const auto road_marks = road_object_book_->FindByType(maliput::api::objects::RoadObjectType::kRoadMark);
-  ASSERT_EQ(1u, road_marks.size());
-  EXPECT_EQ(road_marks[0]->id(), maliput::api::objects::RoadObject::Id("obj_road_mark"));
 }
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/maliput/maliput/pull/747

## Summary
* Add empty RoadMarkingBook to the RoadNetwork
* Deprecate RoadObjectTypes that are covered by RoadMarkingTypes
* Update tests

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.