### PR TITLE
Fix XODR signals and objects z position.

### DIFF
--- a/resources/SingleRoadElevatedAllDeviceTypes.xodr
+++ b/resources/SingleRoadElevatedAllDeviceTypes.xodr
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2026, Woven by Toyota. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ Single straight road with non-zero elevation containing one device of each kind
+ needed by all_device_types_test_db.yaml:
+   - traffic sign signal: type=206
+   - traffic light signal: type=1000001
+   - road object: type=barrier
+   - road marking: type=crosswalk
+
+ This resource is intended for z-position regression tests where device z must
+ be computed relative to road surface + zOffset.
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="4" name="SingleRoadElevatedAllDeviceTypes"/>
+    <road name="Road 1" length="6.0000000000000000e+1" id="1" junction="-1">
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="0.0000000000000000e+0" y="0.0000000000000000e+0" hdg="0.0000000000000000e+0" length="6.0000000000000000e+1">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+0" a="1.5022778571589519e+1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+        </elevationProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false"/>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+            <object id="OBJ_BARRIER" name="GuardRail" type="barrier"
+                    s="1.0000000000000000e+1" t="3.0000000000000000e+0" zOffset="1.0000000000000000e+0"
+                    length="8.0000000000000000e+0" width="3.0000000000000004e-1" height="1.0000000000000000e+0"
+                    hdg="0.0000000000000000e+0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="-1"/>
+            </object>
+            <object id="OBJ_CROSSWALK" name="Crosswalk1" type="crosswalk"
+                    s="2.0000000000000000e+1" t="0.0000000000000000e+0" zOffset="2.0000000000000000e+0"
+                    length="4.0000000000000000e+0" width="7.0000000000000000e+0" height="0.0000000000000000e+0"
+                    hdg="0.0000000000000000e+0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="1"/>
+            </object>
+        </objects>
+        <signals>
+            <signal id="TS1" name="ElevatedStopSign" s="0.0000000000000000e+0" t="-1.0000000000000000e+0"
+                    zOffset="5.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="206" subtype="-1" value="-1" text=""
+                    height="1.0000000000000000e+0" width="5.0000000000000000e-1">
+                <validity fromLane="-1" toLane="-1"/>
+            </signal>
+            <signal id="TL1" name="ElevatedTrafficLight" s="5.0000000000000000e+0" t="1.0000000000000000e+0"
+                    zOffset="6.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="yes" country="OpenDRIVE"
+                    type="1000001" subtype="-1"
+                    height="1.0000000000000000e+0" width="5.0000000000000000e-1">
+                <validity fromLane="-1" toLane="1"/>
+            </signal>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -114,7 +114,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
                                                                             object_.t};
   const maliput::api::RoadPosition rp = mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
   maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
-  inertial_pos.set_z(object_.z_offset);
+  inertial_pos.set_z(inertial_pos.z() + object_.z_offset);
 
   const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
 

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -122,7 +122,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
                                                                             object_.t};
   const maliput::api::RoadPosition rp = mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
   maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
-  inertial_pos.set_z(object_.z_offset);
+  inertial_pos.set_z(inertial_pos.z() + object_.z_offset);
 
   const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
 

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -131,7 +131,8 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
   // road.
   maliput::api::RoadPosition rp = mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
   maliput::api::InertialPosition pos = rp.ToInertialPosition();
-  pos.set_z(signal_.z_offset);
+  pos.set_z(pos.z() + signal_.z_offset);
+  // pos.set_z(pos.z() + signal_.z_offset);
   // The traffic light's orientation is set based on the lane's orientation at the traffic light's position.
   double orientation =
       rp.lane->GetOrientation(rp.pos).yaw() + (signal_.h_offset.has_value() ? signal_.h_offset.value() : 0.);

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -132,7 +132,6 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
   maliput::api::RoadPosition rp = mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
   maliput::api::InertialPosition pos = rp.ToInertialPosition();
   pos.set_z(pos.z() + signal_.z_offset);
-  // pos.set_z(pos.z() + signal_.z_offset);
   // The traffic light's orientation is set based on the lane's orientation at the traffic light's position.
   double orientation =
       rp.lane->GetOrientation(rp.pos).yaw() + (signal_.h_offset.has_value() ? signal_.h_offset.value() : 0.);

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -132,7 +132,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   // the road.
   maliput::api::RoadPosition rp = mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
   maliput::api::InertialPosition pos = rp.ToInertialPosition();
-  pos.set_z(signal_.z_offset);
+  pos.set_z(pos.z() + signal_.z_offset);
   // The traffic sign's orientation is set based on the lane's orientation at the traffic sign's position.
   const double orientation =
       rp.lane->GetOrientation(rp.pos).yaw() + (signal_.h_offset.has_value() ? signal_.h_offset.value() : 0.);

--- a/test/regression/builder/road_marking_builder_test.cc
+++ b/test/regression/builder/road_marking_builder_test.cc
@@ -192,6 +192,67 @@ TEST_F(RoadMarkingBuilderTest, ReturnsNullptrForNoMatchingDefinition) {
   EXPECT_EQ(road_marking, nullptr);
 }
 
+class RoadMarkingBuilderElevatedRoadTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("SingleRoadElevatedAllDeviceTypes.xodr", kMalidriveResourceFolder);
+    tcd_db_path_ = utility::FindResourceInPath("traffic_control_device_db/all_device_types_test_db.yaml",
+                                               kMalidriveResourceFolder);
+
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kTrafficControlDeviceDb, tcd_db_path_},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+
+    const auto* manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+    const auto road_headers = manager->GetRoadHeaders();
+    const auto road_header_it = road_headers.find(xodr::RoadHeader::Id("1"));
+    ASSERT_NE(road_header_it, road_headers.end());
+    ASSERT_TRUE(road_header_it->second.objects.has_value());
+
+    bool found_object = false;
+    for (const auto& object : road_header_it->second.objects->objects) {
+      if (object.id.string() == "OBJ_CROSSWALK") {
+        object_ = object;
+        found_object = true;
+        break;
+      }
+    }
+    ASSERT_TRUE(found_object);
+
+    loader_ = std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(tcd_db_path_);
+  }
+
+  std::string tcd_db_path_;
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  xodr::object::Object object_;
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+  const xodr::RoadHeader::Id road_id_{"1"};
+};
+
+TEST_F(RoadMarkingBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
+  RoadMarkingBuilder builder(object_, road_id_, *loader_, road_geometry_);
+  const auto road_marking = builder();
+  ASSERT_NE(road_marking, nullptr);
+
+  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{1, object_.s, object_.t};
+  const maliput::api::RoadPosition rp =
+      road_geometry_->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
+  const double road_surface_z = rp.ToInertialPosition().z();
+  const double road_marking_z = road_marking->position().inertial_position().z();
+
+  EXPECT_NEAR(road_surface_z + object_.z_offset, road_marking_z, 1e-6);
+  EXPECT_GT(std::abs(road_marking_z - object_.z_offset), 1.0);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace builder

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -44,6 +44,7 @@
 #include "maliput_malidrive/builder/road_network_builder.h"
 #include "maliput_malidrive/builder/road_network_configuration.h"
 #include "maliput_malidrive/builder/road_object_type_mapper.h"
+#include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
 #include "maliput_malidrive/xodr/db_manager.h"
 #include "maliput_malidrive/xodr/object/object.h"
 #include "maliput_malidrive/xodr/road_header.h"
@@ -414,6 +415,66 @@ TEST_F(RoadObjectBuilderTest, VegetationOutlineId) {
   const auto* outline = road_object->outline(0);
   ASSERT_NE(outline, nullptr);
   EXPECT_EQ(outline->id(), maliput::api::objects::Outline::Id("vegetation_star_outline"));
+}
+
+class RoadObjectBuilderElevatedRoadTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("SingleRoadElevatedAllDeviceTypes.xodr", kMalidriveResourceFolder);
+    tcd_db_path_ = utility::FindResourceInPath("traffic_control_device_db/all_device_types_test_db.yaml",
+                                               kMalidriveResourceFolder);
+
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kTrafficControlDeviceDb, tcd_db_path_},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+
+    const auto manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+    const auto road_headers = manager->GetRoadHeaders();
+    const auto road_header_it = road_headers.find(xodr::RoadHeader::Id("1"));
+    ASSERT_NE(road_header_it, road_headers.end());
+    ASSERT_TRUE(road_header_it->second.objects.has_value());
+
+    bool found_object = false;
+    for (const auto& object : road_header_it->second.objects->objects) {
+      if (object.id.string() == "OBJ_BARRIER") {
+        object_ = object;
+        found_object = true;
+        break;
+      }
+    }
+    ASSERT_TRUE(found_object);
+
+    loader_ = std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(tcd_db_path_);
+  }
+
+  std::string tcd_db_path_;
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  xodr::object::Object object_;
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+};
+
+TEST_F(RoadObjectBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
+  RoadObjectBuilder builder(object_, xodr::RoadHeader::Id("1"), *loader_, road_geometry_);
+  const auto road_object = builder();
+  ASSERT_NE(road_object, nullptr);
+
+  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{1, object_.s, object_.t};
+  const maliput::api::RoadPosition rp =
+      road_geometry_->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
+  const double road_surface_z = rp.ToInertialPosition().z();
+  const double road_object_z = road_object->position().inertial_position().z();
+
+  EXPECT_NEAR(road_surface_z + object_.z_offset, road_object_z, 1e-6);
+  EXPECT_GT(std::abs(road_object_z - object_.z_offset), 1.0);
 }
 
 TEST_F(RoadObjectBuilderTest, FindByLane) {

--- a/test/regression/builder/traffic_light_builder_test.cc
+++ b/test/regression/builder/traffic_light_builder_test.cc
@@ -189,6 +189,68 @@ TEST_F(TrafficLightBuilderFigure8Test, PositionOfTrafficLight) {
   EXPECT_NEAR(position.y(), -2.8325, 1e-3);
 }
 
+class TrafficLightBuilderElevatedRoadTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("SingleRoadElevatedAllDeviceTypes.xodr", kMalidriveResourceFolder);
+    traffic_control_device_db_path_ = utility::FindResourceInPath(
+        "traffic_control_device_db/all_device_types_test_db.yaml", kMalidriveResourceFolder);
+
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kTrafficControlDeviceDb, traffic_control_device_db_path_},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+    const auto manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+
+    const auto road_headers = manager->GetRoadHeaders();
+    ASSERT_FALSE(road_headers.empty());
+    const auto road_header = road_headers.find(xodr::RoadHeader::Id("1"));
+    ASSERT_FALSE(road_header == road_headers.end());
+    ASSERT_TRUE(road_header->second.signals.has_value());
+    ASSERT_FALSE(road_header->second.signals->signals.empty());
+
+    bool found_signal = false;
+    for (const auto& signal : road_header->second.signals->signals) {
+      if (signal.id.string() == "TL1") {
+        signal_ = signal;
+        found_signal = true;
+        break;
+      }
+    }
+    ASSERT_TRUE(found_signal);
+    loader_ =
+        std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(traffic_control_device_db_path_);
+  }
+
+  std::string traffic_control_device_db_path_;
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  xodr::signal::Signal signal_{0.0, 0.0, xodr::signal::Signal::Id("none")};
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+};
+
+TEST_F(TrafficLightBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
+  TrafficLightBuilder builder(signal_, xodr::RoadHeader::Id("1"), *loader_, road_geometry_);
+  const auto traffic_light = builder();
+  ASSERT_NE(traffic_light, nullptr);
+
+  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{1, signal_.s, signal_.t};
+  const maliput::api::RoadPosition rp =
+      road_geometry_->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
+  const double road_surface_z = rp.ToInertialPosition().z();
+  const double traffic_light_z = traffic_light->position_road_network().z();
+
+  EXPECT_NEAR(road_surface_z + signal_.z_offset, traffic_light_z, 1e-6);
+  EXPECT_GT(std::abs(traffic_light_z - signal_.z_offset), 1.0);
+}
+
 // ---------------------------------------------------------------------------
 // Tests using TwoRoadsWithTrafficLights.xodr / traffic_control_device_db/traffic_control_device_db_example.yaml.
 //

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -184,6 +184,70 @@ TEST_F(TrafficSignBuilderFigure8Test, BuildTrafficSignThrowsOnUnrecognizedUnit) 
 }
 
 // ---------------------------------------------------------------------------
+// Tests using SingleRoadElevatedAllDeviceTypes.xodr.
+//
+// This map encodes extracted characteristics needed for the regression: a
+// non-zero road elevation profile (z around 15 m at s=0) and a sign with
+// zOffset=5 m. It verifies TrafficSign z is road-relative (road_z + zOffset),
+// not world-relative.
+// ---------------------------------------------------------------------------
+
+class TrafficSignBuilderElevatedRoadTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("SingleRoadElevatedAllDeviceTypes.xodr", kMalidriveResourceFolder);
+    traffic_control_device_db_path_ = utility::FindResourceInPath(
+        "traffic_control_device_db/all_device_types_test_db.yaml", kMalidriveResourceFolder);
+
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kTrafficControlDeviceDb, traffic_control_device_db_path_},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+    const auto manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+
+    // Road 1 has a stop sign with non-zero zOffset on top of non-zero road elevation.
+    const auto road_headers = manager->GetRoadHeaders();
+    ASSERT_FALSE(road_headers.empty());
+    const auto road_header = road_headers.find(xodr::RoadHeader::Id("1"));
+    ASSERT_FALSE(road_header == road_headers.end());
+    ASSERT_TRUE(road_header->second.signals.has_value());
+    ASSERT_FALSE(road_header->second.signals->signals.empty());
+    signal_ = road_header->second.signals->signals[0];
+    loader_ =
+        std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(traffic_control_device_db_path_);
+  }
+
+  std::string traffic_control_device_db_path_;
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  xodr::signal::Signal signal_{0.0, 0.0, xodr::signal::Signal::Id("none")};
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+};
+
+TEST_F(TrafficSignBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
+  const xodr::signal::Signal& stop_signal = signal_;
+  TrafficSignBuilder builder(stop_signal, xodr::RoadHeader::Id("1"), *loader_, road_geometry_);
+  const auto traffic_sign = builder();
+  ASSERT_NE(traffic_sign, nullptr);
+
+  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{1, stop_signal.s, stop_signal.t};
+  const maliput::api::RoadPosition rp =
+      road_geometry_->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
+  const double road_surface_z = rp.ToInertialPosition().z();
+  const double traffic_sign_z = traffic_sign->position_road_network().z();
+
+  EXPECT_NEAR(road_surface_z + stop_signal.z_offset, traffic_sign_z, 1e-6);
+  EXPECT_GT(std::abs(traffic_sign_z - stop_signal.z_offset), 1.0);
+}
+
+// ---------------------------------------------------------------------------
 // Tests using TwoRoadsWithTrafficSigns.xodr / traffic_control_device_db/traffic_control_device_db_example.yaml.
 //
 // This lightweight map defines two straight roads (Road 1 and Road 2), each


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #457 

## Summary
Signals and objects z_offset is defined from the road's reference line, not the world. This PR takes into consideration the road's z position at a given s-t to calculate each XODR signal and XODR object z-position.

### Before
<img width="858" height="360" alt="image" src="https://github.com/user-attachments/assets/31a5480c-c986-415f-aece-22b798159c4b" />

### After 
<img width="902" height="755" alt="image" src="https://github.com/user-attachments/assets/0811a5bc-a193-4dec-bc28-494a55fe48fd" />


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
