### PR TITLE
Implement dependent_signs API.

### DIFF
--- a/resources/XCrossStopAllWay.xodr
+++ b/resources/XCrossStopAllWay.xodr
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2026, Woven by Toyota. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ Four straight roads arranged as an X-cross intersection approach. Each road has
+ one incoming lane and two signals on that approach:
+   - Stop sign (type="206")
+   - All-way supplementary sign (type="1022") with dependency on the stop sign
+
+ Dependencies are encoded on the all-way sign via:
+   <dependency id="STx"/>
+ and should produce reverse relationships where stop signs expose all-way signs
+ in TrafficSign::dependent_signs().
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="4" name="XCrossStopAllWay"/>
+
+    <road name="SouthApproach" length="1.2000000000000000e+2" id="1" junction="-1">
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="0.0000000000000000e+0" y="-6.0000000000000000e+1" hdg="1.5707963267948966e+0" length="1.2000000000000000e+2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false"/>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <signal id="ST1" name="Stop_ST1" s="5.7000000000000000e+1" t="-1.5000000000000000e+0"
+                    zOffset="1.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="206" subtype="-1" value="-1" text=""
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"/>
+            <signal id="AW1" name="AllWay_AW1" s="5.8000000000000000e+1" t="-1.5000000000000000e+0"
+                    zOffset="1.2000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="1022" subtype="-1" value="-1" text="ALL WAY"
+                    height="3.0000000000000000e-1" width="5.0000000000000000e-1">
+                <dependency id="ST1"/>
+            </signal>
+        </signals>
+    </road>
+
+    <road name="NorthApproach" length="1.2000000000000000e+2" id="2" junction="-1">
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="0.0000000000000000e+0" y="6.0000000000000000e+1" hdg="-1.5707963267948966e+0" length="1.2000000000000000e+2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false"/>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <signal id="ST2" name="Stop_ST2" s="5.7000000000000000e+1" t="-1.5000000000000000e+0"
+                    zOffset="1.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="206" subtype="-1" value="-1" text=""
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"/>
+            <signal id="AW2" name="AllWay_AW2" s="5.8000000000000000e+1" t="-1.5000000000000000e+0"
+                    zOffset="1.2000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="1022" subtype="-1" value="-1" text="ALL WAY"
+                    height="3.0000000000000000e-1" width="5.0000000000000000e-1">
+                <dependency id="ST2"/>
+            </signal>
+        </signals>
+    </road>
+
+    <road name="WestApproach" length="1.2000000000000000e+2" id="3" junction="-1">
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="-6.0000000000000000e+1" y="0.0000000000000000e+0" hdg="0.0000000000000000e+0" length="1.2000000000000000e+2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false"/>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <signal id="ST3" name="Stop_ST3" s="5.7000000000000000e+1" t="-1.5000000000000000e+0"
+                    zOffset="1.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="206" subtype="-1" value="-1" text=""
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"/>
+            <signal id="AW3" name="AllWay_AW3" s="5.8000000000000000e+1" t="-1.5000000000000000e+0"
+                    zOffset="1.2000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="1022" subtype="-1" value="-1" text="ALL WAY"
+                    height="3.0000000000000000e-1" width="5.0000000000000000e-1">
+                <dependency id="ST3"/>
+            </signal>
+        </signals>
+    </road>
+
+    <road name="EastApproach" length="1.2000000000000000e+2" id="4" junction="-1">
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="6.0000000000000000e+1" y="0.0000000000000000e+0" hdg="3.1415926535897931e+0" length="1.2000000000000000e+2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false"/>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <signal id="ST4" name="Stop_ST4" s="5.7000000000000000e+1" t="-1.5000000000000000e+0"
+                    zOffset="1.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="206" subtype="-1" value="-1" text=""
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"/>
+            <signal id="AW4" name="AllWay_AW4" s="5.8000000000000000e+1" t="-1.5000000000000000e+0"
+                    zOffset="1.2000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="1022" subtype="-1" value="-1" text="ALL WAY"
+                    height="3.0000000000000000e-1" width="5.0000000000000000e-1">
+                <dependency id="ST4"/>
+            </signal>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/resources/traffic_control_device_db/testing_database.yaml
+++ b/resources/traffic_control_device_db/testing_database.yaml
@@ -30,6 +30,38 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 odr_signal_types:
+  # Stop sign (static traffic sign).
+  - odr_representation:
+      type: "206"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+      name: "*"
+    properties:
+      device_type: TrafficSign
+      device_semantics: Stop
+      description: "Stop sign. Requires a complete stop before proceeding."
+
+      rule_states:
+        - conditions: []
+          value: "StopThenGo"
+
+  # Auxiliary all-way plaque modeled as a TrafficSign.
+  - odr_representation:
+      type: "1022"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+      name: "*"
+    properties:
+      device_type: TrafficSign
+      device_semantics: AllWay
+      description: "All-way supplementary sign."
+
+      rule_states:
+        - conditions: []
+          value: ""
+
   # Speed limit sign (static traffic sign).
   - odr_representation:
       type: "274"

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -28,7 +28,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/builder/traffic_control_device_books_builder.h"
 
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <maliput/base/road_marking_book.h>
 #include <maliput/base/road_object_book.h>
@@ -47,9 +49,37 @@
 #include "maliput_malidrive/traffic_control_device/parser.h"
 #include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
 #include "maliput_malidrive/xodr/object/object.h"
+#include "maliput_malidrive/xodr/signal/signal.h"
 
 namespace malidrive {
 namespace builder {
+
+namespace {
+
+std::unordered_map<std::string, std::vector<xodr::signal::Signal::Id>> BuildDependentSignalIndex(
+    const malidrive::RoadGeometry* mali_rg, bool allow_non_driveable_lanes) {
+  std::unordered_map<std::string, std::vector<xodr::signal::Signal::Id>> dependent_signals_by_signal_id;
+  for (const auto& [road_id, road_header] : mali_rg->get_manager()->GetRoadHeaders()) {
+    if (!road_header.signals.has_value()) {
+      continue;
+    }
+    if (!allow_non_driveable_lanes) {
+      if (AreOnlyNonDrivableLanes(road_header)) {
+        maliput::log()->debug("Skipping dependency pre-processing on road '", road_id.string(),
+                              "' since it has no driveable lanes.");
+        continue;
+      }
+    }
+    for (const auto& signal : road_header.signals->signals) {
+      for (const auto& dependency : signal.dependencies) {
+        dependent_signals_by_signal_id[dependency.signal_id.string()].push_back(signal.id);
+      }
+    }
+  }
+  return dependent_signals_by_signal_id;
+}
+
+}  // namespace
 
 TrafficControlDeviceBooksBuilder::TrafficControlDeviceBooksBuilder(const maliput::api::RoadGeometry* road_geometry,
                                                                    std::optional<std::string> traffic_light_book_path,
@@ -84,6 +114,9 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
 
   // Pre-build the signal-reference index once.
   const auto signal_refs_by_id = mali_rg->get_manager()->GetSignalReferencesBySignalId();
+
+  // Pre-build reverse signal dependencies: controlling-signal-id -> dependent signal IDs.
+  const auto dependent_signals_by_signal_id = BuildDependentSignalIndex(mali_rg, allow_non_driveable_lanes_);
 
   // --- Signals pass: route to TrafficLightBook or TrafficSignBook ---
   for (const auto& [road_id, road_header] : mali_rg->get_manager()->GetRoadHeaders()) {
@@ -134,7 +167,14 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
           tlb_impl->AddTrafficLight(std::move(tl));
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kTrafficSign) {
-        auto ts = TrafficSignBuilder(signal, road_id, loader, road_geometry_, std::move(refs))();
+        std::vector<xodr::signal::Signal::Id> dependent_sign_ids;
+        const auto dependent_it = dependent_signals_by_signal_id.find(signal.id.string());
+        if (dependent_it != dependent_signals_by_signal_id.end()) {
+          dependent_sign_ids = dependent_it->second;
+        }
+
+        auto ts = TrafficSignBuilder(signal, road_id, loader, road_geometry_, std::move(refs),
+                                     std::move(dependent_sign_ids))();
         if (ts) {
           tsb->AddTrafficSign(std::move(ts));
         }

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -85,12 +85,14 @@ std::optional<maliput::api::rules::TrafficSignValueUnit> StringToValueUnit(const
 TrafficSignBuilder::TrafficSignBuilder(const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                                        const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                                        const maliput::api::RoadGeometry* road_geometry,
-                                       std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references)
+                                       std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references,
+                                       std::vector<xodr::signal::Signal::Id> dependent_signs)
     : signal_(signal),
       road_id_(road_id),
       loader_(loader),
       road_geometry_(road_geometry),
-      signal_references_(std::move(signal_references)) {
+      signal_references_(std::move(signal_references)),
+      dependent_signs_(std::move(dependent_signs)) {
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
 }
 
@@ -180,6 +182,18 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
     properties.emplace("name", signal_.name.value());
   }
 
+  // TrafficSign dynamic semantics are sourced from the XODR signal's `dynamic`.
+  const bool is_dynamic = signal_.dynamic;
+  // TrafficSign positional movability is sourced from DB `is_position_dynamic`.
+  const bool is_movable = definition.is_position_dynamic;
+
+  // Converts dependent XODR signal IDs to TrafficSign::Id for the TrafficSign constructor.
+  std::vector<maliput::api::rules::TrafficSign::Id> dependent_signs;
+  dependent_signs.reserve(dependent_signs_.size());
+  for (const auto& dependent_sign_id : dependent_signs_) {
+    dependent_signs.emplace_back(dependent_sign_id.string());
+  }
+
   maliput::log()->debug("TrafficSignBuilder: creating TrafficSign for signal id='", signal_.id.string(), "' type='",
                         signal_.type, "' subtype='", signal_.subtype, "' device_semantics='",
                         definition.device_semantics.value_or("Unknown"), "'. TrafficSign position: (x=", pos.x(),
@@ -187,15 +201,10 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
                         ") with orientation (roll=0, pitch=0, yaw=", orientation_road_network.yaw(),
                         "), related_lanes=", related_lanes.size(), ".");
 
-  // TrafficSign dynamic semantics are sourced from the XODR signal's `dynamic`.
-  const bool is_dynamic = signal_.dynamic;
-  // TrafficSign positional movability is sourced from DB `is_position_dynamic`.
-  const bool is_movable = definition.is_position_dynamic;
-
-  return std::make_unique<maliput::api::rules::TrafficSign>(maliput::api::rules::TrafficSign::Id(signal_.id.string()),
-                                                            sign_meaning, pos, orientation_road_network, signal_.text,
-                                                            std::move(related_lanes), bounding_box, traffic_sign_value,
-                                                            std::move(properties), is_dynamic, is_movable);
+  return std::make_unique<maliput::api::rules::TrafficSign>(
+      maliput::api::rules::TrafficSign::Id(signal_.id.string()), sign_meaning, pos, orientation_road_network,
+      signal_.text, std::move(related_lanes), std::move(dependent_signs), bounding_box, traffic_sign_value,
+      std::move(properties), is_dynamic, is_movable);
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/traffic_sign_builder.h
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.h
@@ -63,11 +63,13 @@ class TrafficSignBuilder {
   /// @param signal_references Signal references from other roads that point to @p signal.
   ///        Each entry carries the referencing road's ID and the reference itself, whose
   ///        validity/s-coordinate is used to resolve related lanes on the referencing road.
+  /// @param dependent_signs IDs of signs that depend on @p signal.
   /// @throws std::invalid_argument if @p road_geometry is nullptr.
   TrafficSignBuilder(const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                      const maliput::api::RoadGeometry* road_geometry,
-                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {});
+                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {},
+                     std::vector<xodr::signal::Signal::Id> dependent_sign_ids = {});
 
   /// Builds and returns the @ref maliput::api::rules::TrafficSign.
   ///
@@ -80,6 +82,7 @@ class TrafficSignBuilder {
   const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader_;
   const maliput::api::RoadGeometry* road_geometry_;
   const std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references_;
+  const std::vector<xodr::signal::Signal::Id> dependent_signs_;
 };
 
 }  // namespace builder

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -493,6 +494,62 @@ TEST_F(TrafficSignBuilderSpeedLimitTest, SpeedLimitSignPosition) {
   EXPECT_NEAR(100., pos.x(), 1e-1);
   EXPECT_NEAR(3., pos.y(), 1e-1);
   EXPECT_NEAR(2.5, pos.z(), 1e-1);
+}
+
+// ---------------------------------------------------------------------------
+// Tests using XCrossStopAllWay.xodr / testing_database.yaml.
+//
+// This map has four incoming approaches (one lane per road). Each approach has
+// two signals: a stop sign and an all-way sign. The all-way sign declares a
+// dependency on its paired stop sign via <dependency id="STx"/>.
+//
+// Expected behavior: each stop sign reports its corresponding all-way sign in
+// dependent_signs().
+// ---------------------------------------------------------------------------
+
+class TrafficSignBuilderDependencyTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file = utility::FindResourceInPath("XCrossStopAllWay.xodr", kMalidriveResourceFolder);
+    const std::string yaml_db =
+        utility::FindResourceInPath("traffic_control_device_db/testing_database.yaml", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file},
+                                                                             {params::kTrafficControlDeviceDb, yaml_db},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    traffic_sign_book_ = road_network_->traffic_sign_book();
+    ASSERT_NE(traffic_sign_book_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::rules::TrafficSignBook* traffic_sign_book_{};
+};
+
+TEST_F(TrafficSignBuilderDependencyTest, StopSignsExposeAllWayAsDependentSigns) {
+  const std::vector<std::pair<std::string, std::string>> expected_dependencies{
+      {"ST1", "AW1"},
+      {"ST2", "AW2"},
+      {"ST3", "AW3"},
+      {"ST4", "AW4"},
+  };
+
+  for (const auto& [stop_id, all_way_id] : expected_dependencies) {
+    const auto* stop_sign = traffic_sign_book_->GetTrafficSign(maliput::api::rules::TrafficSign::Id(stop_id));
+    ASSERT_NE(stop_sign, nullptr);
+    EXPECT_EQ(maliput::api::rules::TrafficSignType::kStop, stop_sign->type());
+
+    const auto& dependent_signs = stop_sign->dependent_signs();
+    ASSERT_EQ(1u, dependent_signs.size());
+    EXPECT_EQ(all_way_id, dependent_signs.at(0).string());
+
+    const auto* all_way_sign = traffic_sign_book_->GetTrafficSign(maliput::api::rules::TrafficSign::Id(all_way_id));
+    ASSERT_NE(all_way_sign, nullptr);
+    EXPECT_EQ(maliput::api::rules::TrafficSignType::kAllWay, all_way_sign->type());
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature

Closes #495 

## Summary
* Creates dependent signs vector cycling through all XODR signals.
* Uses `dependent_signs` vector in `TrafficSignBuilder` to create `TrafficSign`s.
* Adds tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
