### PR TITLE
Reworking road marking types to be more generic

### DIFF
--- a/src/maliput_malidrive/builder/road_marking_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_marking_type_mapper.cc
@@ -42,21 +42,21 @@ maliput::api::objects::RoadMarkingType MapRoadMarkingTypeString(const std::strin
       {"StopLine", T::kStopLine},
       {"Crosswalk", T::kCrosswalk},
       {"ZebraCrossing", T::kCrosswalk},
-      {"ParkingSpace", T::kParkingSpace},
+      {"ParkingSpace", T::kCarParking},
       {"EmergencyLane", T::kEmergencyLane},
       {"SpeedLimit", T::kSpeedLimit},
-      {"NoStopping", T::kDoNotStop},
-      {"RailRoadCrossing", T::kRailRoad},
+      {"NoStopping", T::kNoStopping},
+      {"RailRoadCrossing", T::kRailroadCrossing},
       {"GiveWay", T::kGiveWay},
-      {"ArrowTurnRight", T::kArrowTurnRight},
-      {"ArrowTurnLeft", T::kArrowTurnLeft},
-      {"ArrowForwardTurnRight", T::kArrowForwardTurnRight},
-      {"ArrowForwardTurnLeft", T::kArrowForwardTurnLeft},
-      {"ArrowForward", T::kArrowForward},
-      {"ArrowForwardTurnRightTurnLeft", T::kArrowForwardTurnRightTurnLeft},
-      {"ArrowTurnRightTurnLeft", T::kArrowTurnRightTurnLeft},
-      {"ArrowUTurnRight", T::kArrowUTurnRight},
-      {"ArrowUTurnLeft", T::kArrowUTurnLeft},
+      {"ArrowTurnRight", T::kPrescribedRightTurn},
+      {"ArrowTurnLeft", T::kPrescribedLeftTurn},
+      {"ArrowForwardTurnRight", T::kPrescribedRightTurnAndStraight},
+      {"ArrowForwardTurnLeft", T::kPrescribedLeftTurnAndStraight},
+      {"ArrowForward", T::kPrescribedStraight},
+      {"ArrowForwardTurnRightTurnLeft", T::kPrescribedLeftTurnRightTurnAndStraight},
+      {"ArrowTurnRightTurnLeft", T::kPrescribedLeftTurnAndRightTurn},
+      {"ArrowUTurnRight", T::kPrescribedUTurnRight},
+      {"ArrowUTurnLeft", T::kPrescribedUTurnLeft},
   };
   const auto it = kMapper.find(device_semantics);
   return it != kMapper.end() ? it->second : T::kUnknown;
@@ -80,7 +80,7 @@ maliput::api::objects::RoadMarkingType MapXodrObjectTypeToRoadMarkingType(
     case XodrType::kCrosswalk:
       return MaliputType::kCrosswalk;
     case XodrType::kParkingSpace:
-      return MaliputType::kParkingSpace;
+      return MaliputType::kCarParking;
     default:
       return MaliputType::kUnknown;
   }

--- a/test/regression/builder/road_marking_builder_test.cc
+++ b/test/regression/builder/road_marking_builder_test.cc
@@ -160,7 +160,7 @@ TEST_F(RoadMarkingBuilderTest, BuildArrowForward) {
   ASSERT_NE(road_marking, nullptr);
 
   EXPECT_EQ(road_marking->id(), maliput::api::objects::RoadMarking::Id("rm_arrow"));
-  EXPECT_EQ(road_marking->type(), maliput::api::objects::RoadMarkingType::kArrowForward);
+  EXPECT_EQ(road_marking->type(), maliput::api::objects::RoadMarkingType::kPrescribedStraight);
 
   const auto& pos = road_marking->position().inertial_position();
   EXPECT_NEAR(pos.x(), 70.0, 0.5);

--- a/test/regression/builder/road_marking_type_mapper_test.cc
+++ b/test/regression/builder/road_marking_type_mapper_test.cc
@@ -44,24 +44,24 @@ TEST_F(RoadMarkingTypeMapperTest, DirectMappings) {
   EXPECT_EQ(T::kStopLine, MapRoadMarkingTypeString("StopLine"));
   EXPECT_EQ(T::kCrosswalk, MapRoadMarkingTypeString("Crosswalk"));
   EXPECT_EQ(T::kCrosswalk, MapRoadMarkingTypeString("ZebraCrossing"));
-  EXPECT_EQ(T::kParkingSpace, MapRoadMarkingTypeString("ParkingSpace"));
+  EXPECT_EQ(T::kCarParking, MapRoadMarkingTypeString("ParkingSpace"));
   EXPECT_EQ(T::kEmergencyLane, MapRoadMarkingTypeString("EmergencyLane"));
   EXPECT_EQ(T::kSpeedLimit, MapRoadMarkingTypeString("SpeedLimit"));
-  EXPECT_EQ(T::kDoNotStop, MapRoadMarkingTypeString("NoStopping"));
-  EXPECT_EQ(T::kRailRoad, MapRoadMarkingTypeString("RailRoadCrossing"));
+  EXPECT_EQ(T::kNoStopping, MapRoadMarkingTypeString("NoStopping"));
+  EXPECT_EQ(T::kRailroadCrossing, MapRoadMarkingTypeString("RailRoadCrossing"));
   EXPECT_EQ(T::kGiveWay, MapRoadMarkingTypeString("GiveWay"));
 }
 
 TEST_F(RoadMarkingTypeMapperTest, ArrowMappings) {
-  EXPECT_EQ(T::kArrowTurnRight, MapRoadMarkingTypeString("ArrowTurnRight"));
-  EXPECT_EQ(T::kArrowTurnLeft, MapRoadMarkingTypeString("ArrowTurnLeft"));
-  EXPECT_EQ(T::kArrowForwardTurnRight, MapRoadMarkingTypeString("ArrowForwardTurnRight"));
-  EXPECT_EQ(T::kArrowForwardTurnLeft, MapRoadMarkingTypeString("ArrowForwardTurnLeft"));
-  EXPECT_EQ(T::kArrowForward, MapRoadMarkingTypeString("ArrowForward"));
-  EXPECT_EQ(T::kArrowForwardTurnRightTurnLeft, MapRoadMarkingTypeString("ArrowForwardTurnRightTurnLeft"));
-  EXPECT_EQ(T::kArrowTurnRightTurnLeft, MapRoadMarkingTypeString("ArrowTurnRightTurnLeft"));
-  EXPECT_EQ(T::kArrowUTurnRight, MapRoadMarkingTypeString("ArrowUTurnRight"));
-  EXPECT_EQ(T::kArrowUTurnLeft, MapRoadMarkingTypeString("ArrowUTurnLeft"));
+  EXPECT_EQ(T::kPrescribedRightTurn, MapRoadMarkingTypeString("ArrowTurnRight"));
+  EXPECT_EQ(T::kPrescribedLeftTurn, MapRoadMarkingTypeString("ArrowTurnLeft"));
+  EXPECT_EQ(T::kPrescribedRightTurnAndStraight, MapRoadMarkingTypeString("ArrowForwardTurnRight"));
+  EXPECT_EQ(T::kPrescribedLeftTurnAndStraight, MapRoadMarkingTypeString("ArrowForwardTurnLeft"));
+  EXPECT_EQ(T::kPrescribedStraight, MapRoadMarkingTypeString("ArrowForward"));
+  EXPECT_EQ(T::kPrescribedLeftTurnRightTurnAndStraight, MapRoadMarkingTypeString("ArrowForwardTurnRightTurnLeft"));
+  EXPECT_EQ(T::kPrescribedLeftTurnAndRightTurn, MapRoadMarkingTypeString("ArrowTurnRightTurnLeft"));
+  EXPECT_EQ(T::kPrescribedUTurnRight, MapRoadMarkingTypeString("ArrowUTurnRight"));
+  EXPECT_EQ(T::kPrescribedUTurnLeft, MapRoadMarkingTypeString("ArrowUTurnLeft"));
 }
 
 TEST_F(RoadMarkingTypeMapperTest, StrictPascalCase) {


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/maliput/maliput/issues/756

## Summary

- Merges traffic sign and road marking types into one enum

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
