### PR TITLE
Using correct database mapper for RoadMarkings

### DIFF
--- a/resources/traffic_control_device_db/road_marking_test_db.yaml
+++ b/resources/traffic_control_device_db/road_marking_test_db.yaml
@@ -59,8 +59,8 @@ odr_object_types:
       name: "ArrowForward"
     properties:
       device_type: RoadMarking
-      device_semantics: ArrowForward
-      description: "Forward Arrow road marking"
+      device_semantics: PrescribedStraight
+      description: "Prescribed straight road marking"
 
   # Generic roadMark (fallback with lower specificity).
   - odr_representation:

--- a/src/maliput_malidrive/builder/road_marking_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_marking_type_mapper.cc
@@ -37,27 +37,13 @@ namespace builder {
 
 maliput::api::objects::RoadMarkingType MapRoadMarkingTypeString(const std::string& device_semantics) {
   using T = maliput::api::objects::RoadMarkingType;
-  static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper{
-      {"Stop", T::kStop},
-      {"StopLine", T::kStopLine},
-      {"Crosswalk", T::kCrosswalk},
-      {"ZebraCrossing", T::kCrosswalk},
-      {"ParkingSpace", T::kCarParking},
-      {"EmergencyLane", T::kEmergencyLane},
-      {"SpeedLimit", T::kSpeedLimit},
-      {"NoStopping", T::kNoStopping},
-      {"RailRoadCrossing", T::kRailroadCrossing},
-      {"GiveWay", T::kGiveWay},
-      {"ArrowTurnRight", T::kPrescribedRightTurn},
-      {"ArrowTurnLeft", T::kPrescribedLeftTurn},
-      {"ArrowForwardTurnRight", T::kPrescribedRightTurnAndStraight},
-      {"ArrowForwardTurnLeft", T::kPrescribedLeftTurnAndStraight},
-      {"ArrowForward", T::kPrescribedStraight},
-      {"ArrowForwardTurnRightTurnLeft", T::kPrescribedLeftTurnRightTurnAndStraight},
-      {"ArrowTurnRightTurnLeft", T::kPrescribedLeftTurnAndRightTurn},
-      {"ArrowUTurnRight", T::kPrescribedUTurnRight},
-      {"ArrowUTurnLeft", T::kPrescribedUTurnLeft},
-  };
+  static const std::unordered_map<std::string, T, maliput::common::DefaultHash> kMapper = [] {
+    std::unordered_map<std::string, T, maliput::common::DefaultHash> result;
+    for (const auto& [type, type_name] : maliput::api::objects::RoadMarkingTypeMapper()) {
+      result.emplace(type_name, type);
+    }
+    return result;
+  }();
   const auto it = kMapper.find(device_semantics);
   return it != kMapper.end() ? it->second : T::kUnknown;
 }

--- a/test/regression/builder/road_marking_type_mapper_test.cc
+++ b/test/regression/builder/road_marking_type_mapper_test.cc
@@ -43,25 +43,27 @@ TEST_F(RoadMarkingTypeMapperTest, DirectMappings) {
   EXPECT_EQ(T::kStop, MapRoadMarkingTypeString("Stop"));
   EXPECT_EQ(T::kStopLine, MapRoadMarkingTypeString("StopLine"));
   EXPECT_EQ(T::kCrosswalk, MapRoadMarkingTypeString("Crosswalk"));
-  EXPECT_EQ(T::kCrosswalk, MapRoadMarkingTypeString("ZebraCrossing"));
-  EXPECT_EQ(T::kCarParking, MapRoadMarkingTypeString("ParkingSpace"));
+  EXPECT_EQ(T::kZebraCrossing, MapRoadMarkingTypeString("ZebraCrossing"));
+  EXPECT_EQ(T::kCarParking, MapRoadMarkingTypeString("CarParking"));
   EXPECT_EQ(T::kEmergencyLane, MapRoadMarkingTypeString("EmergencyLane"));
   EXPECT_EQ(T::kSpeedLimit, MapRoadMarkingTypeString("SpeedLimit"));
   EXPECT_EQ(T::kNoStopping, MapRoadMarkingTypeString("NoStopping"));
-  EXPECT_EQ(T::kRailroadCrossing, MapRoadMarkingTypeString("RailRoadCrossing"));
+  EXPECT_EQ(T::kRailroadCrossing, MapRoadMarkingTypeString("RailroadCrossing"));
   EXPECT_EQ(T::kGiveWay, MapRoadMarkingTypeString("GiveWay"));
+  EXPECT_EQ(T::kOther, MapRoadMarkingTypeString("Other"));
 }
 
 TEST_F(RoadMarkingTypeMapperTest, ArrowMappings) {
-  EXPECT_EQ(T::kPrescribedRightTurn, MapRoadMarkingTypeString("ArrowTurnRight"));
-  EXPECT_EQ(T::kPrescribedLeftTurn, MapRoadMarkingTypeString("ArrowTurnLeft"));
-  EXPECT_EQ(T::kPrescribedRightTurnAndStraight, MapRoadMarkingTypeString("ArrowForwardTurnRight"));
-  EXPECT_EQ(T::kPrescribedLeftTurnAndStraight, MapRoadMarkingTypeString("ArrowForwardTurnLeft"));
-  EXPECT_EQ(T::kPrescribedStraight, MapRoadMarkingTypeString("ArrowForward"));
-  EXPECT_EQ(T::kPrescribedLeftTurnRightTurnAndStraight, MapRoadMarkingTypeString("ArrowForwardTurnRightTurnLeft"));
-  EXPECT_EQ(T::kPrescribedLeftTurnAndRightTurn, MapRoadMarkingTypeString("ArrowTurnRightTurnLeft"));
-  EXPECT_EQ(T::kPrescribedUTurnRight, MapRoadMarkingTypeString("ArrowUTurnRight"));
-  EXPECT_EQ(T::kPrescribedUTurnLeft, MapRoadMarkingTypeString("ArrowUTurnLeft"));
+  EXPECT_EQ(T::kPrescribedRightTurn, MapRoadMarkingTypeString("PrescribedRightTurn"));
+  EXPECT_EQ(T::kPrescribedLeftTurn, MapRoadMarkingTypeString("PrescribedLeftTurn"));
+  EXPECT_EQ(T::kPrescribedRightTurnAndStraight, MapRoadMarkingTypeString("PrescribedRightTurnAndStraight"));
+  EXPECT_EQ(T::kPrescribedLeftTurnAndStraight, MapRoadMarkingTypeString("PrescribedLeftTurnAndStraight"));
+  EXPECT_EQ(T::kPrescribedStraight, MapRoadMarkingTypeString("PrescribedStraight"));
+  EXPECT_EQ(T::kPrescribedLeftTurnRightTurnAndStraight,
+            MapRoadMarkingTypeString("PrescribedLeftTurnRightTurnAndStraight"));
+  EXPECT_EQ(T::kPrescribedLeftTurnAndRightTurn, MapRoadMarkingTypeString("PrescribedLeftTurnAndRightTurn"));
+  EXPECT_EQ(T::kPrescribedUTurnRight, MapRoadMarkingTypeString("PrescribedUTurnRight"));
+  EXPECT_EQ(T::kPrescribedUTurnLeft, MapRoadMarkingTypeString("PrescribedUTurnLeft"));
 }
 
 TEST_F(RoadMarkingTypeMapperTest, StrictPascalCase) {
@@ -74,7 +76,6 @@ TEST_F(RoadMarkingTypeMapperTest, StrictPascalCase) {
 }
 
 TEST_F(RoadMarkingTypeMapperTest, UnknownMappings) {
-  EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString("Other"));
   EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString("other"));
   EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString("none"));
   EXPECT_EQ(T::kUnknown, MapRoadMarkingTypeString(""));


### PR DESCRIPTION
# 🦟 Bug fix

No issue attached

## Summary

- The traffic signs and road markigns share the same possible types in maliput. When mapping from the supplementary data base to maliput types, road markings were using a different map to traffic signs, giving unexpected/inconsistent results when mapping entried in the db. This PR makes it so that both use the same mapper from string (db) to maliput type

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
