### PR TITLE
RoadObjectBuilder accepts XODR signals.

### DIFF
--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -76,12 +76,42 @@ class MalidriveRoadObject final : public maliput::api::objects::RoadObject {
                    std::move(subtype), std::move(outlines), std::move(properties), is_movable) {}
 };
 
+std::optional<std::string> NormalizeSubtype(const std::string& subtype) {
+  if (subtype.empty() || subtype == "-1" || subtype == "none") {
+    return std::nullopt;
+  }
+  return subtype;
+}
+
+std::optional<maliput::api::objects::RoadObjectType> StringToRoadObjectType(const std::string& device_semantics) {
+  const auto mapper = maliput::api::objects::RoadObjectTypeMapper();
+  for (const auto& [type, name] : mapper) {
+    if (device_semantics == name) {
+      return type;
+    }
+  }
+  return std::nullopt;
+}
+
 }  // namespace
 
-RoadObjectBuilder::RoadObjectBuilder(const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::object::Object& object,
+                                     const xodr::RoadHeader::Id& road_id,
                                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                                      const maliput::api::RoadGeometry* road_geometry)
-    : object_(object), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+    : source_type_(source_type), object_(&object), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+  MALIDRIVE_VALIDATE(source_type_ == SourceType::kObject, std::invalid_argument,
+                     "RoadObjectBuilder object constructor requires SourceType::kObject.");
+  MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
+}
+
+RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::signal::Signal& signal,
+                                     const xodr::RoadHeader::Id& road_id,
+                                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
+                                     const maliput::api::RoadGeometry* road_geometry)
+    : source_type_(source_type), signal_(&signal), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+  MALIDRIVE_VALIDATE(source_type_ == SourceType::kSignal, std::invalid_argument,
+                     "RoadObjectBuilder signal constructor requires SourceType::kSignal.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
 }
 
@@ -90,94 +120,168 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
   MALIDRIVE_VALIDATE(mali_rg != nullptr, maliput::common::assertion_error,
                      "RoadGeometry cannot be cast to malidrive::RoadGeometry.");
 
-  // Look up the object definition to retrieve is_movable from the database.
-  const std::string type_str =
-      object_.type.has_value() ? xodr::object::Object::object_type_to_str(object_.type.value()) : "";
-  const traffic_control_device::TrafficControlDeviceFingerprint fingerprint{
-      type_str,     object_.subtype,
-      std::nullopt,  // country (not used for objects)
-      std::nullopt,  // country_revision (not used for objects)
-      object_.name,
-  };
+  switch (source_type_) {
+    case SourceType::kObject: {
+      MALIDRIVE_VALIDATE(object_ != nullptr, maliput::common::assertion_error,
+                         "RoadObjectBuilder object source is not set.");
+      const auto& object = *object_;
+      const std::string type_str =
+          object.type.has_value() ? xodr::object::Object::object_type_to_str(object.type.value()) : "";
+      const traffic_control_device::TrafficControlDeviceFingerprint fingerprint{
+          type_str, object.subtype, std::nullopt, std::nullopt, object.name,
+      };
+      bool is_movable = false;
+      const auto definition_opt = loader_.Lookup(fingerprint);
+      if (definition_opt.has_value() &&
+          definition_opt.value().device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
+        is_movable = definition_opt.value().is_position_dynamic;
+      }
 
-  bool is_movable = false;  // Default to false if definition not found or device_type is not kRoadObject.
-  const auto definition_opt = loader_.Lookup(fingerprint);
-  if (definition_opt.has_value() &&
-      definition_opt.value().device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
-    is_movable = definition_opt.value().is_position_dynamic;
+      // --- Position ---
+      double object_s = object.s;
+      if (is_almost_equal(object.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
+        std::ostringstream s_str, adjusted_s_str;
+        s_str << std::fixed << std::setprecision(10) << object.s;
+        adjusted_s_str << std::fixed << std::setprecision(10) << (object.s - kEpsilon);
+        maliput::log()->warn("RoadObjectBuilder: Object ", object.id.string(), " has s coordinate ", s_str.str(),
+                             " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
+                             " to avoid potential issues with lane association and orientation.");
+        object_s -= kEpsilon;
+      }
+
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object_s,
+                                                                                object.t};
+      const maliput::api::RoadPosition rp =
+          mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
+      maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
+      inertial_pos.set_z(inertial_pos.z() + object.z_offset);
+      const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
+
+      // --- Orientation ---
+      const bool perp_to_road = object.perp_to_road.value_or(false);
+      const maliput::math::RollPitchYaw road_orientation =
+          mali_rg->GetRoadOrientationAtOpenScenarioRoadPosition(osc_road_position);
+      const double hdg = object.hdg.value_or(0.);
+      const double pitch = perp_to_road ? 0. : object.pitch.value_or(0.);
+      const double roll = perp_to_road ? 0. : object.roll.value_or(0.);
+      const double orientation_offset =
+          (object.orientation.has_value() && object.orientation.value() == xodr::object::Orientation::kNegative) ? M_PI
+                                                                                                                 : 0.;
+      const maliput::api::Rotation orientation =
+          maliput::api::Rotation::FromRpy(road_orientation.roll_angle() + roll, road_orientation.pitch_angle() + pitch,
+                                          road_orientation.yaw_angle() + hdg + orientation_offset);
+
+      // --- Bounding box ---
+      double bb_length = object.length.value_or(0.);
+      double bb_width = object.width.value_or(0.);
+      const double bb_height = object.height.value_or(0.);
+      if (object.radius.has_value()) {
+        bb_length = 2.0 * object.radius.value();
+        bb_width = 2.0 * object.radius.value();
+      }
+      const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
+                                                    maliput::math::Vector3(bb_length, bb_width, bb_height),
+                                                    maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
+
+      // --- Type ---
+      const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object.type, object.subtype);
+      // --- Related lanes ---
+      auto related_lanes = ResolveLaneIds(road_id_, object_s, object.validities, road_geometry_);
+      // --- Outlines ---
+      auto outlines = BuildOutlines(object, road_id_, road_geometry_, inertial_pos, orientation);
+
+      std::unordered_map<std::string, std::string> properties;
+      if (!object.materials.empty()) {
+        properties["material"] = object.materials[0].surface.value_or("");
+        properties["subtype"] = object.subtype.value_or("");
+      }
+
+      maliput::log()->debug("RoadObjectBuilder: creating RoadObject id='", object.id.string(),
+                            "' type=", static_cast<int>(type), " position=(", inertial_pos.x(), ", ", inertial_pos.y(),
+                            ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
+
+      return std::make_unique<MalidriveRoadObject>(maliput::api::objects::RoadObject::Id(object.id.string()), type,
+                                                   position, orientation, bounding_box, object.dynamic.value_or(false),
+                                                   std::move(related_lanes), object.name, object.subtype,
+                                                   std::move(outlines), std::move(properties), is_movable);
+    }
+    case SourceType::kSignal: {
+      MALIDRIVE_VALIDATE(signal_ != nullptr, maliput::common::assertion_error,
+                         "RoadObjectBuilder signal source is not set.");
+      const auto& signal = *signal_;
+      const traffic_control_device::TrafficControlDeviceFingerprint fingerprint{
+          signal.type, NormalizeSubtype(signal.subtype), signal.country, signal.country_revision, signal.name,
+      };
+      bool is_movable = false;
+      std::optional<maliput::api::objects::RoadObjectType> type_from_db;
+      const auto definition_opt = loader_.Lookup(fingerprint);
+      if (definition_opt.has_value() &&
+          definition_opt.value().device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
+        is_movable = definition_opt.value().is_position_dynamic;
+        if (definition_opt.value().device_semantics.has_value()) {
+          type_from_db = StringToRoadObjectType(definition_opt.value().device_semantics.value());
+        }
+      }
+
+      // --- Position ---
+      double signal_s = signal.s;
+      if (is_almost_equal(signal.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
+        std::ostringstream s_str, adjusted_s_str;
+        s_str << std::fixed << std::setprecision(10) << signal.s;
+        adjusted_s_str << std::fixed << std::setprecision(10) << (signal.s - kEpsilon);
+        maliput::log()->warn("RoadObjectBuilder: Signal ", signal.id.string(), " has s coordinate ", s_str.str(),
+                             " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
+                             " to avoid potential issues with lane association and orientation.");
+        signal_s -= kEpsilon;
+      }
+
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal_s,
+                                                                                signal.t};
+      const maliput::api::RoadPosition rp =
+          mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
+      maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
+      inertial_pos.set_z(inertial_pos.z() + signal.z_offset);
+      const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
+
+      // --- Orientation ---
+      const maliput::math::RollPitchYaw road_orientation =
+          mali_rg->GetRoadOrientationAtOpenScenarioRoadPosition(osc_road_position);
+      const double orientation_offset = signal.orientation == xodr::signal::Orientation::kAgainstS ? 0. : M_PI;
+      const maliput::api::Rotation orientation = maliput::api::Rotation::FromRpy(
+          road_orientation.roll_angle() + signal.roll.value_or(0.),
+          road_orientation.pitch_angle() + signal.pitch.value_or(0.),
+          road_orientation.yaw_angle() + signal.h_offset.value_or(0.) + orientation_offset);
+
+      // --- Bounding box ---
+      const auto default_bounding_box =
+          definition_opt.has_value()
+              ? definition_opt->default_bounding_box.value_or(traffic_control_device::BoundingBoxDimensions{})
+              : traffic_control_device::BoundingBoxDimensions{};
+      const double bb_length = signal.length.value_or(default_bounding_box.length);
+      const double bb_width = signal.width.value_or(default_bounding_box.width);
+      const double bb_height = signal.height.value_or(default_bounding_box.height);
+      const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
+                                                    maliput::math::Vector3(bb_length, bb_width, bb_height),
+                                                    maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
+
+      // --- Related lanes ---
+      auto related_lanes = ResolveLaneIds(road_id_, signal_s, signal.validities, road_geometry_);
+      // --- Type ---
+      const auto type = type_from_db.value_or(maliput::api::objects::RoadObjectType::kUnknown);
+
+      maliput::log()->debug("RoadObjectBuilder: creating RoadObject id='", signal.id.string(),
+                            "' type=", static_cast<int>(type), " position=(", inertial_pos.x(), ", ", inertial_pos.y(),
+                            ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
+
+      return std::make_unique<MalidriveRoadObject>(
+          maliput::api::objects::RoadObject::Id(signal.id.string()), type, position, orientation, bounding_box,
+          signal.dynamic, std::move(related_lanes), signal.name, NormalizeSubtype(signal.subtype),
+          std::vector<std::unique_ptr<maliput::api::objects::Outline>>{},
+          std::unordered_map<std::string, std::string>{}, is_movable);
+    }
   }
 
-  // --- Position ---
-  double object_s = object_.s;
-  if (is_almost_equal(object_.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
-    std::ostringstream s_str, adjusted_s_str;
-    s_str << std::fixed << std::setprecision(10) << object_.s;
-    adjusted_s_str << std::fixed << std::setprecision(10) << (object_.s - kEpsilon);
-    maliput::log()->warn("RoadObjectBuilder: Object ", object_.id.string(), " has s coordinate ", s_str.str(),
-                         " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
-                         " to avoid potential issues with lane association and orientation.");
-    object_s -= kEpsilon;
-  }
-  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object_s,
-                                                                            object_.t};
-  const maliput::api::RoadPosition rp = mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
-  maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
-  inertial_pos.set_z(inertial_pos.z() + object_.z_offset);
-
-  const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
-
-  // --- Orientation ---
-  const bool perp_to_road = object_.perp_to_road.value_or(false);
-  const maliput::math::RollPitchYaw road_orientation =
-      mali_rg->GetRoadOrientationAtOpenScenarioRoadPosition(osc_road_position);
-  const double hdg = object_.hdg.value_or(0.);
-  const double pitch = perp_to_road ? 0. : object_.pitch.value_or(0.);
-  const double roll = perp_to_road ? 0. : object_.roll.value_or(0.);
-  const double orientation_offset =
-      (object_.orientation.has_value() && object_.orientation.value() == xodr::object::Orientation::kNegative) ? M_PI
-                                                                                                               : 0.;
-  const maliput::api::Rotation orientation =
-      maliput::api::Rotation::FromRpy(road_orientation.roll_angle() + roll, road_orientation.pitch_angle() + pitch,
-                                      road_orientation.yaw_angle() + hdg + orientation_offset);
-
-  // --- Bounding box ---
-  double bb_length = object_.length.value_or(0.);
-  double bb_width = object_.width.value_or(0.);
-  const double bb_height = object_.height.value_or(0.);
-  if (object_.radius.has_value()) {
-    bb_length = 2.0 * object_.radius.value();
-    bb_width = 2.0 * object_.radius.value();
-  }
-  const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
-                                                maliput::math::Vector3(bb_length, bb_width, bb_height),
-                                                maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
-
-  // --- Type ---
-  const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object_.type, object_.subtype);
-
-  // --- Related lanes ---
-  auto related_lanes = ResolveLaneIds(road_id_, object_s, object_.validities, road_geometry_);
-
-  // --- Outlines ---
-  auto outlines = BuildOutlines(object_, road_id_, road_geometry_, inertial_pos, orientation);
-
-  // --- Properties ---
-  std::unordered_map<std::string, std::string> properties;
-  if (!object_.materials.empty()) {
-    properties["material"] = object_.materials[0].surface.value_or("");
-    properties["subtype"] = object_.subtype.value_or("");
-  }
-
-  // --- is_dynamic ---
-  const bool is_dynamic = object_.dynamic.value_or(false);
-
-  maliput::log()->debug("RoadObjectBuilder: creating RoadObject id='", object_.id.string(),
-                        "' type=", static_cast<int>(type), " position=(", inertial_pos.x(), ", ", inertial_pos.y(),
-                        ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
-
-  return std::make_unique<MalidriveRoadObject>(
-      maliput::api::objects::RoadObject::Id(object_.id.string()), type, position, orientation, bounding_box, is_dynamic,
-      std::move(related_lanes), object_.name, object_.subtype, std::move(outlines), std::move(properties), is_movable);
+  MALIDRIVE_THROW_MESSAGE("RoadObjectBuilder received an unsupported source type.", maliput::common::assertion_error);
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/road_object_builder.h
+++ b/src/maliput_malidrive/builder/road_object_builder.h
@@ -36,25 +36,45 @@
 #include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
 #include "maliput_malidrive/xodr/object/object.h"
 #include "maliput_malidrive/xodr/road_header.h"
+#include "maliput_malidrive/xodr/signal/signal.h"
 
 namespace malidrive {
 namespace builder {
 
-/// Builds a single @ref maliput::api::objects::RoadObject from an XODR
-/// @ref xodr::object::Object.
+/// Builds a single @ref maliput::api::objects::RoadObject from either an XODR
+/// @ref xodr::object::Object or an XODR @ref xodr::signal::Signal.
 ///
 /// The builder follows the functor pattern: construct it with all required
-/// inputs and call @ref operator()() to produce the result.
+/// inputs and an explicit source selector, then call @ref operator()() to
+/// produce the result.
 class RoadObjectBuilder {
  public:
+  enum class SourceType {
+    kObject,
+    kSignal,
+  };
+
   /// Constructs a RoadObjectBuilder.
   ///
+  /// @param source_type The XODR element type this builder will read from.
   /// @param object The XODR object to build a RoadObject from.
   /// @param road_id The XODR road's ID the @p object belongs to.
   /// @param loader Database loader for looking up object device definitions.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
-  /// @throws std::invalid_argument if @p road_geometry is nullptr.
-  RoadObjectBuilder(const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+  /// @throws std::invalid_argument if @p source_type is not kObject or @p road_geometry is nullptr.
+  RoadObjectBuilder(SourceType source_type, const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+                    const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
+                    const maliput::api::RoadGeometry* road_geometry);
+
+  /// Constructs a RoadObjectBuilder.
+  ///
+  /// @param source_type The XODR element type this builder will read from.
+  /// @param signal The XODR signal to build a RoadObject from.
+  /// @param road_id The XODR road's ID the @p signal belongs to.
+  /// @param loader Database loader for looking up signal device definitions.
+  /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
+  /// @throws std::invalid_argument if @p source_type is not kSignal or @p road_geometry is nullptr.
+  RoadObjectBuilder(SourceType source_type, const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                     const maliput::api::RoadGeometry* road_geometry);
 
@@ -64,7 +84,9 @@ class RoadObjectBuilder {
   std::unique_ptr<maliput::api::objects::RoadObject> operator()() const;
 
  private:
-  const xodr::object::Object& object_;
+  SourceType source_type_;
+  const xodr::object::Object* object_{nullptr};
+  const xodr::signal::Signal* signal_{nullptr};
   const xodr::RoadHeader::Id& road_id_;
   const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader_;
   const maliput::api::RoadGeometry* road_geometry_;

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -140,6 +140,11 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         if (ts) {
           tsb->AddTrafficSign(std::move(ts));
         }
+      } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
+        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal, road_id, loader, road_geometry_)();
+        if (ro) {
+          rob->AddRoadObject(std::move(ro));
+        }
       } else {
         maliput::log()->debug("TrafficControlDeviceBooksBuilder: signal id='", signal.id.string(),
                               "' has device_type='",
@@ -176,7 +181,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         maliput::log()->debug("TrafficControlDeviceBooksBuilder: no definition found for object id='",
                               object.id.string(), "' type='", type_str, "' subtype='", object.subtype.value_or(""),
                               "' name='", object.name.value_or(""), "'.");
-        auto ro = RoadObjectBuilder(object, road_id, loader, road_geometry_)();
+        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }
@@ -196,14 +201,9 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
                                object.id.string(), "' on road '", road_id.string(), "': ", e.what(), ". Skipping.");
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
-        try {
-          auto ro = RoadObjectBuilder(object, road_id, loader, road_geometry_)();
-          if (ro) {
-            rob->AddRoadObject(std::move(ro));
-          }
-        } catch (const std::exception& e) {
-          maliput::log()->warn("TrafficControlDeviceBooksBuilder: failed to build RoadObject id='", object.id.string(),
-                               "' on road '", road_id.string(), "': ", e.what(), ". Skipping.");
+        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_)();
+        if (ro) {
+          rob->AddRoadObject(std::move(ro));
         }
       } else {
         maliput::log()->debug("TrafficControlDeviceBooksBuilder: object id='", object.id.string(),

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -56,6 +56,22 @@ namespace test {
 namespace {
 
 static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+const char kSignalRoadObjectDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      name: "*"
+    properties:
+      device_type: RoadObject
+      device_semantics: Barrier
+      is_position_dynamic: true
+      default_bounding_box:
+        length: 1.0
+        width: 0.5
+        height: 1.2
+)";
 
 // ---------------------------------------------------------------------------
 // Type mapper tests.
@@ -463,7 +479,8 @@ class RoadObjectBuilderElevatedRoadTest : public ::testing::Test {
 };
 
 TEST_F(RoadObjectBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
-  RoadObjectBuilder builder(object_, xodr::RoadHeader::Id("1"), *loader_, road_geometry_);
+  RoadObjectBuilder builder(RoadObjectBuilder::SourceType::kObject, object_, xodr::RoadHeader::Id("1"), *loader_,
+                            road_geometry_);
   const auto road_object = builder();
   ASSERT_NE(road_object, nullptr);
 
@@ -475,6 +492,60 @@ TEST_F(RoadObjectBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
 
   EXPECT_NEAR(road_surface_z + object_.z_offset, road_object_z, 1e-6);
   EXPECT_GT(std::abs(road_object_z - object_.z_offset), 1.0);
+}
+
+class RoadObjectBuilderSignalTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("RoadWithAllDeviceTypes.xodr", kMalidriveResourceFolder);
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+
+    const auto* manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+    const auto road_headers = manager->GetRoadHeaders();
+    const auto road_header_it = road_headers.find(xodr::RoadHeader::Id("1"));
+    ASSERT_NE(road_header_it, road_headers.end());
+    ASSERT_TRUE(road_header_it->second.signals.has_value());
+    signals_ = road_header_it->second.signals->signals;
+    loader_ = std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(kSignalRoadObjectDb);
+  }
+
+  const xodr::signal::Signal& FindSignal(const std::string& id) const {
+    for (const auto& signal : signals_) {
+      if (signal.id.string() == id) return signal;
+    }
+    MALIPUT_THROW_MESSAGE("Signal " + id + " not found");
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  std::vector<xodr::signal::Signal> signals_;
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+};
+
+TEST_F(RoadObjectBuilderSignalTest, BuildRoadObjectFromSignal) {
+  const auto& signal = FindSignal("TL1");
+  RoadObjectBuilder builder(RoadObjectBuilder::SourceType::kSignal, signal, xodr::RoadHeader::Id("1"), *loader_,
+                            road_geometry_);
+  auto road_object = builder();
+  ASSERT_NE(road_object, nullptr);
+
+  EXPECT_EQ(road_object->id(), maliput::api::objects::RoadObject::Id("TL1"));
+  EXPECT_EQ(road_object->type(), maliput::api::objects::RoadObjectType::kBarrier);
+  EXPECT_TRUE(road_object->is_dynamic());
+  EXPECT_TRUE(road_object->is_movable());
+  EXPECT_EQ(road_object->num_outlines(), 0);
+  EXPECT_EQ(road_object->related_lanes().size(), 1u);
+  EXPECT_NEAR(road_object->bounding_box().box_size().x(), 1.0, 1e-6);
+  EXPECT_NEAR(road_object->bounding_box().box_size().y(), 0.5, 1e-6);
 }
 
 TEST_F(RoadObjectBuilderTest, FindByLane) {

--- a/test/regression/builder/traffic_control_device_books_builder_test.cc
+++ b/test/regression/builder/traffic_control_device_books_builder_test.cc
@@ -57,6 +57,36 @@ namespace test {
 namespace {
 
 static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+const char kSignalRoadDevicesDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+      name: "*"
+    properties:
+      device_type: RoadObject
+      device_semantics: Barrier
+      is_position_dynamic: true
+      default_bounding_box:
+        length: 1.0
+        width: 0.5
+        height: 1.2
+odr_object_types:
+  - odr_representation:
+      type: crosswalk
+    properties:
+      device_type: RoadMarking
+      device_semantics: Crosswalk
+  - odr_representation:
+      type: barrier
+      subtype: "*"
+      name: "*"
+    properties:
+      device_type: RoadObject
+      is_position_dynamic: true
+)";
 
 std::string ReadFile(const std::string& file_path) {
   std::ifstream input(file_path);


### PR DESCRIPTION
# 🎉 New feature

Closes #502 

## Summary
* `RoadObjects` can be created from either `XODR signals` or `XODR objects`.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
