### PR TITLE
Map XODR object barrier to kGuardRail, kGuardWall, kBarrier based on subtype.

### DIFF
--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -153,7 +153,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
   // --- Type ---
-  const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object_.type);
+  const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object_.type, object_.subtype);
 
   // --- Related lanes ---
   auto related_lanes = ResolveLaneIds(road_id_, object_s, object_.validities, road_geometry_);

--- a/src/maliput_malidrive/builder/road_object_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.cc
@@ -32,7 +32,8 @@ namespace malidrive {
 namespace builder {
 
 // These subtype strings are based on OpenDRIVE 1.9.0 specification.
-// See https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/v1.9.0/specification/13_objects/13_14_object_examples.html#_barrier
+// See
+// https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/v1.9.0/specification/13_objects/13_14_object_examples.html#_barrier
 static const char* kGuardRailSubtype = "guardRail";
 static const char* kWallSubtype = "wall";
 static const char* kJerseySubtype = "jerseyBarrier";
@@ -51,10 +52,8 @@ maliput::api::objects::RoadObjectType MapXodrObjectType(
   switch (xodr_type.value()) {
     // @{
     case XodrType::kBarrier:
-      if (subtype == kGuardRailSubtype)
-        return MaliputType::kGuardRail;
-      if (subtype == kWallSubtype || subtype == kJerseySubtype)
-        return MaliputType::kGuardWall;
+      if (subtype == kGuardRailSubtype) return MaliputType::kGuardRail;
+      if (subtype == kWallSubtype || subtype == kJerseySubtype) return MaliputType::kGuardWall;
       // else, fall through to default barrier type.
     case XodrType::kSoundBarrier:
     case XodrType::kRailing:

--- a/src/maliput_malidrive/builder/road_object_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.cc
@@ -31,9 +31,9 @@
 namespace malidrive {
 namespace builder {
 
-// These subtype strings are based on OpenDRIVE 1.9.0 specification.
+// These subtype strings are based on OpenDRIVE 1.8.0 specification.
 // See
-// https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/v1.9.0/specification/13_objects/13_14_object_examples.html#_barrier
+// https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/1.8.0/specification/13_objects/13_14_object_examples.html
 static const char* kGuardRailSubtype = "guardRail";
 static const char* kWallSubtype = "wall";
 static const char* kJerseySubtype = "jerseyBarrier";

--- a/src/maliput_malidrive/builder/road_object_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.cc
@@ -31,8 +31,14 @@
 namespace malidrive {
 namespace builder {
 
+// These subtype strings are based on OpenDRIVE 1.9.0 specification.
+// See https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/v1.9.0/specification/13_objects/13_14_object_examples.html#_barrier
+static const char* kGuardRailSubtype = "guardRail";
+static const char* kWallSubtype = "wall";
+static const char* kJerseySubtype = "jerseyBarrier";
+
 maliput::api::objects::RoadObjectType MapXodrObjectType(
-    const std::optional<xodr::object::Object::ObjectType>& xodr_type) {
+    const std::optional<xodr::object::Object::ObjectType>& xodr_type, std::optional<std::string> xodr_subtype) {
   using XodrType = xodr::object::Object::ObjectType;
   using MaliputType = maliput::api::objects::RoadObjectType;
 
@@ -40,9 +46,16 @@ maliput::api::objects::RoadObjectType MapXodrObjectType(
     return MaliputType::kUnknown;
   }
 
+  const std::string subtype = xodr_subtype.value_or("");
+
   switch (xodr_type.value()) {
     // @{
     case XodrType::kBarrier:
+      if (subtype == kGuardRailSubtype)
+        return MaliputType::kGuardRail;
+      if (subtype == kWallSubtype || subtype == kJerseySubtype)
+        return MaliputType::kGuardWall;
+      // else, fall through to default barrier type.
     case XodrType::kSoundBarrier:
     case XodrType::kRailing:
       return MaliputType::kBarrier;

--- a/src/maliput_malidrive/builder/road_object_type_mapper.h
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.h
@@ -48,9 +48,10 @@ namespace builder {
 /// A std::nullopt input maps to kUnknown.
 ///
 /// @param xodr_type The optional XODR object type to map.
+/// @param xodr_subtype The optional XODR object subtype to map.
 /// @returns The corresponding maliput RoadObjectType.
 maliput::api::objects::RoadObjectType MapXodrObjectType(
-    const std::optional<xodr::object::Object::ObjectType>& xodr_type);
+    const std::optional<xodr::object::Object::ObjectType>& xodr_type, std::optional<std::string> xodr_subtype = std::nullopt);
 
 }  // namespace builder
 }  // namespace malidrive

--- a/src/maliput_malidrive/builder/road_object_type_mapper.h
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.h
@@ -51,7 +51,8 @@ namespace builder {
 /// @param xodr_subtype The optional XODR object subtype to map.
 /// @returns The corresponding maliput RoadObjectType.
 maliput::api::objects::RoadObjectType MapXodrObjectType(
-    const std::optional<xodr::object::Object::ObjectType>& xodr_type, std::optional<std::string> xodr_subtype = std::nullopt);
+    const std::optional<xodr::object::Object::ObjectType>& xodr_type,
+    std::optional<std::string> xodr_subtype = std::nullopt);
 
 }  // namespace builder
 }  // namespace malidrive

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -1545,7 +1545,7 @@ TEST_F(RoadObjectBookBuilderTest, GetRoadObjectById) {
 
 TEST_F(RoadObjectBookBuilderTest, FindByType) {
   using RoadObjectType = maliput::api::objects::RoadObjectType;
-  const auto barriers = rob_->FindByType(RoadObjectType::kBarrier);
+  const auto barriers = rob_->FindByType(RoadObjectType::kGuardRail);
   EXPECT_EQ(1u, barriers.size());
 
   const auto buildings = rob_->FindByType(RoadObjectType::kBuilding);

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -102,6 +102,17 @@ TEST_F(RoadObjectTypeMapperTest, UnknownMappings) {
   EXPECT_EQ(MaliputType::kUnknown, MapXodrObjectType(std::nullopt));
 }
 
+TEST_F(RoadObjectTypeMapperTest, SubtypeMappings) {
+  using XodrType = xodr::object::Object::ObjectType;
+  using MaliputType = maliput::api::objects::RoadObjectType;
+
+  EXPECT_EQ(MaliputType::kGuardRail, MapXodrObjectType(XodrType::kBarrier, "guardRail"));
+  EXPECT_EQ(MaliputType::kGuardWall, MapXodrObjectType(XodrType::kBarrier, "wall"));
+  EXPECT_EQ(MaliputType::kGuardWall, MapXodrObjectType(XodrType::kBarrier, "jerseyBarrier"));
+  EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kBarrier, "otherSubtype"));
+  EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kBarrier, std::nullopt));
+}
+
 // ---------------------------------------------------------------------------
 // RoadObjectBuilder tests.
 // Uses the TwoRoadsWithRoadObjects.xodr resource.
@@ -142,13 +153,13 @@ TEST_F(RoadObjectBuilderTest, GetRoadObjectByIdReturnsNullForUnknownId) {
   EXPECT_EQ(nullptr, road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("nonexistent")));
 }
 
-TEST_F(RoadObjectBuilderTest, BarrierObject) {
-  // obj_barrier: barrier at s=20, t=3
+TEST_F(RoadObjectBuilderTest, BarrierObjectMapsToGuardRailDueToSubtype) {
+  // obj_barrier: guard rail at s=20, t=3
   const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_barrier"));
   ASSERT_NE(road_object, nullptr);
 
   EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("obj_barrier"));
-  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kBarrier);
+  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kGuardRail);
   EXPECT_EQ(road_object->name(), "GuardRail");
   EXPECT_EQ(road_object->subtype(), "guardRail");
   EXPECT_FALSE(road_object->is_dynamic());
@@ -176,10 +187,10 @@ TEST_F(RoadObjectBuilderTest, BarrierObject) {
   EXPECT_EQ(it->second, "metal");
 }
 
-TEST_F(RoadObjectBuilderTest, FindByTypeBarrier) {
-  const auto barriers = road_object_book_->FindByType(maliput::api::objects::RoadObjectType::kBarrier);
-  ASSERT_EQ(1u, barriers.size());
-  EXPECT_EQ(barriers[0]->id(), maliput::api::objects::RoadObject::Id("obj_barrier"));
+TEST_F(RoadObjectBuilderTest, FindByTypeGuardRail) {
+  const auto guard_rails = road_object_book_->FindByType(maliput::api::objects::RoadObjectType::kGuardRail);
+  ASSERT_EQ(1u, guard_rails.size());
+  EXPECT_EQ(guard_rails[0]->id(), maliput::api::objects::RoadObject::Id("obj_barrier"));
 }
 
 TEST_F(RoadObjectBuilderTest, BuildingObjectWithRadius) {


### PR DESCRIPTION
# 🎉 New feature

## Summary
* XODR objects of type barrier with subtype map to specific RoadObjectTypes.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
