### PR TITLE
odr_signal_types now allows RoadMarkings and RoadObjects.

### DIFF
--- a/src/maliput_malidrive/traffic_control_device/README.md
+++ b/src/maliput_malidrive/traffic_control_device/README.md
@@ -11,8 +11,8 @@ A traffic control device type definition describes the physical structure, seman
 
 The database has **two root keys**:
 
-- **`odr_signal_types`** — devices represented by OpenDRIVE `signal` elements (traffic lights, traffic signs, road markings, and road objects).
-- **`odr_object_types`** — devices represented by OpenDRIVE `object` elements (road markings, road objects).
+- **`odr_signal_types`** — devices represented by XODR `signal` elements (traffic lights, traffic signs, road markings, and road objects).
+- **`odr_object_types`** — devices represented by XODR `object` elements (road markings, road objects).
 
 At least one of the two root keys must be present. The parser returns a single flat `std::vector<TrafficControlDeviceDefinition>` that mixes signal and object entries; downstream code discriminates them via the `device_type` field.
 
@@ -66,7 +66,7 @@ odr_signal_types:
       rule_states: [...]          # Optional: only meaningful for TrafficLight
 ```
 
-For signals, `device_type` MUST be `TrafficLight`, `TrafficSign`, `RoadMarking`, or `RoadObject`.
+For signals, `device_type` MUST be `TrafficLight`, `TrafficSign`, `RoadMarking` or `RoadObject`.
 
 ### `odr_object_types`
 

--- a/src/maliput_malidrive/traffic_control_device/README.md
+++ b/src/maliput_malidrive/traffic_control_device/README.md
@@ -11,7 +11,7 @@ A traffic control device type definition describes the physical structure, seman
 
 The database has **two root keys**:
 
-- **`odr_signal_types`** — devices represented by OpenDRIVE `signal` elements (traffic lights, traffic signs).
+- **`odr_signal_types`** — devices represented by OpenDRIVE `signal` elements (traffic lights, traffic signs, road markings, and road objects).
 - **`odr_object_types`** — devices represented by OpenDRIVE `object` elements (road markings, road objects).
 
 At least one of the two root keys must be present. The parser returns a single flat `std::vector<TrafficControlDeviceDefinition>` that mixes signal and object entries; downstream code discriminates them via the `device_type` field.
@@ -66,7 +66,7 @@ odr_signal_types:
       rule_states: [...]          # Optional: only meaningful for TrafficLight
 ```
 
-For signals, `device_type` MUST be `TrafficLight` or `TrafficSign`. Using `RoadMarking` or `RoadObject` in a signal entry is rejected with a parser error.
+For signals, `device_type` MUST be `TrafficLight`, `TrafficSign`, `RoadMarking`, or `RoadObject`.
 
 ### `odr_object_types`
 
@@ -108,8 +108,8 @@ Required string that identifies the device category. Used to route entries to th
 |----------------------|------------------------|-----------------------------------------------------|
 | `"TrafficLight"`    | `odr_signal_types`     | Creates a `maliput::api::rules::TrafficLight`       |
 | `"TrafficSign"`     | `odr_signal_types`     | Creates a `maliput::api::rules::TrafficSign`        |
-| `"RoadMarking"`     | `odr_object_types`     | Creates a `maliput::api::object::RoadMarking`       |
-| `"RoadObject"`      | `odr_object_types`     | Creates a `maliput::api::object::RoadObject`        |
+| `"RoadMarking"`     | `odr_signal_types`, `odr_object_types` | Creates a `maliput::api::objects::RoadMarking` |
+| `"RoadObject"`      | `odr_signal_types`, `odr_object_types` | Creates a `maliput::api::objects::RoadObject` |
 
 The `device_type` matching is **strict PascalCase**. Variants like `"Road_Marking"` and `"ROAD_MARKING"` are rejected.
 

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -407,11 +407,13 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
   const std::string device_type_str = GetRequiredStringField(props_node, TrafficControlDeviceConstants::kDeviceType);
   tcd_definition.device_type = StringToTrafficControlDeviceType(device_type_str);
   MALIDRIVE_VALIDATE(tcd_definition.device_type == TrafficControlDeviceType::kTrafficLight ||
-                         tcd_definition.device_type == TrafficControlDeviceType::kTrafficSign,
+                         tcd_definition.device_type == TrafficControlDeviceType::kTrafficSign ||
+                         tcd_definition.device_type == TrafficControlDeviceType::kRoadMarking ||
+                         tcd_definition.device_type == TrafficControlDeviceType::kRoadObject,
                      maliput::common::road_network_description_parser_error,
                      "device_type '" + device_type_str +
                          "' is not allowed for odr_signal_types entries; "
-                         "expected 'traffic_light' or 'traffic_sign'.");
+                         "expected 'traffic_light', 'traffic_sign', 'road_marking', or 'road_object'.");
 
   tcd_definition.device_semantics = GetOptionalStringField(props_node, TrafficControlDeviceConstants::kDeviceSemantics);
 

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -181,8 +181,8 @@ struct TrafficControlDeviceDefinition {
 /// Design:
 /// - Each definition carries a `device_type` field that determines whether the entry is a
 ///   traffic light, traffic sign, road marking, or road object.
-/// - For signals (`odr_signal_types`): `device_type` must be `traffic_light` or
-///   `traffic_sign`.
+/// - For signals (`odr_signal_types`): `device_type` must be `traffic_light`,
+///   `traffic_sign`, `road_marking`, or `road_object`.
 /// - For objects (`odr_object_types`): `device_type` must be `road_marking` or
 ///   `road_object`. Object entries' `odr_representation` only carries `type`, `subtype`,
 ///   and `name`; `country`/`country_revision` are not permitted. Object entries'
@@ -200,6 +200,8 @@ struct TrafficControlDeviceDefinition {
 /// 3. Inspect `device_type` to route the signal to the appropriate builder:
 ///    - `"traffic_light"` → build a `TrafficLight`.
 ///    - `"traffic_sign"`  → build a `TrafficSign` whose type is mapped from `device_semantics`.
+///    - `"road_marking"`  → build a `RoadMarking`.
+///    - `"road_object"`   → build a `RoadObject`.
 /// 4. Link the resulting objects to their affected lanes using signal validity data from the XODR file.
 class TrafficControlDeviceParser {
  public:

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -1768,27 +1768,32 @@ odr_object_types:
   EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kDb), maliput::common::road_network_description_parser_error);
 }
 
-GTEST_TEST(OdrObjectTypesParserTest, RejectsObjectDeviceTypeInSignal) {
+GTEST_TEST(OdrObjectTypesParserTest, AcceptsRoadDeviceTypesInSignal) {
   const char kRoadMarkingInSignal[] = R"(
 odr_signal_types:
   - odr_representation:
       type: "1000001"
     properties:
       device_type: RoadMarking
-      description: "Should fail"
+      device_semantics: Crosswalk
+      description: "Road marking from signal"
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kRoadMarkingInSignal),
-               maliput::common::road_network_description_parser_error);
+  const auto road_marking_defs = TrafficControlDeviceParser::LoadFromString(kRoadMarkingInSignal);
+  ASSERT_EQ(road_marking_defs.size(), 1u);
+  EXPECT_EQ(road_marking_defs[0].device_type, TrafficControlDeviceType::kRoadMarking);
+
   const char kRoadObjectInSignal[] = R"(
 odr_signal_types:
   - odr_representation:
       type: "1000001"
     properties:
       device_type: RoadObject
-      description: "Should fail"
+      device_semantics: Barrier
+      description: "Road object from signal"
 )";
-  EXPECT_THROW(TrafficControlDeviceParser::LoadFromString(kRoadObjectInSignal),
-               maliput::common::road_network_description_parser_error);
+  const auto road_object_defs = TrafficControlDeviceParser::LoadFromString(kRoadObjectInSignal);
+  ASSERT_EQ(road_object_defs.size(), 1u);
+  EXPECT_EQ(road_object_defs[0].device_type, TrafficControlDeviceType::kRoadObject);
 }
 
 GTEST_TEST(OdrObjectTypesParserTest, EqualSpecificityObjectConflictIsRejected) {


### PR DESCRIPTION
# 🎉 New feature

Relates to #501 and #502 

## Summary
TrafficControlDevice DB now allows `RoadMarking` and `RoadObject` `device_type`s in the `odr_signal_types`


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
