### PR TITLE
Fix: build signal dependencies from parent to child sign.

### DIFF
--- a/resources/XCrossStopAllWay.xodr
+++ b/resources/XCrossStopAllWay.xodr
@@ -31,12 +31,12 @@
 
  Four straight roads arranged as an X-cross intersection approach. Each road has
  one incoming lane and two signals on that approach:
-   - Stop sign (type="206")
-   - All-way supplementary sign (type="1022") with dependency on the stop sign
+   - Stop sign (type="206") with dependency on the all-way sign
+   - All-way supplementary sign (type="1022")
 
- Dependencies are encoded on the all-way sign via:
-   <dependency id="STx"/>
- and should produce reverse relationships where stop signs expose all-way signs
+ Dependencies are encoded on the stop sign via:
+   <dependency id="AWx"/>
+ and should produce relationships where stop signs expose all-way signs
  in TrafficSign::dependent_signs().
 -->
 <OpenDRIVE>
@@ -66,15 +66,15 @@
                     roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
                     orientation="+" dynamic="no" country="OpenDRIVE"
                     type="206" subtype="-1" value="-1" text=""
-                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"/>
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1">
+                <dependency id="AW1"/>
+            </signal>
             <signal id="AW1" name="AllWay_AW1" s="5.8000000000000000e+1" t="-1.5000000000000000e+0"
                     zOffset="1.2000000000000000e+0" hOffset="0.0000000000000000e+0"
                     roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
                     orientation="+" dynamic="no" country="OpenDRIVE"
                     type="1022" subtype="-1" value="-1" text="ALL WAY"
-                    height="3.0000000000000000e-1" width="5.0000000000000000e-1">
-                <dependency id="ST1"/>
-            </signal>
+                    height="3.0000000000000000e-1" width="5.0000000000000000e-1"/>
         </signals>
     </road>
 
@@ -102,15 +102,15 @@
                     roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
                     orientation="+" dynamic="no" country="OpenDRIVE"
                     type="206" subtype="-1" value="-1" text=""
-                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"/>
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1">
+                <dependency id="AW2"/>
+            </signal>
             <signal id="AW2" name="AllWay_AW2" s="5.8000000000000000e+1" t="-1.5000000000000000e+0"
                     zOffset="1.2000000000000000e+0" hOffset="0.0000000000000000e+0"
                     roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
                     orientation="+" dynamic="no" country="OpenDRIVE"
                     type="1022" subtype="-1" value="-1" text="ALL WAY"
-                    height="3.0000000000000000e-1" width="5.0000000000000000e-1">
-                <dependency id="ST2"/>
-            </signal>
+                    height="3.0000000000000000e-1" width="5.0000000000000000e-1"/>
         </signals>
     </road>
 
@@ -138,15 +138,15 @@
                     roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
                     orientation="+" dynamic="no" country="OpenDRIVE"
                     type="206" subtype="-1" value="-1" text=""
-                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"/>
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1">
+                <dependency id="AW3"/>
+            </signal>
             <signal id="AW3" name="AllWay_AW3" s="5.8000000000000000e+1" t="-1.5000000000000000e+0"
                     zOffset="1.2000000000000000e+0" hOffset="0.0000000000000000e+0"
                     roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
                     orientation="+" dynamic="no" country="OpenDRIVE"
                     type="1022" subtype="-1" value="-1" text="ALL WAY"
-                    height="3.0000000000000000e-1" width="5.0000000000000000e-1">
-                <dependency id="ST3"/>
-            </signal>
+                    height="3.0000000000000000e-1" width="5.0000000000000000e-1"/>
         </signals>
     </road>
 
@@ -174,15 +174,15 @@
                     roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
                     orientation="+" dynamic="no" country="OpenDRIVE"
                     type="206" subtype="-1" value="-1" text=""
-                    height="6.1000000000000000e-1" width="6.1000000000000000e-1"/>
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1">
+                <dependency id="AW4"/>
+            </signal>
             <signal id="AW4" name="AllWay_AW4" s="5.8000000000000000e+1" t="-1.5000000000000000e+0"
                     zOffset="1.2000000000000000e+0" hOffset="0.0000000000000000e+0"
                     roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
                     orientation="+" dynamic="no" country="OpenDRIVE"
                     type="1022" subtype="-1" value="-1" text="ALL WAY"
-                    height="3.0000000000000000e-1" width="5.0000000000000000e-1">
-                <dependency id="ST4"/>
-            </signal>
+                    height="3.0000000000000000e-1" width="5.0000000000000000e-1"/>
         </signals>
     </road>
 </OpenDRIVE>

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -28,7 +28,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/builder/traffic_control_device_books_builder.h"
 
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -53,33 +52,6 @@
 
 namespace malidrive {
 namespace builder {
-
-namespace {
-
-std::unordered_map<std::string, std::vector<xodr::signal::Signal::Id>> BuildDependentSignalIndex(
-    const malidrive::RoadGeometry* mali_rg, bool allow_non_driveable_lanes) {
-  std::unordered_map<std::string, std::vector<xodr::signal::Signal::Id>> dependent_signals_by_signal_id;
-  for (const auto& [road_id, road_header] : mali_rg->get_manager()->GetRoadHeaders()) {
-    if (!road_header.signals.has_value()) {
-      continue;
-    }
-    if (!allow_non_driveable_lanes) {
-      if (AreOnlyNonDrivableLanes(road_header)) {
-        maliput::log()->debug("Skipping dependency pre-processing on road '", road_id.string(),
-                              "' since it has no driveable lanes.");
-        continue;
-      }
-    }
-    for (const auto& signal : road_header.signals->signals) {
-      for (const auto& dependency : signal.dependencies) {
-        dependent_signals_by_signal_id[dependency.signal_id.string()].push_back(signal.id);
-      }
-    }
-  }
-  return dependent_signals_by_signal_id;
-}
-
-}  // namespace
 
 TrafficControlDeviceBooksBuilder::TrafficControlDeviceBooksBuilder(const maliput::api::RoadGeometry* road_geometry,
                                                                    std::optional<std::string> traffic_light_book_path,
@@ -114,9 +86,6 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
 
   // Pre-build the signal-reference index once.
   const auto signal_refs_by_id = mali_rg->get_manager()->GetSignalReferencesBySignalId();
-
-  // Pre-build reverse signal dependencies: controlling-signal-id -> dependent signal IDs.
-  const auto dependent_signals_by_signal_id = BuildDependentSignalIndex(mali_rg, allow_non_driveable_lanes_);
 
   // --- Signals pass: route to TrafficLightBook or TrafficSignBook ---
   for (const auto& [road_id, road_header] : mali_rg->get_manager()->GetRoadHeaders()) {
@@ -167,14 +136,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
           tlb_impl->AddTrafficLight(std::move(tl));
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kTrafficSign) {
-        std::vector<xodr::signal::Signal::Id> dependent_sign_ids;
-        const auto dependent_it = dependent_signals_by_signal_id.find(signal.id.string());
-        if (dependent_it != dependent_signals_by_signal_id.end()) {
-          dependent_sign_ids = dependent_it->second;
-        }
-
-        auto ts = TrafficSignBuilder(signal, road_id, loader, road_geometry_, std::move(refs),
-                                     std::move(dependent_sign_ids))();
+        auto ts = TrafficSignBuilder(signal, road_id, loader, road_geometry_, std::move(refs))();
         if (ts) {
           tsb->AddTrafficSign(std::move(ts));
         }

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -85,14 +85,12 @@ std::optional<maliput::api::rules::TrafficSignValueUnit> StringToValueUnit(const
 TrafficSignBuilder::TrafficSignBuilder(const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                                        const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                                        const maliput::api::RoadGeometry* road_geometry,
-                                       std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references,
-                                       std::vector<xodr::signal::Signal::Id> dependent_signs)
+                                       std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references)
     : signal_(signal),
       road_id_(road_id),
       loader_(loader),
       road_geometry_(road_geometry),
-      signal_references_(std::move(signal_references)),
-      dependent_signs_(std::move(dependent_signs)) {
+      signal_references_(std::move(signal_references)) {
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
 }
 
@@ -189,11 +187,8 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
 
   // Converts dependent XODR signal IDs to TrafficSign::Id for the TrafficSign constructor.
   std::vector<maliput::api::rules::TrafficSign::Id> dependent_signs;
-  dependent_signs.reserve(dependent_signs_.size());
-  for (const auto& dependent_sign_id : dependent_signs_) {
-    dependent_signs.emplace_back(dependent_sign_id.string());
-  }
-
+  for (const auto& dependent_sign : signal_.dependencies) {
+    dependent_signs.emplace_back(dependent_sign.signal_id.string());
   maliput::log()->debug("TrafficSignBuilder: creating TrafficSign for signal id='", signal_.id.string(), "' type='",
                         signal_.type, "' subtype='", signal_.subtype, "' device_semantics='",
                         definition.device_semantics.value_or("Unknown"), "'. TrafficSign position: (x=", pos.x(),

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -189,6 +189,8 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   std::vector<maliput::api::rules::TrafficSign::Id> dependent_signs;
   for (const auto& dependent_sign : signal_.dependencies) {
     dependent_signs.emplace_back(dependent_sign.signal_id.string());
+  }
+
   maliput::log()->debug("TrafficSignBuilder: creating TrafficSign for signal id='", signal_.id.string(), "' type='",
                         signal_.type, "' subtype='", signal_.subtype, "' device_semantics='",
                         definition.device_semantics.value_or("Unknown"), "'. TrafficSign position: (x=", pos.x(),

--- a/src/maliput_malidrive/builder/traffic_sign_builder.h
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.h
@@ -63,13 +63,11 @@ class TrafficSignBuilder {
   /// @param signal_references Signal references from other roads that point to @p signal.
   ///        Each entry carries the referencing road's ID and the reference itself, whose
   ///        validity/s-coordinate is used to resolve related lanes on the referencing road.
-  /// @param dependent_signs IDs of signs that depend on @p signal.
   /// @throws std::invalid_argument if @p road_geometry is nullptr.
   TrafficSignBuilder(const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                      const maliput::api::RoadGeometry* road_geometry,
-                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {},
-                     std::vector<xodr::signal::Signal::Id> dependent_sign_ids = {});
+                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {});
 
   /// Builds and returns the @ref maliput::api::rules::TrafficSign.
   ///
@@ -82,7 +80,6 @@ class TrafficSignBuilder {
   const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader_;
   const maliput::api::RoadGeometry* road_geometry_;
   const std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references_;
-  const std::vector<xodr::signal::Signal::Id> dependent_signs_;
 };
 
 }  // namespace builder

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -500,8 +500,8 @@ TEST_F(TrafficSignBuilderSpeedLimitTest, SpeedLimitSignPosition) {
 // Tests using XCrossStopAllWay.xodr / testing_database.yaml.
 //
 // This map has four incoming approaches (one lane per road). Each approach has
-// two signals: a stop sign and an all-way sign. The all-way sign declares a
-// dependency on its paired stop sign via <dependency id="STx"/>.
+// two signals: a stop sign and an all-way sign. The stop sign declares a
+// dependency on its paired all-way sign via <dependency id="AWx"/>.
 //
 // Expected behavior: each stop sign reports its corresponding all-way sign in
 // dependent_signs().


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #504 

## Summary
* Changes logic so that parent signs point to their children, and not the other way around.
* Signal dependencies are no longer required to be checked before TrafficSign creation since all the info is provided in the XODR parser.
* Update test XODR to properly describe XODR signals dependencies.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
