### PR TITLE
Align bounding box's bottom-center with device's s-t-z_offset position.

### DIFF
--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -164,7 +164,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
         bb_length = 2.0 * object.radius.value();
         bb_width = 2.0 * object.radius.value();
       }
-      const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
+      const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., bb_height / 2.),
                                                     maliput::math::Vector3(bb_length, bb_width, bb_height),
                                                     maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -179,7 +179,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
         bb_length = 2.0 * object.radius.value();
         bb_width = 2.0 * object.radius.value();
       }
-      const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
+      const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., bb_height / 2.),
                                                     maliput::math::Vector3(bb_length, bb_width, bb_height),
                                                     maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -147,7 +147,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   const double depth = signal_.length.value_or(0.);
   const double width = signal_.width.value_or(0.);
   const double height = signal_.height.value_or(0.);
-  const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., 0.),
+  const maliput::math::BoundingBox bounding_box{maliput::math::Vector3(0., 0., height / 2.),
                                                 maliput::math::Vector3(depth, width, height),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 


### PR DESCRIPTION
# 🎉 New feature

Closes #461 

## Summary
Align bounding box's bottom-center with device's s-t-z_offset position.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
