### PR TITLE
Add mapping for new TrafficSignTypes.

### DIFF
--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -118,10 +118,10 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
     return nullptr;
   }
 
-  const auto sign_meaning = MapSignTypeString(definition.device_semantics.value_or("Other"));
+  const auto sign_meaning = MapSignTypeString(definition.device_semantics.value_or("Unknown"));
   if (sign_meaning == maliput::api::rules::TrafficSignType::kUnknown) {
     maliput::log()->debug("TrafficSignBuilder: unrecognized device_semantics='",
-                          definition.device_semantics.value_or("Other"), "' for signal id='", signal_.id.string(),
+                          definition.device_semantics.value_or("Unknown"), "' for signal id='", signal_.id.string(),
                           "'. Defaulting to TrafficSignType::kUnknown.");
   }
 
@@ -182,7 +182,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
 
   maliput::log()->debug("TrafficSignBuilder: creating TrafficSign for signal id='", signal_.id.string(), "' type='",
                         signal_.type, "' subtype='", signal_.subtype, "' device_semantics='",
-                        definition.device_semantics.value_or("Other"), "'. TrafficSign position: (x=", pos.x(),
+                        definition.device_semantics.value_or("Unknown"), "'. TrafficSign position: (x=", pos.x(),
                         ", y=", pos.y(), ", z=", pos.z(),
                         ") with orientation (roll=0, pitch=0, yaw=", orientation_road_network.yaw(),
                         "), related_lanes=", related_lanes.size(), ".");

--- a/src/maliput_malidrive/builder/traffic_sign_type_mapper.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_type_mapper.cc
@@ -37,27 +37,13 @@ namespace builder {
 
 maliput::api::rules::TrafficSignType MapSignTypeString(const std::string& device_semantics) {
   using T = maliput::api::rules::TrafficSignType;
-  static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper{
-      {"Stop", T::kStop},
-      {"Yield", T::kYield},
-      {"SpeedLimit", T::kSpeedLimit},
-      {"NoEntry", T::kNoEntry},
-      {"OneWay", T::kOneWay},
-      {"PedestrianCrossing", T::kPedestrianCrossing},
-      {"NoLeftTurn", T::kNoLeftTurn},
-      {"NoRightTurn", T::kNoRightTurn},
-      {"NoUTurn", T::kNoUTurn},
-      {"SchoolZone", T::kSchoolZone},
-      {"Construction", T::kConstruction},
-      {"RailroadCrossing", T::kRailroadCrossing},
-      {"NoOvertaking", T::kNoOvertaking},
-      {"AllWay", T::kAllWay},
-      {"NoUTurnLeft", T::kNoUTurnLeft},
-      {"NoUTurnRight", T::kNoUTurnRight},
-      {"GiveWay", T::kYield},
-      {"SpeedLimitBegin", T::kSpeedLimit},
-      {"Crosswalk", T::kPedestrianCrossing},
-  };
+  static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper = [] {
+    std::unordered_map<std::string, T, maliput::common::DefaultHash> result;
+    for (const auto& [type, type_name] : maliput::api::rules::TrafficSignTypeMapper()) {
+      result.emplace(type_name, type);
+    }
+    return result;
+  }();
   const auto it = kMapper.find(device_semantics);
   return it != kMapper.end() ? it->second : T::kUnknown;
 }

--- a/src/maliput_malidrive/traffic_control_device/README.md
+++ b/src/maliput_malidrive/traffic_control_device/README.md
@@ -115,29 +115,25 @@ The `device_type` matching is **strict PascalCase**. Variants like `"Road_Markin
 
 #### `device_semantics`
 
-Optional string for traffic signs that identifies the semantic meaning. Defaults to `"Other"` when absent. The supported values and their mapping to `maliput::api::rules::TrafficSignType` are:
+Optional string for traffic signs that identifies the semantic meaning. Defaults to `"Other"` when absent.
 
-| `device_semantics` value | `TrafficSignType` enum      |
-|--------------------------|------------------------------|
-| `"Stop"`                 | `kStop`                     |
-| `"Yield"`                | `kYield`                    |
-| `"GiveWay"`             | `kYield`                    |
-| `"SpeedLimit"`          | `kSpeedLimit`               |
-| `"SpeedLimitBegin"`    | `kSpeedLimit`               |
-| `"NoEntry"`             | `kNoEntry`                  |
-| `"OneWay"`              | `kOneWay`                   |
-| `"PedestrianCrossing"`  | `kPedestrianCrossing`       |
-| `"Crosswalk"`            | `kPedestrianCrossing`       |
-| `"NoLeftTurn"`         | `kNoLeftTurn`               |
-| `"NoRightTurn"`        | `kNoRightTurn`              |
-| `"NoUTurn"`            | `kNoUTurn`                  |
-| `"SchoolZone"`          | `kSchoolZone`               |
-| `"Construction"`         | `kConstruction`             |
-| `"RailroadCrossing"`    | `kRailroadCrossing`         |
-| `"NoOvertaking"`        | `kNoOvertaking`             |
-| *(any Other value)*      | `kUnknown`                  |
+The mapping is one-to-one for supported PascalCase tokens:
 
-If `device_semantics` is set to a value not listed above, the builder will still create a `TrafficSign` with `TrafficSignType::kUnknown`. This allows the database to contain signal definitions for region-specific or non-standard sign types without requiring code changes.
+`"TokenName"` → `maliput::api::rules::TrafficSignType::kTokenName`
+
+Examples:
+
+| `device_semantics` value | `TrafficSignType` enum |
+|--------------------------|------------------------|
+| `"Stop"`                 | `kStop`                |
+| `"NoUTurnRight"`         | `kNoUTurnRight`        |
+| `"RoadWorks"`            | `kRoadWorks`           |
+| `"DoNotEnter"`           | `kDoNotEnter`          |
+| `"TrafficCone"`          | `kTrafficCone`         |
+| `"Stop4Way"`             | `kStop4Way`            |
+| `"Car"`                  | `kCar`                 |
+
+Any unrecognized value still maps to `kUnknown`.
 
 The `device_semantics` matching is **strict PascalCase**. Variants like `"No_Entry"` and `"NO_ENTRY"` are rejected.
 

--- a/test/regression/builder/traffic_sign_type_mapper_test.cc
+++ b/test/regression/builder/traffic_sign_type_mapper_test.cc
@@ -61,21 +61,18 @@ INSTANTIATE_TEST_CASE_P(AllKnownTypes, MapSignTypeStringTest,
                             MapSignTypeStringTestCase{"Yield", TrafficSignType::kYield},
                             MapSignTypeStringTestCase{"SpeedLimit", TrafficSignType::kSpeedLimit},
                             MapSignTypeStringTestCase{"NoEntry", TrafficSignType::kNoEntry},
-                            MapSignTypeStringTestCase{"OneWay", TrafficSignType::kOneWay},
-                            MapSignTypeStringTestCase{"PedestrianCrossing", TrafficSignType::kPedestrianCrossing},
-                            MapSignTypeStringTestCase{"NoLeftTurn", TrafficSignType::kNoLeftTurn},
-                            MapSignTypeStringTestCase{"NoRightTurn", TrafficSignType::kNoRightTurn},
-                            MapSignTypeStringTestCase{"NoUTurn", TrafficSignType::kNoUTurn},
-                            MapSignTypeStringTestCase{"SchoolZone", TrafficSignType::kSchoolZone},
-                            MapSignTypeStringTestCase{"Construction", TrafficSignType::kConstruction},
-                            MapSignTypeStringTestCase{"RailroadCrossing", TrafficSignType::kRailroadCrossing},
-                            MapSignTypeStringTestCase{"NoOvertaking", TrafficSignType::kNoOvertaking},
-                            MapSignTypeStringTestCase{"AllWay", TrafficSignType::kAllWay},
                             MapSignTypeStringTestCase{"NoUTurnLeft", TrafficSignType::kNoUTurnLeft},
                             MapSignTypeStringTestCase{"NoUTurnRight", TrafficSignType::kNoUTurnRight},
-                            MapSignTypeStringTestCase{"GiveWay", TrafficSignType::kYield},
-                            MapSignTypeStringTestCase{"SpeedLimitBegin", TrafficSignType::kSpeedLimit},
-                            MapSignTypeStringTestCase{"Crosswalk", TrafficSignType::kPedestrianCrossing}));
+                            MapSignTypeStringTestCase{"None", TrafficSignType::kNone},
+                            MapSignTypeStringTestCase{"Other", TrafficSignType::kOther},
+                            MapSignTypeStringTestCase{"Crosswalk", TrafficSignType::kCrosswalk},
+                            MapSignTypeStringTestCase{"RoadWorks", TrafficSignType::kRoadWorks},
+                            MapSignTypeStringTestCase{"GiveWay", TrafficSignType::kGiveWay},
+                            MapSignTypeStringTestCase{"DoNotEnter", TrafficSignType::kDoNotEnter},
+                            MapSignTypeStringTestCase{"SpeedLimitBegin", TrafficSignType::kSpeedLimitBegin},
+                            MapSignTypeStringTestCase{"TrafficCone", TrafficSignType::kTrafficCone},
+                            MapSignTypeStringTestCase{"Stop4Way", TrafficSignType::kStop4Way},
+                            MapSignTypeStringTestCase{"Car", TrafficSignType::kCar}));
 
 INSTANTIATE_TEST_CASE_P(UnknownTypes, MapSignTypeStringTest,
                         ::testing::Values(
@@ -90,9 +87,10 @@ INSTANTIATE_TEST_CASE_P(StrictPascalCase, MapSignTypeStringTest,
                             // Non-PascalCase variants are rejected.
                             MapSignTypeStringTestCase{"Stop", TrafficSignType::kStop},
                             MapSignTypeStringTestCase{"STOP", TrafficSignType::kUnknown},
-                            MapSignTypeStringTestCase{"Yield", TrafficSignType::kYield},
+                            MapSignTypeStringTestCase{"RoadWorks", TrafficSignType::kRoadWorks},
                             MapSignTypeStringTestCase{"speed_limit", TrafficSignType::kUnknown},
-                            MapSignTypeStringTestCase{"No_Overtaking", TrafficSignType::kUnknown}));
+                            MapSignTypeStringTestCase{"No_Overtaking", TrafficSignType::kUnknown},
+                            MapSignTypeStringTestCase{"roadworks", TrafficSignType::kUnknown}));
 
 }  // namespace
 }  // namespace test


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/maliput/maliput/pull/753

## Summary
* Mapping support for the new TrafficSignTypes added in https://github.com/maliput/maliput/pull/753.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

