### PR TITLE
Optional odr_representation fields are defaulted to wildcard string.

### DIFF
--- a/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
+++ b/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
@@ -58,7 +58,6 @@ odr_signal_types:
       subtype: "-1"
       country: "OpenDRIVE"
       country_revision: null
-      name: "*"
     properties:
       device_type: traffic_light
       description: "Standard three-bulb vertical traffic light with red, yellow, and green bulbs."
@@ -156,7 +155,6 @@ odr_signal_types:
       subtype: "10"
       country: "OpenDRIVE"
       country_revision: null
-      name: "*"
     properties:
       device_type: traffic_light
       description: "Three-bulb traffic light with optional arrow support (left/straight/right)."
@@ -222,7 +220,6 @@ odr_signal_types:
       subtype: "-1"
       country: "OpenDRIVE"
       country_revision: null
-      name: "*"
     properties:
       device_type: traffic_light
       description: "Pedestrian walk/don't walk signal (red standing figure on black background / green walking figure on black background)."
@@ -272,7 +269,6 @@ odr_signal_types:
       subtype: "-1"
       country: "OpenDRIVE"
       country_revision: null
-      name: "*"
     properties:
       device_type: traffic_sign
       device_semantics: stop
@@ -291,7 +287,6 @@ odr_signal_types:
       subtype: "-1"
       country: "OpenDRIVE"
       country_revision: null
-      name: "*"
     properties:
       device_type: traffic_sign
       description: "Unknown sign. No specific behavior defined."

--- a/src/maliput_malidrive/traffic_control_device/README.md
+++ b/src/maliput_malidrive/traffic_control_device/README.md
@@ -52,6 +52,7 @@ odr_signal_types:
       subtype: "-1"             # Optional: signal subtype ("-1" / "none" treated as absent)
       country: "OpenDRIVE"      # Optional: country code or standard
       country_revision: null    # Optional: country standard revision
+      name: null                # Optional: OpenDRIVE name attribute
     properties:
       device_type: traffic_light  # Required: "traffic_light" or "traffic_sign"
       device_semantics: stop      # Optional: semantic meaning for traffic signs
@@ -94,6 +95,10 @@ The following fields are **not allowed** in `odr_object_types` entries and are r
 - `bulbs` and `rule_states` in `properties` (objects don't carry bulbs or rule logic).
 
 For objects, `device_type` MUST be `road_marking` or `road_object`. Using `traffic_light` or `traffic_sign` in an object entry is rejected with a parser error.
+
+#### `odr_representation`
+
+If any of the optional fields are missing in the database defintion, those will be treated as a `"*"` wildcard field, matching any value, including nulled OpenDRIVE attributes.
 
 #### `device_type`
 

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -334,6 +334,7 @@ RuleState ParseRuleState(const YAML::Node& rule_state_node) {
 //            subtype: ...
 //            country: ...
 //            country_revision: ...
+//            name: ...
 //          properties:
 //            device_type: ...
 //            device_semantics: ...
@@ -369,7 +370,7 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
   // --- Parse fingerprint from odr_representation ---
   tcd_definition.fingerprint.type = GetRequiredStringField(repr_node, TrafficControlDeviceConstants::kType);
 
-  if (const auto subtype = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kSubtype)) {
+  if (const auto subtype = GetOptionalStringFieldWildcardDefault(repr_node, TrafficControlDeviceConstants::kSubtype)) {
     if (subtype.value() == "-1" || subtype.value() == "none") {
       tcd_definition.fingerprint.subtype = std::nullopt;
     } else {
@@ -377,15 +378,16 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
     }
   }
 
-  if (const auto country = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kCountry)) {
+  if (const auto country = GetOptionalStringFieldWildcardDefault(repr_node, TrafficControlDeviceConstants::kCountry)) {
     tcd_definition.fingerprint.country = country;
   }
 
-  if (const auto revision = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kCountryRevision)) {
+  if (const auto revision =
+          GetOptionalStringFieldWildcardDefault(repr_node, TrafficControlDeviceConstants::kCountryRevision)) {
     tcd_definition.fingerprint.country_revision = revision;
   }
 
-  if (const auto name = GetOptionalStringField(repr_node, TrafficControlDeviceConstants::kName)) {
+  if (const auto name = GetOptionalStringFieldWildcardDefault(repr_node, TrafficControlDeviceConstants::kName)) {
     tcd_definition.fingerprint.name = name;
   }
 

--- a/src/maliput_malidrive/traffic_control_device/yaml_helper.cc
+++ b/src/maliput_malidrive/traffic_control_device/yaml_helper.cc
@@ -34,6 +34,7 @@
 #include <maliput/common/maliput_throw.h>
 
 #include "maliput_malidrive/common/macros.h"
+#include "maliput_malidrive/traffic_control_device/parser.h"
 
 namespace malidrive {
 namespace traffic_control_device {
@@ -57,6 +58,18 @@ std::string GetRequiredStringField(const YAML::Node& node, const std::string& fi
 
 std::optional<std::string> GetOptionalStringField(const YAML::Node& node, const std::string& field_name) {
   if (!node[field_name].IsDefined() || node[field_name].IsNull()) {
+    return std::nullopt;
+  }
+
+  return node[field_name].as<std::string>();
+}
+
+std::optional<std::string> GetOptionalStringFieldWildcardDefault(const YAML::Node& node,
+                                                                 const std::string& field_name) {
+  if (!node[field_name].IsDefined()) {
+    return std::make_optional<std::string>(TrafficControlDeviceParser::kWildcard);
+  }
+  if (node[field_name].IsNull()) {
     return std::nullopt;
   }
 

--- a/src/maliput_malidrive/traffic_control_device/yaml_helper.h
+++ b/src/maliput_malidrive/traffic_control_device/yaml_helper.h
@@ -129,6 +129,14 @@ std::string GetRequiredStringField(const YAML::Node& node, const std::string& fi
 ///          std::nullopt otherwise.
 std::optional<std::string> GetOptionalStringField(const YAML::Node& node, const std::string& field_name);
 
+/// Retrieves an optional string field from a YAML node.
+///
+/// @param node The YAML node containing the field.
+/// @param field_name The name of the field to retrieve.
+/// @returns An optional containing the string value if defined and not null;
+///          if the node is not defined, returns a wildcard string; if the node is null, returns std::nullopt.
+std::optional<std::string> GetOptionalStringFieldWildcardDefault(const YAML::Node& node, const std::string& field_name);
+
 /// Retrieves an optional integer field from a YAML node.
 ///
 /// @param node The YAML node containing the field.

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -334,12 +334,14 @@ TEST_F(TrafficControlDeviceParserTest, LoadFromString) {
       .subtype = std::nullopt,
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
+      .name = TrafficControlDeviceParser::kWildcard,
   };
   const auto& arrow_fingerprint = TrafficControlDeviceFingerprint{
       .type = "1000011",
       .subtype = "10",
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
+      .name = TrafficControlDeviceParser::kWildcard,
   };
   EXPECT_NE(FindDefinition(signal_definitions_, standard_fingerprint), nullptr);
   EXPECT_NE(FindDefinition(signal_definitions_, arrow_fingerprint), nullptr);
@@ -351,6 +353,7 @@ TEST_F(TrafficControlDeviceParserTest, ValidateTrafficSign) {
       .subtype = "30",
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
+      .name = TrafficControlDeviceParser::kWildcard,
   };
   const auto* dut_ptr = FindDefinition(signal_definitions_, sign_fingerprint);
   ASSERT_NE(dut_ptr, nullptr);
@@ -375,6 +378,7 @@ TEST_F(TrafficControlDeviceParserTest, ValidateSignalType1000001) {
       .subtype = std::nullopt,
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
+      .name = TrafficControlDeviceParser::kWildcard,
   };
   const auto* dut_ptr = FindDefinition(signal_definitions_, fingerprint);
   ASSERT_NE(dut_ptr, nullptr);
@@ -412,6 +416,7 @@ TEST_F(TrafficControlDeviceParserTest, ValidateArrowSignal) {
       .subtype = "10",
       .country = "OpenDRIVE",
       .country_revision = std::nullopt,
+      .name = TrafficControlDeviceParser::kWildcard,
   };
   const auto* dut_ptr = FindDefinition(signal_definitions_, arrow_fingerprint);
   ASSERT_NE(dut_ptr, nullptr);
@@ -528,6 +533,7 @@ TEST_F(TrafficControlDeviceParserTest, DefaultBulbStatesAndBoundingBox) {
       .subtype = std::nullopt,
       .country = std::nullopt,
       .country_revision = std::nullopt,
+      .name = TrafficControlDeviceParser::kWildcard,
   };
   const auto* dut_ptr = FindDefinition(signal_definitions_, default_fingerprint);
   ASSERT_NE(dut_ptr, nullptr);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #476 

## Summary
* Optional odr_representation fields are defaulted to wildcard string.
* Updated one of the database resources to test out the fix.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
