### PR TITLE
RoadMarkingBuilder accepts XODR signals as input.

### DIFF
--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -50,115 +50,213 @@
 
 static constexpr double kEpsilon{1e-10};
 
+namespace {
+
+bool is_almost_equal(double a, double b) { return std::abs(a - b) < kEpsilon; }
+
+std::optional<std::string> NormalizeSubtype(const std::string& subtype) {
+  if (subtype.empty() || subtype == "-1" || subtype == "none") {
+    return std::nullopt;
+  }
+  return subtype;
+}
+
+}  // namespace
+
 namespace malidrive {
 namespace builder {
 
-RoadMarkingBuilder::RoadMarkingBuilder(const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+RoadMarkingBuilder::RoadMarkingBuilder(SourceType source_type, const xodr::signal::Signal& signal,
+                                       const xodr::RoadHeader::Id& road_id,
                                        const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                                        const maliput::api::RoadGeometry* road_geometry)
-    : object_(object), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+    : source_type_(source_type), signal_(&signal), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+  MALIDRIVE_VALIDATE(source_type_ == SourceType::kSignal, std::invalid_argument,
+                     "RoadMarkingBuilder signal constructor requires SourceType::kSignal.");
+  MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
+}
+
+RoadMarkingBuilder::RoadMarkingBuilder(SourceType source_type, const xodr::object::Object& object,
+                                       const xodr::RoadHeader::Id& road_id,
+                                       const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
+                                       const maliput::api::RoadGeometry* road_geometry)
+    : source_type_(source_type), object_(&object), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+  MALIDRIVE_VALIDATE(source_type_ == SourceType::kObject, std::invalid_argument,
+                     "RoadMarkingBuilder object constructor requires SourceType::kObject.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
 }
 
 std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator()() const {
-  // Build the fingerprint from the XODR object attributes.
-  const std::string type_str =
-      object_.type.has_value() ? xodr::object::Object::object_type_to_str(object_.type.value()) : "";
-  const traffic_control_device::TrafficControlDeviceFingerprint fingerprint{
-      type_str,     object_.subtype,
-      std::nullopt,  // country (not used for objects)
-      std::nullopt,  // country_revision (not used for objects)
-      object_.name,
-  };
-
-  const auto definition_opt = loader_.Lookup(fingerprint);
-  if (!definition_opt.has_value()) {
-    maliput::log()->debug("RoadMarkingBuilder: no definition found for object id='", object_.id.string(), "' type='",
-                          type_str, "' subtype='", object_.subtype.value_or(""), "' name='", object_.name.value_or(""),
-                          "'. Skipping RoadMarking creation.");
-    return nullptr;
-  }
-  const auto& definition = definition_opt.value();
-
-  // Only build RoadMarking objects for objects whose database device_type is kRoadMarking.
-  if (definition.device_type != traffic_control_device::TrafficControlDeviceType::kRoadMarking) {
-    maliput::log()->debug("RoadMarkingBuilder: object id='", object_.id.string(), "' has device_type='",
-                          traffic_control_device::TrafficControlDeviceTypeToString(definition.device_type),
-                          "', expected 'RoadMarking'. Skipping RoadMarking creation.");
-    return nullptr;
-  }
-
-  const auto marking_type = MapRoadMarkingTypeString(definition.device_semantics.value_or("Other"));
-  if (marking_type == maliput::api::objects::RoadMarkingType::kUnknown) {
-    maliput::log()->debug("RoadMarkingBuilder: unrecognized device_semantics='",
-                          definition.device_semantics.value_or("Other"), "' for object id='", object_.id.string(),
-                          "'. Defaulting to RoadMarkingType::kUnknown.");
-  }
-
   const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry_);
   MALIDRIVE_VALIDATE(mali_rg != nullptr, maliput::common::assertion_error,
                      "RoadGeometry cannot be cast to malidrive::RoadGeometry.");
 
-  // --- Position ---
-  double object_s = object_.s;
-  if (std::abs(object_.s - mali_rg->GetRoadCurve(road_id_)->p1()) < kEpsilon) {
-    std::ostringstream s_str, adjusted_s_str;
-    s_str << std::fixed << std::setprecision(10) << object_.s;
-    adjusted_s_str << std::fixed << std::setprecision(10) << (object_.s - kEpsilon);
-    maliput::log()->warn("RoadMarkingBuilder: Object ", object_.id.string(), " has s coordinate ", s_str.str(),
-                         " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
-                         " to avoid potential issues with lane association and orientation.");
-    object_s -= kEpsilon;
+  switch (source_type_) {
+    case SourceType::kObject: {
+      MALIDRIVE_VALIDATE(object_ != nullptr, maliput::common::assertion_error,
+                         "RoadMarkingBuilder object source is not set.");
+      const auto& object = *object_;
+      const std::string type_str =
+          object.type.has_value() ? xodr::object::Object::object_type_to_str(object.type.value()) : "";
+      const traffic_control_device::TrafficControlDeviceFingerprint fingerprint{
+          type_str, object.subtype, std::nullopt, std::nullopt, object.name,
+      };
+
+      const auto definition_opt = loader_.Lookup(fingerprint);
+      if (!definition_opt.has_value()) {
+        maliput::log()->debug("RoadMarkingBuilder: no definition found for object id='", object.id.string(), "' type='",
+                              type_str, "' subtype='", object.subtype.value_or(""), "' name='",
+                              object.name.value_or(""), "'. Skipping RoadMarking creation.");
+        return nullptr;
+      }
+      const auto& definition = definition_opt.value();
+      if (definition.device_type != traffic_control_device::TrafficControlDeviceType::kRoadMarking) {
+        maliput::log()->debug("RoadMarkingBuilder: object id='", object.id.string(), "' has device_type='",
+                              traffic_control_device::TrafficControlDeviceTypeToString(definition.device_type),
+                              "', expected 'RoadMarking'. Skipping RoadMarking creation.");
+        return nullptr;
+      }
+
+      const auto marking_type = MapRoadMarkingTypeString(definition.device_semantics.value_or("Other"));
+      if (marking_type == maliput::api::objects::RoadMarkingType::kUnknown) {
+        maliput::log()->debug("RoadMarkingBuilder: unrecognized device_semantics='",
+                              definition.device_semantics.value_or("Other"), "' for object id='", object.id.string(),
+                              "'. Defaulting to RoadMarkingType::kUnknown.");
+      }
+
+      double object_s = object.s;
+      if (is_almost_equal(object.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
+        std::ostringstream s_str, adjusted_s_str;
+        s_str << std::fixed << std::setprecision(10) << object.s;
+        adjusted_s_str << std::fixed << std::setprecision(10) << (object.s - kEpsilon);
+        maliput::log()->warn("RoadMarkingBuilder: Object ", object.id.string(), " has s coordinate ", s_str.str(),
+                             " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
+                             " to avoid potential issues with lane association and orientation.");
+        object_s -= kEpsilon;
+      }
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object_s,
+                                                                                object.t};
+      const maliput::api::RoadPosition rp =
+          mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
+      maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
+      inertial_pos.set_z(inertial_pos.z() + object.z_offset);
+
+      const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
+      const bool perp_to_road = object.perp_to_road.value_or(false);
+      const maliput::math::RollPitchYaw road_orientation =
+          mali_rg->GetRoadOrientationAtOpenScenarioRoadPosition(osc_road_position);
+      const double hdg = object.hdg.value_or(0.);
+      const double pitch = perp_to_road ? 0. : object.pitch.value_or(0.);
+      const double roll = perp_to_road ? 0. : object.roll.value_or(0.);
+      const double orientation_offset =
+          (object.orientation.has_value() && object.orientation.value() == xodr::object::Orientation::kNegative) ? M_PI
+                                                                                                                 : 0.;
+      const maliput::api::Rotation orientation =
+          maliput::api::Rotation::FromRpy(road_orientation.roll_angle() + roll, road_orientation.pitch_angle() + pitch,
+                                          road_orientation.yaw_angle() + hdg + orientation_offset);
+
+      const auto default_bounding_box =
+          definition.default_bounding_box.value_or(traffic_control_device::BoundingBoxDimensions{});
+      double bb_length = object.length.value_or(default_bounding_box.length);
+      double bb_width = object.width.value_or(default_bounding_box.width);
+      const double bb_height = object.height.value_or(default_bounding_box.height);
+      if (object.radius.has_value()) {
+        bb_length = 2.0 * object.radius.value();
+        bb_width = 2.0 * object.radius.value();
+      }
+      const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
+                                                    maliput::math::Vector3(bb_length, bb_width, bb_height),
+                                                    maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
+
+      auto related_lanes = ResolveLaneIds(road_id_, object_s, object.validities, road_geometry_);
+      auto outlines = BuildOutlines(object, road_id_, road_geometry_, inertial_pos, orientation);
+
+      maliput::log()->debug("RoadMarkingBuilder: creating RoadMarking id='", object.id.string(),
+                            "' type=", static_cast<int>(marking_type), " position=(", inertial_pos.x(), ", ",
+                            inertial_pos.y(), ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
+
+      return std::make_unique<maliput::api::objects::RoadMarking>(
+          maliput::api::objects::RoadMarking::Id(object.id.string()), marking_type, position, orientation, bounding_box,
+          std::move(related_lanes), object.name, std::move(outlines));
+    }
+    case SourceType::kSignal: {
+      MALIDRIVE_VALIDATE(signal_ != nullptr, maliput::common::assertion_error,
+                         "RoadMarkingBuilder signal source is not set.");
+      const auto& signal = *signal_;
+      const traffic_control_device::TrafficControlDeviceFingerprint fingerprint{
+          signal.type, NormalizeSubtype(signal.subtype), signal.country, signal.country_revision, signal.name,
+      };
+
+      const auto definition_opt = loader_.Lookup(fingerprint);
+      if (!definition_opt.has_value()) {
+        maliput::log()->debug("RoadMarkingBuilder: no definition found for signal id='", signal.id.string(), "' type='",
+                              signal.type, "' subtype='", signal.subtype, "' name='", signal.name.value_or(""),
+                              "'. Skipping RoadMarking creation.");
+        return nullptr;
+      }
+      const auto& definition = definition_opt.value();
+      if (definition.device_type != traffic_control_device::TrafficControlDeviceType::kRoadMarking) {
+        maliput::log()->debug("RoadMarkingBuilder: signal id='", signal.id.string(), "' has device_type='",
+                              traffic_control_device::TrafficControlDeviceTypeToString(definition.device_type),
+                              "', expected 'RoadMarking'. Skipping RoadMarking creation.");
+        return nullptr;
+      }
+
+      const auto marking_type = MapRoadMarkingTypeString(definition.device_semantics.value_or("Other"));
+      if (marking_type == maliput::api::objects::RoadMarkingType::kUnknown) {
+        maliput::log()->debug("RoadMarkingBuilder: unrecognized device_semantics='",
+                              definition.device_semantics.value_or("Other"), "' for signal id='", signal.id.string(),
+                              "'. Defaulting to RoadMarkingType::kUnknown.");
+      }
+
+      double signal_s = signal.s;
+      if (is_almost_equal(signal.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
+        std::ostringstream s_str, adjusted_s_str;
+        s_str << std::fixed << std::setprecision(10) << signal.s;
+        adjusted_s_str << std::fixed << std::setprecision(10) << (signal.s - kEpsilon);
+        maliput::log()->warn("RoadMarkingBuilder: Signal ", signal.id.string(), " has s coordinate ", s_str.str(),
+                             " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
+                             " to avoid potential issues with lane association and orientation.");
+        signal_s -= kEpsilon;
+      }
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal_s,
+                                                                                signal.t};
+      const maliput::api::RoadPosition rp =
+          mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
+      maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
+      inertial_pos.set_z(inertial_pos.z() + signal.z_offset);
+
+      const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
+      const maliput::math::RollPitchYaw road_orientation =
+          mali_rg->GetRoadOrientationAtOpenScenarioRoadPosition(osc_road_position);
+      const double orientation_offset = signal.orientation == xodr::signal::Orientation::kAgainstS ? 0. : M_PI;
+      const maliput::api::Rotation orientation = maliput::api::Rotation::FromRpy(
+          road_orientation.roll_angle() + signal.roll.value_or(0.),
+          road_orientation.pitch_angle() + signal.pitch.value_or(0.),
+          road_orientation.yaw_angle() + signal.h_offset.value_or(0.) + orientation_offset);
+
+      const auto default_bounding_box =
+          definition.default_bounding_box.value_or(traffic_control_device::BoundingBoxDimensions{});
+      const double bb_length = signal.length.value_or(default_bounding_box.length);
+      const double bb_width = signal.width.value_or(default_bounding_box.width);
+      const double bb_height = signal.height.value_or(default_bounding_box.height);
+      const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
+                                                    maliput::math::Vector3(bb_length, bb_width, bb_height),
+                                                    maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
+
+      auto related_lanes = ResolveLaneIds(road_id_, signal_s, signal.validities, road_geometry_);
+
+      maliput::log()->debug("RoadMarkingBuilder: creating RoadMarking id='", signal.id.string(),
+                            "' type=", static_cast<int>(marking_type), " position=(", inertial_pos.x(), ", ",
+                            inertial_pos.y(), ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
+
+      return std::make_unique<maliput::api::objects::RoadMarking>(
+          maliput::api::objects::RoadMarking::Id(signal.id.string()), marking_type, position, orientation, bounding_box,
+          std::move(related_lanes), signal.name, std::vector<std::unique_ptr<maliput::api::objects::Outline>>{});
+    }
   }
-  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object_s,
-                                                                            object_.t};
-  const maliput::api::RoadPosition rp = mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
-  maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
-  inertial_pos.set_z(inertial_pos.z() + object_.z_offset);
 
-  const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
-
-  // --- Orientation ---
-  const bool perp_to_road = object_.perp_to_road.value_or(false);
-  const maliput::math::RollPitchYaw road_orientation =
-      mali_rg->GetRoadOrientationAtOpenScenarioRoadPosition(osc_road_position);
-  const double hdg = object_.hdg.value_or(0.);
-  const double pitch = perp_to_road ? 0. : object_.pitch.value_or(0.);
-  const double roll = perp_to_road ? 0. : object_.roll.value_or(0.);
-  const double orientation_offset =
-      (object_.orientation.has_value() && object_.orientation.value() == xodr::object::Orientation::kNegative) ? M_PI
-                                                                                                               : 0.;
-  const maliput::api::Rotation orientation =
-      maliput::api::Rotation::FromRpy(road_orientation.roll_angle() + roll, road_orientation.pitch_angle() + pitch,
-                                      road_orientation.yaw_angle() + hdg + orientation_offset);
-
-  malidrive::traffic_control_device::BoundingBoxDimensions bounding_box_dimensions{};
-  // --- Bounding box ---
-  double bb_length = object_.length.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).length);
-  double bb_width = object_.width.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).width);
-  const double bb_height =
-      object_.height.value_or(definition.default_bounding_box.value_or(bounding_box_dimensions).height);
-  if (object_.radius.has_value()) {
-    bb_length = 2.0 * object_.radius.value();
-    bb_width = 2.0 * object_.radius.value();
-  }
-  const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
-                                                maliput::math::Vector3(bb_length, bb_width, bb_height),
-                                                maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
-
-  // --- Related lanes ---
-  auto related_lanes = ResolveLaneIds(road_id_, object_s, object_.validities, road_geometry_);
-
-  // --- Outlines ---
-  auto outlines = BuildOutlines(object_, road_id_, road_geometry_, inertial_pos, orientation);
-
-  maliput::log()->debug("RoadMarkingBuilder: creating RoadMarking id='", object_.id.string(),
-                        "' type=", static_cast<int>(marking_type), " position=(", inertial_pos.x(), ", ",
-                        inertial_pos.y(), ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
-
-  return std::make_unique<maliput::api::objects::RoadMarking>(
-      maliput::api::objects::RoadMarking::Id(object_.id.string()), marking_type, position, orientation, bounding_box,
-      std::move(related_lanes), object_.name, std::move(outlines));
+  MALIDRIVE_THROW_MESSAGE("RoadMarkingBuilder received an unsupported source type.", maliput::common::assertion_error);
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/road_marking_builder.h
+++ b/src/maliput_malidrive/builder/road_marking_builder.h
@@ -36,31 +36,54 @@
 #include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
 #include "maliput_malidrive/xodr/object/object.h"
 #include "maliput_malidrive/xodr/road_header.h"
+#include "maliput_malidrive/xodr/signal/signal.h"
 
 namespace malidrive {
 namespace builder {
 
-/// Builds a single @ref maliput::api::objects::RoadMarking from an XODR
-/// @ref xodr::object::Object and its matching definition in the traffic
-/// control device YAML database.
+/// Builds a single @ref maliput::api::objects::RoadMarking from either an XODR
+/// @ref xodr::object::Object or an XODR @ref xodr::signal::Signal together
+/// with its matching definition in the traffic control device YAML database.
 ///
 /// The builder follows the functor pattern: construct it with all required
 /// inputs and call @ref operator()() to produce the result.
 ///
+/// The source type must be selected explicitly at construction time, and only
+/// the matching source payload is accepted.
+///
 /// When no matching @ref traffic_control_device::TrafficControlDeviceDefinition is found in
-/// the loader for the given object's type/subtype/name fingerprint, or the device_type is not
+/// the loader for the selected source fingerprint, or the device_type is not
 /// @ref traffic_control_device::TrafficControlDeviceType::kRoadMarking, the builder returns nullptr.
 class RoadMarkingBuilder {
  public:
+  enum class SourceType {
+    kObject,
+    kSignal,
+  };
+
   /// Constructs a RoadMarkingBuilder.
   ///
+  /// @param source_type The XODR element type this builder will read from.
   /// @param object The XODR object to build a @ref maliput::api::objects::RoadMarking from.
   /// @param road_id The XODR road's ID the @p object belongs to.
   /// @param loader The @ref traffic_control_device::TrafficControlDeviceDatabaseLoader providing access
   ///        to the traffic control device YAML database.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
-  /// @throws std::invalid_argument if @p road_geometry is nullptr.
-  RoadMarkingBuilder(const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+  /// @throws std::invalid_argument if @p source_type is not kObject or @p road_geometry is nullptr.
+  RoadMarkingBuilder(SourceType source_type, const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
+                     const maliput::api::RoadGeometry* road_geometry);
+
+  /// Constructs a RoadMarkingBuilder.
+  ///
+  /// @param source_type The XODR element type this builder will read from.
+  /// @param signal The XODR signal to build a @ref maliput::api::objects::RoadMarking from.
+  /// @param road_id The XODR road's ID the @p object belongs to.
+  /// @param loader The @ref traffic_control_device::TrafficControlDeviceDatabaseLoader providing access
+  ///        to the traffic control device YAML database.
+  /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
+  /// @throws std::invalid_argument if @p source_type is not kSignal or @p road_geometry is nullptr.
+  RoadMarkingBuilder(SourceType source_type, const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                      const maliput::api::RoadGeometry* road_geometry);
 
@@ -71,7 +94,9 @@ class RoadMarkingBuilder {
   std::unique_ptr<maliput::api::objects::RoadMarking> operator()() const;
 
  private:
-  const xodr::object::Object& object_;
+  SourceType source_type_;
+  const xodr::object::Object* object_{nullptr};
+  const xodr::signal::Signal* signal_{nullptr};
   const xodr::RoadHeader::Id& road_id_;
   const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader_;
   const maliput::api::RoadGeometry* road_geometry_;

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -145,6 +145,12 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }
+      } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadMarking) {
+        auto rm =
+            RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kSignal, signal, road_id, loader, road_geometry_)();
+        if (rm) {
+          rmb->AddRoadMarking(std::move(rm));
+        }
       } else {
         maliput::log()->debug("TrafficControlDeviceBooksBuilder: signal id='", signal.id.string(),
                               "' has device_type='",
@@ -191,14 +197,10 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
       const auto& definition = definition_opt.value();
 
       if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadMarking) {
-        try {
-          auto rm = RoadMarkingBuilder(object, road_id, loader, road_geometry_)();
-          if (rm) {
-            rmb->AddRoadMarking(std::move(rm));
-          }
-        } catch (const std::exception& e) {
-          maliput::log()->warn("TrafficControlDeviceBooksBuilder: failed to build RoadMarking from object id='",
-                               object.id.string(), "' on road '", road_id.string(), "': ", e.what(), ". Skipping.");
+        auto rm =
+            RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kObject, object, road_id, loader, road_geometry_)();
+        if (rm) {
+          rmb->AddRoadMarking(std::move(rm));
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
         auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_)();

--- a/test/regression/builder/road_marking_builder_test.cc
+++ b/test/regression/builder/road_marking_builder_test.cc
@@ -53,6 +53,21 @@ namespace test {
 namespace {
 
 static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+const char kSignalRoadMarkingDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "206"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      name: "*"
+    properties:
+      device_type: RoadMarking
+      device_semantics: StopLine
+      default_bounding_box:
+        length: 3.0
+        width: 0.61
+        height: 0.0
+)";
 
 // ---------------------------------------------------------------------------
 // RoadMarkingBuilder tests.
@@ -106,17 +121,19 @@ class RoadMarkingBuilderTest : public ::testing::Test {
 
 TEST_F(RoadMarkingBuilderTest, Constructor) {
   const auto& object = FindObject("rm_stop_line");
-  EXPECT_NO_THROW(RoadMarkingBuilder(object, road_id_, *loader_, road_geometry_));
+  EXPECT_NO_THROW(
+      RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kObject, object, road_id_, *loader_, road_geometry_));
 }
 
 TEST_F(RoadMarkingBuilderTest, ConstructorThrowsOnNullptrRoadGeometry) {
   const auto& object = FindObject("rm_stop_line");
-  EXPECT_THROW(RoadMarkingBuilder(object, road_id_, *loader_, nullptr), std::invalid_argument);
+  EXPECT_THROW(RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kObject, object, road_id_, *loader_, nullptr),
+               std::invalid_argument);
 }
 
 TEST_F(RoadMarkingBuilderTest, BuildStopLine) {
   const auto& object = FindObject("rm_stop_line");
-  RoadMarkingBuilder builder(object, road_id_, *loader_, road_geometry_);
+  RoadMarkingBuilder builder(RoadMarkingBuilder::SourceType::kObject, object, road_id_, *loader_, road_geometry_);
   auto road_marking = builder();
   ASSERT_NE(road_marking, nullptr);
 
@@ -141,7 +158,7 @@ TEST_F(RoadMarkingBuilderTest, BuildStopLine) {
 
 TEST_F(RoadMarkingBuilderTest, BuildCrosswalk) {
   const auto& object = FindObject("rm_crosswalk");
-  RoadMarkingBuilder builder(object, road_id_, *loader_, road_geometry_);
+  RoadMarkingBuilder builder(RoadMarkingBuilder::SourceType::kObject, object, road_id_, *loader_, road_geometry_);
   auto road_marking = builder();
   ASSERT_NE(road_marking, nullptr);
 
@@ -155,7 +172,7 @@ TEST_F(RoadMarkingBuilderTest, BuildCrosswalk) {
 
 TEST_F(RoadMarkingBuilderTest, BuildArrowForward) {
   const auto& object = FindObject("rm_arrow");
-  RoadMarkingBuilder builder(object, road_id_, *loader_, road_geometry_);
+  RoadMarkingBuilder builder(RoadMarkingBuilder::SourceType::kObject, object, road_id_, *loader_, road_geometry_);
   auto road_marking = builder();
   ASSERT_NE(road_marking, nullptr);
 
@@ -173,7 +190,7 @@ TEST_F(RoadMarkingBuilderTest, BuildArrowForward) {
 TEST_F(RoadMarkingBuilderTest, ReturnsNullptrForNonRoadMarkingDeviceType) {
   // The pole object maps to device_type: road_object, so should return nullptr.
   const auto& object = FindObject("rm_pole");
-  RoadMarkingBuilder builder(object, road_id_, *loader_, road_geometry_);
+  RoadMarkingBuilder builder(RoadMarkingBuilder::SourceType::kObject, object, road_id_, *loader_, road_geometry_);
   auto road_marking = builder();
   EXPECT_EQ(road_marking, nullptr);
 }
@@ -187,7 +204,7 @@ TEST_F(RoadMarkingBuilderTest, ReturnsNullptrForNoMatchingDefinition) {
   fake_object.z_offset = 0.0;
   fake_object.type = xodr::object::Object::str_to_object_type("building");
 
-  RoadMarkingBuilder builder(fake_object, road_id_, *loader_, road_geometry_);
+  RoadMarkingBuilder builder(RoadMarkingBuilder::SourceType::kObject, fake_object, road_id_, *loader_, road_geometry_);
   auto road_marking = builder();
   EXPECT_EQ(road_marking, nullptr);
 }
@@ -239,7 +256,7 @@ class RoadMarkingBuilderElevatedRoadTest : public ::testing::Test {
 };
 
 TEST_F(RoadMarkingBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
-  RoadMarkingBuilder builder(object_, road_id_, *loader_, road_geometry_);
+  RoadMarkingBuilder builder(RoadMarkingBuilder::SourceType::kObject, object_, road_id_, *loader_, road_geometry_);
   const auto road_marking = builder();
   ASSERT_NE(road_marking, nullptr);
 
@@ -251,6 +268,59 @@ TEST_F(RoadMarkingBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
 
   EXPECT_NEAR(road_surface_z + object_.z_offset, road_marking_z, 1e-6);
   EXPECT_GT(std::abs(road_marking_z - object_.z_offset), 1.0);
+}
+
+class RoadMarkingBuilderSignalTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("RoadWithAllDeviceTypes.xodr", kMalidriveResourceFolder);
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+
+    const auto* manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+    const auto road_headers = manager->GetRoadHeaders();
+    const auto road_header_it = road_headers.find(xodr::RoadHeader::Id("1"));
+    ASSERT_NE(road_header_it, road_headers.end());
+    ASSERT_TRUE(road_header_it->second.signals.has_value());
+    signals_ = road_header_it->second.signals->signals;
+    loader_ = std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(kSignalRoadMarkingDb);
+  }
+
+  const xodr::signal::Signal& FindSignal(const std::string& id) const {
+    for (const auto& signal : signals_) {
+      if (signal.id.string() == id) return signal;
+    }
+    MALIPUT_THROW_MESSAGE("Signal " + id + " not found");
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  std::vector<xodr::signal::Signal> signals_;
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+};
+
+TEST_F(RoadMarkingBuilderSignalTest, BuildRoadMarkingFromSignal) {
+  const auto& signal = FindSignal("TS1");
+  RoadMarkingBuilder builder(RoadMarkingBuilder::SourceType::kSignal, signal, xodr::RoadHeader::Id("1"), *loader_,
+                             road_geometry_);
+  auto road_marking = builder();
+  ASSERT_NE(road_marking, nullptr);
+
+  EXPECT_EQ(road_marking->id(), maliput::api::objects::RoadMarking::Id("TS1"));
+  EXPECT_EQ(road_marking->type(), maliput::api::objects::RoadMarkingType::kStopLine);
+  EXPECT_EQ(road_marking->name(), "StopSign1");
+  EXPECT_EQ(road_marking->num_outlines(), 0);
+  EXPECT_EQ(road_marking->related_lanes().size(), 1u);
+  EXPECT_NEAR(road_marking->bounding_box().box_size().x(), 3.0, 1e-6);
+  EXPECT_NEAR(road_marking->bounding_box().box_size().y(), 0.61, 1e-6);
 }
 
 }  // namespace

--- a/test/regression/builder/traffic_control_device_books_builder_test.cc
+++ b/test/regression/builder/traffic_control_device_books_builder_test.cc
@@ -73,6 +73,19 @@ odr_signal_types:
         length: 1.0
         width: 0.5
         height: 1.2
+  - odr_representation:
+      type: "206"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      country_revision: null
+      name: "*"
+    properties:
+      device_type: RoadMarking
+      device_semantics: StopLine
+      default_bounding_box:
+        length: 3.0
+        width: 0.61
+        height: 0.0
 odr_object_types:
   - odr_representation:
       type: crosswalk
@@ -261,6 +274,33 @@ TEST_F(TrafficControlDeviceBooksBuilderTest, UnmatchedObjectIsPlacedInRoadObject
 
   const auto* rmb = road_network_->road_marking_book();
   EXPECT_EQ(nullptr, rmb->GetRoadMarking(maliput::api::objects::RoadMarking::Id("UNMATCHED1")));
+}
+
+TEST_F(TrafficControlDeviceBooksBuilderTest, SignalDerivedRoadDevicesAreRoutedToBooks) {
+  const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+      {params::kOpendriveFile, xodr_file_path_},
+      {params::kTrafficControlDeviceDb, kSignalRoadDevicesDb},
+      {params::kOmitNonDrivableLanes, "false"},
+  })};
+  const auto road_network = RoadNetworkBuilder(rn_config.ToStringMap())();
+  ASSERT_NE(road_network, nullptr);
+
+  EXPECT_TRUE(road_network->traffic_light_book()->TrafficLights().empty());
+  EXPECT_TRUE(road_network->traffic_sign_book()->TrafficSigns().empty());
+
+  const auto* rmb = road_network->road_marking_book();
+  ASSERT_NE(rmb, nullptr);
+  EXPECT_NE(nullptr, rmb->GetRoadMarking(maliput::api::objects::RoadMarking::Id("RM1")));
+  const auto* signal_road_marking = rmb->GetRoadMarking(maliput::api::objects::RoadMarking::Id("TS1"));
+  ASSERT_NE(signal_road_marking, nullptr);
+  EXPECT_EQ(signal_road_marking->type(), maliput::api::objects::RoadMarkingType::kStopLine);
+
+  const auto* rob = road_network->road_object_book();
+  ASSERT_NE(rob, nullptr);
+  EXPECT_NE(nullptr, rob->GetRoadObject(maliput::api::objects::RoadObject::Id("RO1")));
+  const auto* signal_road_object = rob->GetRoadObject(maliput::api::objects::RoadObject::Id("TL1"));
+  ASSERT_NE(signal_road_object, nullptr);
+  EXPECT_EQ(signal_road_object->type(), maliput::api::objects::RoadObjectType::kBarrier);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# 🎉 New feature

Closes #501 

## Summary

* `RoadMarking` can be created from either `XODR signals` or `XODR objects`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
