### PR TITLE
RoadMarkingBuilder

### DIFF
--- a/resources/RoadWithRoadMarkings.xodr
+++ b/resources/RoadWithRoadMarkings.xodr
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2026, Woven by Toyota. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ Test XODR file for RoadMarkingBuilder tests.
+ Road 1: 100 m straight road at x=[0,100], y=0, hdg=0.
+ Contains road marking objects:
+   - rm_stop_line: roadMark at s=30, t=0, name="StopLine", spanning both lanes
+   - rm_crosswalk: crosswalk at s=50, t=0, spanning both lanes
+   - rm_arrow: roadMark at s=70, t=-1.75, name="ArrowForward", on lane -1 only
+   - rm_pole: pole at s=80, t=4 (this is a road_object, not road_marking)
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="1" name="RoadWithRoadMarkings" version="1.00" date="Mon Jun 01 12:00:00 2026" north="0.0" south="0.0" east="0.0" west="0.0" maxRoad="1" maxJunc="0" maxPrg="0">
+    </header>
+    <road name="TestRoad1" length="100.0" id="1" junction="-1">
+        <link>
+        </link>
+        <planView>
+            <geometry s="0.0" x="0.0" y="0.0" hdg="0.0" length="100.0">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0">
+                <left>
+                    <lane id="1" type="driving" level="0">
+                        <width sOffset="0.0" a="3.5" b="0.0" c="0.0" d="0.0"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="driving" level="0">
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="0">
+                        <width sOffset="0.0" a="3.5" b="0.0" c="0.0" d="0.0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+            <!-- Stop line spanning both lanes -->
+            <object id="rm_stop_line" name="StopLine" type="roadMark"
+                    s="30.0" t="0.0" zOffset="0.0"
+                    length="0.3" width="7.0" height="0.0"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="1"/>
+            </object>
+
+            <!-- Crosswalk spanning both lanes -->
+            <object id="rm_crosswalk" name="Crosswalk1" type="crosswalk"
+                    s="50.0" t="0.0" zOffset="0.0"
+                    length="4.0" width="7.0" height="0.0"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="1"/>
+            </object>
+
+            <!-- Arrow forward on right lane only -->
+            <object id="rm_arrow" name="ArrowForward" type="roadMark"
+                    s="70.0" t="-1.75" zOffset="0.0"
+                    length="3.0" width="1.0" height="0.0"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="-1"/>
+            </object>
+
+            <!-- Pole (road_object, NOT road_marking) -->
+            <object id="rm_pole" name="LightPole" type="pole"
+                    s="80.0" t="4.0" zOffset="0.0"
+                    radius="0.15" height="5.0"
+                    dynamic="no">
+            </object>
+        </objects>
+    </road>
+</OpenDRIVE>

--- a/resources/traffic_control_device_db/road_marking_test_db.yaml
+++ b/resources/traffic_control_device_db/road_marking_test_db.yaml
@@ -1,0 +1,82 @@
+# -*- yaml -*-
+#
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Woven by Toyota. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Traffic Control Device Database for RoadMarkingBuilder tests.
+
+odr_object_types:
+  # Stop line matched by type=roadMark, name=StopLine.
+  - odr_representation:
+      type: roadMark
+      subtype: "*"
+      name: "StopLine"
+    properties:
+      device_type: road_marking
+      device_semantics: stop_line
+      description: "Stop line road marking"
+
+  # Crosswalk matched by type=crosswalk.
+  - odr_representation:
+      type: crosswalk
+      subtype: "*"
+      name: "*"
+    properties:
+      device_type: road_marking
+      device_semantics: crosswalk
+      description: "Generic crosswalk road marking"
+
+  # Arrow forward matched by type=roadMark, name=ArrowForward.
+  - odr_representation:
+      type: roadMark
+      subtype: "*"
+      name: "ArrowForward"
+    properties:
+      device_type: road_marking
+      device_semantics: arrow_forward
+      description: "Forward arrow road marking"
+
+  # Generic roadMark (fallback with lower specificity).
+  - odr_representation:
+      type: roadMark
+      subtype: "*"
+      name: "*"
+    properties:
+      device_type: road_marking
+      device_semantics: other
+      description: "Generic road marking"
+
+  # A pole entry (road_object device_type, NOT road_marking).
+  - odr_representation:
+      type: pole
+      subtype: "*"
+      name: "*"
+    properties:
+      device_type: road_object
+      description: "Generic pole object"

--- a/src/maliput_malidrive/builder/CMakeLists.txt
+++ b/src/maliput_malidrive/builder/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(builder
   road_object_book_builder.cc
   road_object_builder.cc
   road_object_type_mapper.cc
+  road_marking_builder.cc
+  road_marking_type_mapper.cc
   rule_registry_builder.cc
   road_rulebook_builder.cc
   road_rulebook_builder_old_rules.cc

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -30,11 +30,14 @@
 #include "maliput_malidrive/builder/builder_tools.h"
 
 #include <algorithm>
+#include <cmath>
 #include <map>
 
 #include <maliput/api/lane.h>
+#include <maliput/api/objects/road_object.h>
 #include <maliput/common/logger.h>
 #include <maliput/common/maliput_unused.h>
+#include <maliput/math/vector.h>
 #include <tinyxml2.h>
 
 #include "maliput_malidrive/base/road_geometry.h"
@@ -610,6 +613,55 @@ std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
                       related_lanes.end());
 
   return related_lanes;
+}
+
+std::vector<std::unique_ptr<maliput::api::objects::Outline>> BuildOutlines(
+    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+    const maliput::api::RoadGeometry* road_geometry, const maliput::api::InertialPosition& object_inertial_pos,
+    const maliput::api::Rotation& object_orientation) {
+  std::vector<std::unique_ptr<maliput::api::objects::Outline>> result;
+  if (!object.outlines.has_value()) {
+    return result;
+  }
+
+  const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry);
+  MALIDRIVE_VALIDATE(mali_rg != nullptr, maliput::common::assertion_error,
+                     "RoadGeometry cannot be cast to malidrive::RoadGeometry.");
+
+  int outline_index = 0;
+  for (const auto& xodr_outline : object.outlines->outlines) {
+    std::vector<maliput::api::objects::OutlineCorner> corners;
+
+    if (!xodr_outline.corner_road.empty()) {
+      for (const auto& cr : xodr_outline.corner_road) {
+        const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_pos{std::stoi(road_id.string()), cr.s, cr.t};
+        const maliput::api::RoadPosition rp = mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_pos, true);
+        maliput::api::InertialPosition ip = rp.ToInertialPosition();
+        ip.set_z(ip.z() + cr.dz);
+        corners.emplace_back(maliput::math::Vector3(ip.x(), ip.y(), ip.z()), cr.height);
+      }
+    } else if (!xodr_outline.corner_local.empty()) {
+      const double cos_yaw = std::cos(object_orientation.yaw());
+      const double sin_yaw = std::sin(object_orientation.yaw());
+      for (const auto& cl : xodr_outline.corner_local) {
+        const double x = object_inertial_pos.x() + cos_yaw * cl.u - sin_yaw * cl.v;
+        const double y = object_inertial_pos.y() + sin_yaw * cl.u + cos_yaw * cl.v;
+        const double z = object_inertial_pos.z() + cl.z;
+        corners.emplace_back(maliput::math::Vector3(x, y, z), cl.height);
+      }
+    }
+
+    if (corners.size() >= 3u) {
+      const std::string outline_id_str = xodr_outline.id.has_value()
+                                             ? xodr_outline.id->string()
+                                             : (object.id.string() + "_outline_" + std::to_string(outline_index));
+      const bool closed = xodr_outline.closed.value_or(true);
+      result.push_back(std::make_unique<maliput::api::objects::Outline>(
+          maliput::api::objects::Outline::Id(outline_id_str), std::move(corners), closed));
+    }
+    ++outline_index;
+  }
+  return result;
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -29,11 +29,13 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include <maliput/api/lane_data.h>
+#include <maliput/api/objects/road_object.h>
 #include <maliput/api/road_geometry.h>
 
 #include "maliput_malidrive/base/lane.h"
@@ -42,6 +44,7 @@
 #include "maliput_malidrive/xodr/db_manager.h"
 #include "maliput_malidrive/xodr/junction.h"
 #include "maliput_malidrive/xodr/lane.h"
+#include "maliput_malidrive/xodr/object/object.h"
 #include "maliput_malidrive/xodr/road_header.h"
 #include "maliput_malidrive/xodr/validity.h"
 
@@ -442,6 +445,24 @@ std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
     const xodr::RoadHeader::Id& road_id, double s_coordinate, const std::vector<xodr::Validity>& validities,
     const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
     const maliput::api::RoadGeometry* road_geometry);
+
+/// Converts XODR outline corners to maliput Outlines.
+///
+/// Processes the outlines defined in an XODR object element and converts them
+/// to maliput @ref maliput::api::objects::Outline instances. Supports both
+/// `cornerRoad` (road-frame coordinates) and `cornerLocal` (object-local coordinates).
+///
+/// @param object The XODR object containing outline data.
+/// @param road_id The XODR road's ID the @p object belongs to.
+/// @param road_geometry Pointer to the road geometry (must be castable to malidrive::RoadGeometry).
+/// @param object_inertial_pos The inertial position of the object's origin.
+/// @param object_orientation The orientation of the object in the inertial frame.
+/// @returns A vector of Outline unique_ptrs. Empty if the object has no outlines or all outlines
+///          have fewer than 3 corners.
+std::vector<std::unique_ptr<maliput::api::objects::Outline>> BuildOutlines(
+    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+    const maliput::api::RoadGeometry* road_geometry, const maliput::api::InertialPosition& object_inertial_pos,
+    const maliput::api::Rotation& object_orientation);
 
 }  // namespace builder
 }  // namespace malidrive

--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -136,7 +136,8 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
   // --- Bounding box ---
   double bb_length = object_.length.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).length);
   double bb_width = object_.width.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).width);
-  const double bb_height = object_.height.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).height);
+  const double bb_height =
+      object_.height.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).height);
   if (object_.radius.has_value()) {
     bb_length = 2.0 * object_.radius.value();
     bb_width = 2.0 * object_.radius.value();

--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -26,17 +26,16 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "maliput_malidrive/builder/road_object_builder.h"
+#include "maliput_malidrive/builder/road_marking_builder.h"
 
 #include <cmath>
 #include <iomanip>
 #include <sstream>
 #include <string>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include <maliput/api/lane_data.h>
+#include <maliput/api/objects/road_marking.h>
 #include <maliput/api/objects/road_object.h>
 #include <maliput/common/logger.h>
 #include <maliput/math/bounding_box.h>
@@ -45,57 +44,68 @@
 
 #include "maliput_malidrive/base/road_geometry.h"
 #include "maliput_malidrive/builder/builder_tools.h"
-#include "maliput_malidrive/builder/road_object_type_mapper.h"
+#include "maliput_malidrive/builder/road_marking_type_mapper.h"
 #include "maliput_malidrive/common/macros.h"
+#include "maliput_malidrive/traffic_control_device/parser.h"
 
 static constexpr double kEpsilon{1e-10};
 
-namespace {
-
-bool is_almost_equal(double a, double b) { return std::abs(a - b) < kEpsilon; }
-
-}  // namespace
 namespace malidrive {
 namespace builder {
 
-namespace {
-
-/// Concrete subclass of maliput::api::objects::RoadObject.
-/// The base class has a protected constructor, so this subclass is needed
-/// to construct instances.
-class MalidriveRoadObject final : public maliput::api::objects::RoadObject {
- public:
-  MalidriveRoadObject(const Id& id, maliput::api::objects::RoadObjectType type,
-                      const maliput::api::objects::RoadObjectPosition& position,
-                      const maliput::api::Rotation& orientation, const maliput::math::BoundingBox& bounding_box,
-                      bool is_dynamic, std::vector<maliput::api::LaneId> related_lanes, std::optional<std::string> name,
-                      std::optional<std::string> subtype,
-                      std::vector<std::unique_ptr<maliput::api::objects::Outline>> outlines,
-                      std::unordered_map<std::string, std::string> properties)
-      : RoadObject(id, type, position, orientation, bounding_box, is_dynamic, std::move(related_lanes), std::move(name),
-                   std::move(subtype), std::move(outlines), std::move(properties)) {}
-};
-
-}  // namespace
-
-RoadObjectBuilder::RoadObjectBuilder(const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
-                                     const maliput::api::RoadGeometry* road_geometry)
-    : object_(object), road_id_(road_id), road_geometry_(road_geometry) {
+RoadMarkingBuilder::RoadMarkingBuilder(const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+                                       const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
+                                       const maliput::api::RoadGeometry* road_geometry)
+    : object_(object), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
 }
 
-std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()() const {
+std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator()() const {
+  // Build the fingerprint from the XODR object attributes.
+  const std::string type_str =
+      object_.type.has_value() ? xodr::object::Object::object_type_to_str(object_.type.value()) : "";
+  const traffic_control_device::TrafficControlDeviceFingerprint fingerprint{
+      type_str,     object_.subtype,
+      std::nullopt,  // country (not used for objects)
+      std::nullopt,  // country_revision (not used for objects)
+      object_.name,
+  };
+
+  const auto definition_opt = loader_.Lookup(fingerprint);
+  if (!definition_opt.has_value()) {
+    maliput::log()->debug("RoadMarkingBuilder: no definition found for object id='", object_.id.string(), "' type='",
+                          type_str, "' subtype='", object_.subtype.value_or(""), "' name='", object_.name.value_or(""),
+                          "'. Skipping RoadMarking creation.");
+    return nullptr;
+  }
+  const auto& definition = definition_opt.value();
+
+  // Only build RoadMarking objects for objects whose database device_type is kRoadMarking.
+  if (definition.device_type != traffic_control_device::TrafficControlDeviceType::kRoadMarking) {
+    maliput::log()->debug("RoadMarkingBuilder: object id='", object_.id.string(), "' has device_type='",
+                          traffic_control_device::TrafficControlDeviceTypeToString(definition.device_type),
+                          "', expected 'road_marking'. Skipping RoadMarking creation.");
+    return nullptr;
+  }
+
+  const auto marking_type = MapRoadMarkingTypeString(definition.device_semantics.value_or("other"));
+  if (marking_type == maliput::api::objects::RoadMarkingType::kUnknown) {
+    maliput::log()->debug("RoadMarkingBuilder: unrecognized device_semantics='",
+                          definition.device_semantics.value_or("other"), "' for object id='", object_.id.string(),
+                          "'. Defaulting to RoadMarkingType::kUnknown.");
+  }
+
   const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry_);
   MALIDRIVE_VALIDATE(mali_rg != nullptr, maliput::common::assertion_error,
                      "RoadGeometry cannot be cast to malidrive::RoadGeometry.");
 
   // --- Position ---
   double object_s = object_.s;
-  if (is_almost_equal(object_.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
+  if (std::abs(object_.s - mali_rg->GetRoadCurve(road_id_)->p1()) < kEpsilon) {
     std::ostringstream s_str, adjusted_s_str;
     s_str << std::fixed << std::setprecision(10) << object_.s;
     adjusted_s_str << std::fixed << std::setprecision(10) << (object_.s - kEpsilon);
-    maliput::log()->warn("RoadObjectBuilder: Object ", object_.id.string(), " has s coordinate ", s_str.str(),
+    maliput::log()->warn("RoadMarkingBuilder: Object ", object_.id.string(), " has s coordinate ", s_str.str(),
                          " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
                          " to avoid potential issues with lane association and orientation.");
     object_s -= kEpsilon;
@@ -123,9 +133,9 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
                                       road_orientation.yaw_angle() + hdg + orientation_offset);
 
   // --- Bounding box ---
-  double bb_length = object_.length.value_or(0.);
-  double bb_width = object_.width.value_or(0.);
-  const double bb_height = object_.height.value_or(0.);
+  double bb_length = object_.length.value_or(definition.default_bounding_box.value_or(0.).length);
+  double bb_width = object_.width.value_or(definition.default_bounding_box.value_or(0.).width);
+  const double bb_height = object_.height.value_or(definition.default_bounding_box.value_or(0.).height);
   if (object_.radius.has_value()) {
     bb_length = 2.0 * object_.radius.value();
     bb_width = 2.0 * object_.radius.value();
@@ -134,32 +144,19 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
                                                 maliput::math::Vector3(bb_length, bb_width, bb_height),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
-  // --- Type ---
-  const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object_.type, object_.name, object_.subtype);
-
   // --- Related lanes ---
   auto related_lanes = ResolveLaneIds(road_id_, object_s, object_.validities, road_geometry_);
 
   // --- Outlines ---
   auto outlines = BuildOutlines(object_, road_id_, road_geometry_, inertial_pos, orientation);
 
-  // --- Properties ---
-  std::unordered_map<std::string, std::string> properties;
-  if (!object_.materials.empty()) {
-    properties["material"] = object_.materials[0].surface.value_or("");
-    properties["subtype"] = object_.subtype.value_or("");
-  }
+  maliput::log()->debug("RoadMarkingBuilder: creating RoadMarking id='", object_.id.string(),
+                        "' type=", static_cast<int>(marking_type), " position=(", inertial_pos.x(), ", ",
+                        inertial_pos.y(), ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
 
-  // --- is_dynamic ---
-  const bool is_dynamic = object_.dynamic.value_or(false);
-
-  maliput::log()->debug("RoadObjectBuilder: creating RoadObject id='", object_.id.string(),
-                        "' type=", static_cast<int>(type), " position=(", inertial_pos.x(), ", ", inertial_pos.y(),
-                        ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
-
-  return std::make_unique<MalidriveRoadObject>(
-      maliput::api::objects::RoadObject::Id(object_.id.string()), type, position, orientation, bounding_box, is_dynamic,
-      std::move(related_lanes), object_.name, object_.subtype, std::move(outlines), std::move(properties));
+  return std::make_unique<maliput::api::objects::RoadMarking>(
+      maliput::api::objects::RoadMarking::Id(object_.id.string()), marking_type, position, orientation, bounding_box,
+      std::move(related_lanes), object_.name, std::move(outlines));
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -132,10 +132,11 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
       maliput::api::Rotation::FromRpy(road_orientation.roll_angle() + roll, road_orientation.pitch_angle() + pitch,
                                       road_orientation.yaw_angle() + hdg + orientation_offset);
 
+  malidrive::traffic_control_device::BoundingBoxDimensions bounding_box_dimensions{};
   // --- Bounding box ---
-  double bb_length = object_.length.value_or(definition.default_bounding_box.value_or(0.).length);
-  double bb_width = object_.width.value_or(definition.default_bounding_box.value_or(0.).width);
-  const double bb_height = object_.height.value_or(definition.default_bounding_box.value_or(0.).height);
+  double bb_length = object_.length.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).length);
+  double bb_width = object_.width.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).width);
+  const double bb_height = object_.height.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).height);
   if (object_.radius.has_value()) {
     bb_length = 2.0 * object_.radius.value();
     bb_width = 2.0 * object_.radius.value();

--- a/src/maliput_malidrive/builder/road_marking_builder.h
+++ b/src/maliput_malidrive/builder/road_marking_builder.h
@@ -1,0 +1,81 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <memory>
+
+#include <maliput/api/objects/road_marking.h>
+#include <maliput/api/road_geometry.h>
+
+#include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
+#include "maliput_malidrive/xodr/object/object.h"
+#include "maliput_malidrive/xodr/road_header.h"
+
+namespace malidrive {
+namespace builder {
+
+/// Builds a single @ref maliput::api::objects::RoadMarking from an XODR
+/// @ref xodr::object::Object and its matching definition in the traffic
+/// control device YAML database.
+///
+/// The builder follows the functor pattern: construct it with all required
+/// inputs and call @ref operator()() to produce the result.
+///
+/// When no matching @ref traffic_control_device::TrafficControlDeviceDefinition is found in
+/// the loader for the given object's type/subtype/name fingerprint, or the device_type is not
+/// @ref traffic_control_device::TrafficControlDeviceType::kRoadMarking, the builder returns nullptr.
+class RoadMarkingBuilder {
+ public:
+  /// Constructs a RoadMarkingBuilder.
+  ///
+  /// @param object The XODR object to build a @ref maliput::api::objects::RoadMarking from.
+  /// @param road_id The XODR road's ID the @p object belongs to.
+  /// @param loader The @ref traffic_control_device::TrafficControlDeviceDatabaseLoader providing access
+  ///        to the traffic control device YAML database.
+  /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
+  /// @throws std::invalid_argument if @p road_geometry is nullptr.
+  RoadMarkingBuilder(const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
+                     const maliput::api::RoadGeometry* road_geometry);
+
+  /// Builds and returns the @ref maliput::api::objects::RoadMarking.
+  ///
+  /// @returns A unique_ptr to the constructed RoadMarking, or nullptr if no
+  ///          matching definition is found or the device_type is not kRoadMarking.
+  std::unique_ptr<maliput::api::objects::RoadMarking> operator()() const;
+
+ private:
+  const xodr::object::Object& object_;
+  const xodr::RoadHeader::Id& road_id_;
+  const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader_;
+  const maliput::api::RoadGeometry* road_geometry_;
+};
+
+}  // namespace builder
+}  // namespace malidrive

--- a/src/maliput_malidrive/builder/road_marking_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_marking_type_mapper.cc
@@ -1,0 +1,70 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/builder/road_marking_type_mapper.h"
+
+#include <algorithm>
+#include <cctype>
+#include <unordered_map>
+
+#include <maliput/common/maliput_hash.h>
+
+namespace malidrive {
+namespace builder {
+
+maliput::api::objects::RoadMarkingType MapRoadMarkingTypeString(const std::string& device_semantics) {
+  using T = maliput::api::objects::RoadMarkingType;
+  static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper{
+      {"stop", T::kStop},
+      {"stop_line", T::kStopLine},
+      {"crosswalk", T::kCrosswalk},
+      {"zebra_crossing", T::kCrosswalk},
+      {"parking_space", T::kParkingSpace},
+      {"emergency_lane", T::kEmergencyLane},
+      {"speed_limit", T::kSpeedLimit},
+      {"no_stopping", T::kDoNotStop},
+      {"rail_road_crossing", T::kRailRoad},
+      {"give_way", T::kGiveWay},
+      {"arrow_turn_right", T::kArrowTurnRight},
+      {"arrow_turn_left", T::kArrowTurnLeft},
+      {"arrow_forward_turn_right", T::kArrowForwardTurnRight},
+      {"arrow_forward_turn_left", T::kArrowForwardTurnLeft},
+      {"arrow_forward", T::kArrowForward},
+      {"arrow_forward_turn_right_turn_left", T::kArrowForwardTurnRightTurnLeft},
+      {"arrow_turn_right_turn_left", T::kArrowTurnRightTurnLeft},
+      {"arrow_u_turn_right", T::kArrowUTurnRight},
+      {"arrow_u_turn_left", T::kArrowUTurnLeft},
+  };
+  std::string lower = device_semantics;
+  std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+  const auto it = kMapper.find(lower);
+  return it != kMapper.end() ? it->second : T::kUnknown;
+}
+
+}  // namespace builder
+}  // namespace malidrive

--- a/src/maliput_malidrive/builder/road_marking_type_mapper.h
+++ b/src/maliput_malidrive/builder/road_marking_type_mapper.h
@@ -1,0 +1,51 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+
+#include <maliput/api/objects/road_marking.h>
+
+namespace malidrive {
+namespace builder {
+
+/// Maps a device_semantics string from the YAML traffic control device database to a
+/// @ref maliput::api::objects::RoadMarkingType enum.
+///
+/// The comparison is case-insensitive: "Stop_Line", "STOP_LINE", and "stop_line"
+/// all map to RoadMarkingType::kStopLine.
+///
+/// Any unrecognized string (including "none" and "other") maps to kUnknown.
+///
+/// @param device_semantics The device_semantics value from the YAML database.
+/// @returns The corresponding RoadMarkingType, or kUnknown if not recognized.
+maliput::api::objects::RoadMarkingType MapRoadMarkingTypeString(const std::string& device_semantics);
+
+}  // namespace builder
+}  // namespace malidrive

--- a/test/regression/builder/CMakeLists.txt
+++ b/test/regression/builder/CMakeLists.txt
@@ -24,6 +24,8 @@ set(UNIT_BUILDER_TEST_SOURCES
   road_network_builder_traffic_lights_test.cc
   road_network_configuration_test.cc
   road_object_builder_test.cc
+  road_marking_builder_test.cc
+  road_marking_type_mapper_test.cc
   simplify_geometries_test.cc
   traffic_light_builder_test.cc
   traffic_sign_builder_test.cc

--- a/test/regression/builder/road_marking_builder_test.cc
+++ b/test/regression/builder/road_marking_builder_test.cc
@@ -1,0 +1,198 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/builder/road_marking_builder.h"
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <maliput/api/lane_data.h>
+#include <maliput/api/objects/road_marking.h>
+#include <maliput/api/road_network.h>
+#include <maliput/common/maliput_throw.h>
+
+#include "maliput_malidrive/base/road_geometry.h"
+#include "maliput_malidrive/builder/params.h"
+#include "maliput_malidrive/builder/road_network_builder.h"
+#include "maliput_malidrive/builder/road_network_configuration.h"
+#include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
+#include "maliput_malidrive/xodr/db_manager.h"
+#include "maliput_malidrive/xodr/object/object.h"
+#include "maliput_malidrive/xodr/road_header.h"
+#include "utility/resources.h"
+
+namespace malidrive {
+namespace builder {
+namespace test {
+namespace {
+
+static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+
+// ---------------------------------------------------------------------------
+// RoadMarkingBuilder tests.
+// Uses the RoadWithRoadMarkings.xodr resource and road_marking_test_db.yaml.
+// ---------------------------------------------------------------------------
+
+class RoadMarkingBuilderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("RoadWithRoadMarkings.xodr", kMalidriveResourceFolder);
+    tcd_db_path_ =
+        utility::FindResourceInPath("traffic_control_device_db/road_marking_test_db.yaml", kMalidriveResourceFolder);
+
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kTrafficControlDeviceDb, tcd_db_path_},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+
+    const auto* manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+    const auto road_headers = manager->GetRoadHeaders();
+    const auto road_header_it = road_headers.find(xodr::RoadHeader::Id("1"));
+    ASSERT_NE(road_header_it, road_headers.end());
+    ASSERT_TRUE(road_header_it->second.objects.has_value());
+    objects_ = road_header_it->second.objects->objects;
+    ASSERT_EQ(4u, objects_.size());
+
+    loader_ = std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(tcd_db_path_);
+  }
+
+  const xodr::object::Object& FindObject(const std::string& id) const {
+    for (const auto& obj : objects_) {
+      if (obj.id.string() == id) return obj;
+    }
+    MALIPUT_THROW_MESSAGE("Object " + id + " not found");
+  }
+
+  std::string tcd_db_path_;
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  std::vector<xodr::object::Object> objects_;
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+  const xodr::RoadHeader::Id road_id_{"1"};
+};
+
+TEST_F(RoadMarkingBuilderTest, Constructor) {
+  const auto& object = FindObject("rm_stop_line");
+  EXPECT_NO_THROW(RoadMarkingBuilder(object, road_id_, *loader_, road_geometry_));
+}
+
+TEST_F(RoadMarkingBuilderTest, ConstructorThrowsOnNullptrRoadGeometry) {
+  const auto& object = FindObject("rm_stop_line");
+  EXPECT_THROW(RoadMarkingBuilder(object, road_id_, *loader_, nullptr), std::invalid_argument);
+}
+
+TEST_F(RoadMarkingBuilderTest, BuildStopLine) {
+  const auto& object = FindObject("rm_stop_line");
+  RoadMarkingBuilder builder(object, road_id_, *loader_, road_geometry_);
+  auto road_marking = builder();
+  ASSERT_NE(road_marking, nullptr);
+
+  EXPECT_EQ(road_marking->id(), maliput::api::objects::RoadMarking::Id("rm_stop_line"));
+  EXPECT_EQ(road_marking->type(), maliput::api::objects::RoadMarkingType::kStopLine);
+  EXPECT_EQ(road_marking->name(), "StopLine");
+
+  // Position: straight road at hdg=0, s=30, t=0 → inertial x≈30, y≈0.
+  const auto& pos = road_marking->position().inertial_position();
+  EXPECT_NEAR(pos.x(), 30.0, 0.5);
+  EXPECT_NEAR(pos.y(), 0.0, 0.5);
+
+  // Bounding box: length=0.3, width=7.0, height=0.0.
+  const auto& bb = road_marking->bounding_box();
+  EXPECT_NEAR(bb.box_size().x(), 0.3, 1e-3);
+  EXPECT_NEAR(bb.box_size().y(), 7.0, 1e-3);
+  EXPECT_NEAR(bb.box_size().z(), 0.0, 1e-3);
+
+  // Related lanes: both lanes.
+  EXPECT_GE(road_marking->related_lanes().size(), 2u);
+}
+
+TEST_F(RoadMarkingBuilderTest, BuildCrosswalk) {
+  const auto& object = FindObject("rm_crosswalk");
+  RoadMarkingBuilder builder(object, road_id_, *loader_, road_geometry_);
+  auto road_marking = builder();
+  ASSERT_NE(road_marking, nullptr);
+
+  EXPECT_EQ(road_marking->id(), maliput::api::objects::RoadMarking::Id("rm_crosswalk"));
+  EXPECT_EQ(road_marking->type(), maliput::api::objects::RoadMarkingType::kCrosswalk);
+
+  const auto& pos = road_marking->position().inertial_position();
+  EXPECT_NEAR(pos.x(), 50.0, 0.5);
+  EXPECT_NEAR(pos.y(), 0.0, 0.5);
+}
+
+TEST_F(RoadMarkingBuilderTest, BuildArrowForward) {
+  const auto& object = FindObject("rm_arrow");
+  RoadMarkingBuilder builder(object, road_id_, *loader_, road_geometry_);
+  auto road_marking = builder();
+  ASSERT_NE(road_marking, nullptr);
+
+  EXPECT_EQ(road_marking->id(), maliput::api::objects::RoadMarking::Id("rm_arrow"));
+  EXPECT_EQ(road_marking->type(), maliput::api::objects::RoadMarkingType::kArrowForward);
+
+  const auto& pos = road_marking->position().inertial_position();
+  EXPECT_NEAR(pos.x(), 70.0, 0.5);
+  EXPECT_NEAR(pos.y(), -1.75, 0.5);
+
+  // Only lane -1 via validity.
+  EXPECT_EQ(1u, road_marking->related_lanes().size());
+}
+
+TEST_F(RoadMarkingBuilderTest, ReturnsNullptrForNonRoadMarkingDeviceType) {
+  // The pole object maps to device_type: road_object, so should return nullptr.
+  const auto& object = FindObject("rm_pole");
+  RoadMarkingBuilder builder(object, road_id_, *loader_, road_geometry_);
+  auto road_marking = builder();
+  EXPECT_EQ(road_marking, nullptr);
+}
+
+TEST_F(RoadMarkingBuilderTest, ReturnsNullptrForNoMatchingDefinition) {
+  // Create a fake object with a type that's not in the database.
+  xodr::object::Object fake_object;
+  fake_object.id = xodr::object::Object::Id("fake_obj");
+  fake_object.s = 10.0;
+  fake_object.t = 0.0;
+  fake_object.z_offset = 0.0;
+  fake_object.type = xodr::object::Object::str_to_object_type("building");
+
+  RoadMarkingBuilder builder(fake_object, road_id_, *loader_, road_geometry_);
+  auto road_marking = builder();
+  EXPECT_EQ(road_marking, nullptr);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace builder
+}  // namespace malidrive

--- a/test/regression/builder/road_marking_type_mapper_test.cc
+++ b/test/regression/builder/road_marking_type_mapper_test.cc
@@ -1,0 +1,86 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_malidrive/builder/road_marking_type_mapper.h"
+
+#include <gtest/gtest.h>
+
+namespace malidrive {
+namespace builder {
+namespace test {
+namespace {
+
+using T = maliput::api::objects::RoadMarkingType;
+
+using RoadMarkingTypeMapperTest = ::testing::Test;
+
+TEST_F(RoadMarkingTypeMapperTest, DirectMappings) {
+  EXPECT_EQ(T::kStop, MapRoadMarkingTypeString("stop"));
+  EXPECT_EQ(T::kStopLine, MapRoadMarkingTypeString("stop_line"));
+  EXPECT_EQ(T::kCrosswalk, MapRoadMarkingTypeString("crosswalk"));
+  EXPECT_EQ(T::kCrosswalk, MapRoadMarkingTypeString("zebra_crossing"));
+  EXPECT_EQ(T::kParkingSpace, MapRoadMarkingTypeString("parking_space"));
+  EXPECT_EQ(T::kEmergencyLane, MapRoadMarkingTypeString("emergency_lane"));
+  EXPECT_EQ(T::kSpeedLimit, MapRoadMarkingTypeString("speed_limit"));
+  EXPECT_EQ(T::kDoNotStop, MapRoadMarkingTypeString("no_stopping"));
+  EXPECT_EQ(T::kRailRoad, MapRoadMarkingTypeString("rail_road_crossing"));
+  EXPECT_EQ(T::kGiveWay, MapRoadMarkingTypeString("give_way"));
+}
+
+TEST_F(RoadMarkingTypeMapperTest, ArrowMappings) {
+  EXPECT_EQ(T::kArrowTurnRight, MapRoadMarkingTypeString("arrow_turn_right"));
+  EXPECT_EQ(T::kArrowTurnLeft, MapRoadMarkingTypeString("arrow_turn_left"));
+  EXPECT_EQ(T::kArrowForwardTurnRight, MapRoadMarkingTypeString("arrow_forward_turn_right"));
+  EXPECT_EQ(T::kArrowForwardTurnLeft, MapRoadMarkingTypeString("arrow_forward_turn_left"));
+  EXPECT_EQ(T::kArrowForward, MapRoadMarkingTypeString("arrow_forward"));
+  EXPECT_EQ(T::kArrowForwardTurnRightTurnLeft, MapRoadMarkingTypeString("arrow_forward_turn_right_turn_left"));
+  EXPECT_EQ(T::kArrowTurnRightTurnLeft, MapRoadMarkingTypeString("arrow_turn_right_turn_left"));
+  EXPECT_EQ(T::kArrowUTurnRight, MapRoadMarkingTypeString("arrow_u_turn_right"));
+  EXPECT_EQ(T::kArrowUTurnLeft, MapRoadMarkingTypeString("arrow_u_turn_left"));
+}
+
+TEST_F(RoadMarkingTypeMapperTest, CaseInsensitive) {
+  EXPECT_EQ(T::kStopLine, MapRoadMarkingTypeString("Stop_Line"));
+  EXPECT_EQ(T::kStopLine, MapRoadMarkingTypeString("STOP_LINE"));
+  EXPECT_EQ(T::kCrosswalk, MapRoadMarkingTypeString("CROSSWALK"));
+  EXPECT_EQ(T::kArrowForward, MapRoadMarkingTypeString("Arrow_Forward"));
+  EXPECT_EQ(T::kGiveWay, MapRoadMarkingTypeString("Give_Way"));
+}
+
+TEST_F(RoadMarkingTypeMapperTest, UnknownMappings) {
+  EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString("other"));
+  EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString("none"));
+  EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString(""));
+  EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString("unknown_value"));
+  EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString("traffic_light"));
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace builder
+}  // namespace malidrive


### PR DESCRIPTION
# 🎉 New feature

Relates to #466 

## Summary
Standalone creation of RoadMarkingBuilder. That means RoadMarking elements are not yet added into the book, nor loaded into the RoadNetwork.
* `RoadMarkingBuilder` looks for `road_marking` devices in the `traffic_control_device` database, and maps their `device_semantics` into a `RoadMarkingType`.
* `RoadMarking`s are then returned to be loaded into their book.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

