### PR TITLE
Implement Junction::is_intersection API 

### DIFF
--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -203,6 +203,15 @@ static constexpr char const* kIntegratorAccuracyMultiplier{"integrator_accuracy_
 ///   - Default: @e "false"
 static constexpr char const* kUseUserDataTrafficDirection{"use_userdata_traffic_direction"};
 
+/// True for supporting userData XODR nodes within Junction XODR nodes. If false, they will be ignored.
+/// userData are used for intersection classification based on OpenDRIVE data.
+/// When enabled, junction userData parsing and intersection detection logic are applied.
+///   - Options:
+///     - 1. <em> "true", "True", "TRUE", "on", "On", "ON" </em>
+///     - 2. <em> "false", "False",  "FALSE", "off", "Off", "OFF" </em>
+///   - Default: @e "false"
+static constexpr char const* kUseUserDataIntersections{"use_userdata_intersections"};
+
 /// @}
 
 }  // namespace params

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <set>
 
 #include <maliput/api/lane.h>
 #include <maliput/api/objects/road_object.h>
@@ -235,6 +236,99 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsWithinJunction(
                             maliput::common::road_geometry_construction_error);
   }
   return SolveLaneEndsForConnectingRoad(rg, xodr_lane_properties, road_headers, connection_type);
+}
+
+std::optional<bool> DetermineJunctionIntersectionFromXodr(
+    const xodr::Junction& junction, const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers) {
+  struct IntersectionOverrideResult {
+    std::optional<bool> value{std::nullopt};
+    bool has_conflict{false};
+  };
+  // Returns true if the junction is an intersection, false if it is not, and nullopt if it cannot be determined.
+  // Also checks if the junction has conflicting userData that cannot be resolved.
+  auto parse_intersection_override = [](const std::vector<std::string>& user_data) -> IntersectionOverrideResult {
+    if (user_data.empty()) {
+      return {};
+    }
+    bool has_intersection{false};
+    bool has_non_intersection{false};
+    for (const auto& user_data_element_xml : user_data) {
+      tinyxml2::XMLDocument xml_document;
+      if (xml_document.Parse(user_data_element_xml.c_str()) != tinyxml2::XML_SUCCESS) {
+        maliput::log()->debug("Unable to parse junction userData for intersection override.");
+        continue;
+      }
+      tinyxml2::XMLElement* root = xml_document.FirstChildElement();
+      if (root == nullptr) {
+        continue;
+      }
+      std::vector<tinyxml2::XMLElement*> nodes{root};
+      while (!nodes.empty()) {
+        tinyxml2::XMLElement* node = nodes.back();
+        nodes.pop_back();
+        const char* code = node->Attribute("code");
+        if (code != nullptr && std::string(code) == "junctionType") {
+          const char* value = node->Attribute("value");
+          if (value != nullptr) {
+            const std::string junction_type_value(value);
+            if (junction_type_value == "intersection") {
+              has_intersection = true;
+            } else if (junction_type_value == "nonIntersection") {
+              has_non_intersection = true;
+            }
+          }
+        }
+        for (tinyxml2::XMLElement* child = node->FirstChildElement(); child != nullptr;
+             child = child->NextSiblingElement()) {
+          nodes.push_back(child);
+        }
+      }
+    }
+    if (has_intersection && has_non_intersection) {
+      maliput::log()->warn("Junction userData contains conflicting junctionType overrides.");
+      return {std::nullopt, true};
+    }
+    if (has_intersection) {
+      return {true, false};
+    }
+    if (has_non_intersection) {
+      return {false, false};
+    }
+    return {};
+  };
+
+  auto has_any_motorway_participating_road = [&road_headers](const xodr::Junction& xodr_junction) -> bool {
+    std::set<std::string> participating_road_ids{};
+    for (const auto& connection : xodr_junction.connections) {
+      participating_road_ids.insert(connection.second.incoming_road);
+      participating_road_ids.insert(connection.second.connecting_road);
+    }
+    for (const std::string& road_id : participating_road_ids) {
+      const auto road_header_it = road_headers.find(xodr::RoadHeader::Id(road_id));
+      if (road_header_it == road_headers.end()) {
+        continue;
+      }
+      const auto& road_types = road_header_it->second.road_types;
+      if (std::any_of(road_types.begin(), road_types.end(), [](const xodr::RoadType& road_type) {
+            return road_type.type == xodr::RoadType::Type::kMotorway;
+          })) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const auto user_data_override = parse_intersection_override(junction.user_data);
+  if (user_data_override.has_conflict) {
+    return std::nullopt;
+  }
+  if (user_data_override.value.has_value()) {
+    return user_data_override.value.value();
+  }
+  if (has_any_motorway_participating_road(junction)) {
+    return false;
+  }
+  return junction.connections.size() > 4;
 }
 
 std::vector<maliput::api::LaneEnd> SolveLaneEndsForInnerLaneSection(

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -244,8 +244,9 @@ std::optional<bool> DetermineJunctionIntersectionFromXodr(
     std::optional<bool> value{std::nullopt};
     bool has_conflict{false};
   };
-  // Returns true if the junction is an intersection, false if it is not, and nullopt if it cannot be determined.
-  // Also checks if the junction has conflicting userData that cannot be resolved.
+  // Returns true if the junction has a userData with code "junctionType" and value "intersection", false if the value
+  // is "nonIntersection", and nullopt if it cannot be determined. Also checks if the junction has conflicting userData
+  // that cannot be resolved.
   auto parse_intersection_override = [](const std::vector<std::string>& user_data) -> IntersectionOverrideResult {
     if (user_data.empty()) {
       return {};
@@ -272,8 +273,16 @@ std::optional<bool> DetermineJunctionIntersectionFromXodr(
           if (value != nullptr) {
             const std::string junction_type_value(value);
             if (junction_type_value == "intersection") {
+              if (has_non_intersection) {
+                maliput::log()->warn("Junction userData contains conflicting junctionType overrides.");
+                return {std::nullopt, true};
+              }
               has_intersection = true;
             } else if (junction_type_value == "nonIntersection") {
+              if (has_intersection) {
+                maliput::log()->warn("Junction userData contains conflicting junctionType overrides.");
+                return {std::nullopt, true};
+              }
               has_non_intersection = true;
             }
           }
@@ -283,10 +292,6 @@ std::optional<bool> DetermineJunctionIntersectionFromXodr(
           nodes.push_back(child);
         }
       }
-    }
-    if (has_intersection && has_non_intersection) {
-      maliput::log()->warn("Junction userData contains conflicting junctionType overrides.");
-      return {std::nullopt, true};
     }
     if (has_intersection) {
       return {true, false};

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -152,7 +152,10 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsWithinJunction(
 ///
 /// @param junction Junction data from the XODR map.
 /// @param road_headers Road headers from the XODR map.
-/// @returns Intersection classification according to the priority rules.
+/// @returns `true` when the junction is classified as intersection;
+///          `false` when it is classified as non-intersection;
+///          `std::nullopt` when no classification can be determined from
+///          available XODR data.
 std::optional<bool> DetermineJunctionIntersectionFromXodr(
     const xodr::Junction& junction, const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers);
 

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -142,6 +142,20 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsWithinJunction(
     const maliput::api::RoadGeometry* rg, const MalidriveXodrLaneProperties& xodr_lane_properties,
     const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers, XodrConnectionType connection_type);
 
+/// Determines whether a Junction should be classified as intersection using
+/// OpenDRIVE-derived data and first-match-wins priority:
+/// 1. junction userData override (`code="junctionType"` with value
+///    `intersection` / `nonIntersection`).
+/// 2. motorway road type participation (if any participating road is motorway,
+///    classify as non-intersection).
+/// 3. connection-count fallback (`connections.size() > 4`).
+///
+/// @param junction Junction data from the XODR map.
+/// @param road_headers Road headers from the XODR map.
+/// @returns Intersection classification according to the priority rules.
+std::optional<bool> DetermineJunctionIntersectionFromXodr(
+    const xodr::Junction& junction, const std::map<xodr::RoadHeader::Id, xodr::RoadHeader>& road_headers);
+
 /// Searches which LaneEnds connect to `lane_end` considering it
 /// belongs to an inner interface.
 ///

--- a/src/maliput_malidrive/builder/road_geometry_builder.cc
+++ b/src/maliput_malidrive/builder/road_geometry_builder.cc
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/builder/road_geometry_builder.h"
 
+#include <algorithm>
 #include <array>
 #include <future>
 #include <iterator>
@@ -814,14 +815,25 @@ std::unique_ptr<maliput::geometry_base::Junction> RoadGeometryBuilder::BuildJunc
   const int xodr_track = std::stoi(xodr_track_id);
   MALIDRIVE_THROW_UNLESS(xodr_track >= 0, maliput::common::road_geometry_construction_error);
   MALIDRIVE_THROW_UNLESS(lane_section_index >= 0, maliput::common::road_geometry_construction_error);
-  return std::make_unique<maliput::geometry_base::Junction>(GetJunctionId(xodr_track, lane_section_index));
+  const std::optional<bool> is_intersection =
+      rg_config_.use_userdata_intersections ? std::make_optional(false) : std::nullopt;
+  return std::make_unique<maliput::geometry_base::Junction>(GetJunctionId(xodr_track, lane_section_index),
+                                                            is_intersection);
 }
 
 std::unique_ptr<maliput::geometry_base::Junction> RoadGeometryBuilder::BuildJunction(
     const std::string& xodr_junction_id) {
   const int xodr_junction = std::stoi(xodr_junction_id);
   MALIDRIVE_THROW_UNLESS(xodr_junction >= 0, maliput::common::road_geometry_construction_error);
-  return std::make_unique<maliput::geometry_base::Junction>(GetJunctionId(xodr_junction));
+  std::optional<bool> is_intersection = std::nullopt;
+  if (rg_config_.use_userdata_intersections) {
+    maliput::log()->debug("Determining if junction id ", xodr_junction_id, " is an intersection.");
+    const auto junction_it = manager_->GetJunctions().find(xodr::Junction::Id(xodr_junction_id));
+    MALIDRIVE_THROW_UNLESS(junction_it != manager_->GetJunctions().end(),
+                           maliput::common::road_geometry_construction_error);
+    is_intersection = DetermineJunctionIntersectionFromXodr(junction_it->second, manager_->GetRoadHeaders());
+  }
+  return std::make_unique<maliput::geometry_base::Junction>(GetJunctionId(xodr_junction), is_intersection);
 }
 
 std::unique_ptr<malidrive::road_curve::GroundCurve> RoadGeometryBuilder::MakeGroundCurve(

--- a/src/maliput_malidrive/builder/road_geometry_configuration.cc
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.cc
@@ -176,6 +176,10 @@ RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(
   if (it != road_geometry_configuration.end()) {
     rg_config.use_userdata_traffic_direction = ParseBoolean(it->second);
   }
+  it = road_geometry_configuration.find(params::kUseUserDataIntersections);
+  if (it != road_geometry_configuration.end()) {
+    rg_config.use_userdata_intersections = ParseBoolean(it->second);
+  }
   return rg_config;
 }
 
@@ -201,6 +205,7 @@ std::map<std::string, std::string> RoadGeometryConfiguration::ToStringMap() cons
   }
   config_map.emplace(params::kIntegratorAccuracyMultiplier, std::to_string(integrator_accuracy_multiplier));
   config_map.emplace(params::kUseUserDataTrafficDirection, use_userdata_traffic_direction ? "true" : "false");
+  config_map.emplace(params::kUseUserDataIntersections, use_userdata_intersections ? "true" : "false");
   return config_map;
 }
 

--- a/src/maliput_malidrive/builder/road_geometry_configuration.h
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.h
@@ -184,6 +184,7 @@ struct RoadGeometryConfiguration {
   bool omit_nondrivable_lanes{true};
   double integrator_accuracy_multiplier{1.0};
   bool use_userdata_traffic_direction{false};
+  bool use_userdata_intersections{false};
   /// @}
 };
 

--- a/src/maliput_malidrive/builder/xodr_parser_configuration.cc
+++ b/src/maliput_malidrive/builder/xodr_parser_configuration.cc
@@ -41,7 +41,7 @@ xodr::ParserConfiguration XodrParserConfigurationFromRoadGeometryConfiguration(
           (rg_config.standard_strictness_policy &
            RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors) ==
               RoadGeometryConfiguration::StandardStrictnessPolicy::kAllowSemanticErrors,
-          rg_config.use_userdata_traffic_direction};
+          rg_config.use_userdata_traffic_direction, rg_config.use_userdata_intersections};
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/xodr/junction.cc
+++ b/src/maliput_malidrive/xodr/junction.cc
@@ -53,13 +53,22 @@ Junction::Type Junction::str_to_type(const std::string& type) {
 std::string Junction::type_to_str(Type type) { return type_to_str_map.at(type); }
 
 bool Junction::operator==(const Junction& other) const {
-  return id == other.id && name == other.name && type == other.type && connections == other.connections;
+  return id == other.id && name == other.name && type == other.type && connections == other.connections &&
+         user_data == other.user_data;
 }
 
 std::ostream& operator<<(std::ostream& out, const Junction& junction) {
   out << "{\"id\": " << junction.id.string();
   out << ", \"name\": " << (junction.name.has_value() ? junction.name.value() : "");
   out << ", \"type\": {" << (junction.type.has_value() ? Junction::type_to_str(junction.type.value()) : "") << "}";
+  out << ", \"user_data\": [";
+  for (size_t i = 0; i < junction.user_data.size(); ++i) {
+    out << junction.user_data.at(i);
+    if (i + 1 < junction.user_data.size()) {
+      out << ", ";
+    }
+  }
+  out << "]";
   out << "}";
   // TODO(malidrive#574): Once other entities acquire serialization overloads, we should include them.
   return out;

--- a/src/maliput_malidrive/xodr/junction.h
+++ b/src/maliput_malidrive/xodr/junction.h
@@ -63,6 +63,7 @@ struct Junction {
   static constexpr const char* kId = "id";
   static constexpr const char* kName = "name";
   static constexpr const char* kType = "type";
+  static constexpr const char* kUserData = "userData";
 
   /// Enum junction types.
   enum Type { kDefault = 0, kVirtual };
@@ -91,6 +92,8 @@ struct Junction {
   std::optional<Type> type{Type::kDefault};
   /// Connections within the junction.
   std::map<Connection::Id, Connection> connections{};
+  /// Contains ancillary data in XML format. Each item holds one complete userData node.
+  std::vector<std::string> user_data{};
 };
 
 /// Streams a string representation of @p junction into @p out. Returns

--- a/src/maliput_malidrive/xodr/parser.cc
+++ b/src/maliput_malidrive/xodr/parser.cc
@@ -1685,7 +1685,15 @@ Junction NodeParser::As() const {
     connections.insert({connection.id, std::move(connection)});
     connection_element = connection_element->NextSiblingElement(Connection::kConnectionTag);
   }
-  return {Junction::Id(*id), name, type, connections};
+
+  std::vector<std::string> user_data{};
+  if (parser_configuration_.use_userdata_intersections) {
+    for (tinyxml2::XMLElement* user_data_element = element_->FirstChildElement(Junction::kUserData);
+         user_data_element != nullptr; user_data_element = user_data_element->NextSiblingElement(Junction::kUserData)) {
+      user_data.emplace_back(ConvertXMLNodeToText(user_data_element));
+    }
+  }
+  return {Junction::Id(*id), name, type, connections, user_data};
 }
 
 std::string ConvertXMLNodeToText(tinyxml2::XMLElement* element) {

--- a/src/maliput_malidrive/xodr/parser_configuration.h
+++ b/src/maliput_malidrive/xodr/parser_configuration.h
@@ -55,6 +55,9 @@ struct ParserConfiguration {
 
   /// When active, the parser will support userData XODR nodes.
   bool use_userdata_traffic_direction{false};
+
+  /// When active, the parser will support intersection-related userData XODR nodes.
+  bool use_userdata_intersections{false};
 };
 
 }  // namespace xodr

--- a/src/maliput_malidrive/xodr/parser_configuration.h
+++ b/src/maliput_malidrive/xodr/parser_configuration.h
@@ -1,6 +1,6 @@
 // BSD 3-Clause License
 //
-// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2022-2026, Woven Planet. All rights reserved.
 // Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -57,6 +57,7 @@ struct ParserConfiguration {
   bool use_userdata_traffic_direction{false};
 
   /// When active, the parser will support intersection-related userData XODR nodes.
+  /// See @ref builder::DetermineJunctionIntersectionFromXodr() for more information.
   bool use_userdata_intersections{false};
 };
 

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -1050,6 +1050,32 @@ GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, ConnectionCountFallback) {
   EXPECT_EQ(std::make_optional(true), DetermineJunctionIntersectionFromXodr(junction, road_headers));
 }
 
+GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, FewConnectionsFallbackToNonIntersection) {
+  xodr::Junction junction{};
+  junction.id = xodr::Junction::Id("13");
+  for (int i = 0; i < 4; ++i) {
+    const std::string id = std::to_string(i);
+    junction.connections.emplace(xodr::Connection::Id(id), xodr::Connection{xodr::Connection::Id(id),
+                                                                            "9",
+                                                                            "10",
+                                                                            xodr::Connection::ContactPoint::kStart,
+                                                                            std::nullopt,
+                                                                            std::nullopt,
+                                                                            {}});
+  }
+
+  xodr::RoadHeader incoming_road{};
+  incoming_road.id = xodr::RoadHeader::Id("9");
+  incoming_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+  xodr::RoadHeader connecting_road{};
+  connecting_road.id = xodr::RoadHeader::Id("10");
+  connecting_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+  const std::map<xodr::RoadHeader::Id, xodr::RoadHeader> road_headers{{incoming_road.id, incoming_road},
+                                                                      {connecting_road.id, connecting_road}};
+
+  EXPECT_EQ(std::make_optional(false), DetermineJunctionIntersectionFromXodr(junction, road_headers));
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace builder

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -30,6 +30,7 @@
 #include "maliput_malidrive/builder/builder_tools.h"
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -914,6 +915,113 @@ TEST_F(ResolveLaneIdsOmitNonDrivableTest, ExplicitValidityFilteredByBuiltLanes) 
 
   EXPECT_EQ(1u, result.size());
   EXPECT_NE(std::find(result.begin(), result.end(), maliput::api::LaneId("1_0_-1")), result.end());
+}
+
+GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, UserDataOverrideHasPriority) {
+  xodr::Junction junction{};
+  junction.id = xodr::Junction::Id("10");
+  junction.user_data = {"<userData code=\"junctionType\" value=\"intersection\"/>"};
+  junction.connections = {
+      {xodr::Connection::Id("0"),
+       {xodr::Connection::Id("0"), "1", "2", xodr::Connection::ContactPoint::kStart, std::nullopt, std::nullopt, {}}}};
+
+  xodr::RoadHeader incoming_road{};
+  incoming_road.id = xodr::RoadHeader::Id("1");
+  incoming_road.road_types = {{0., xodr::RoadType::Type::kMotorway, std::nullopt, {}}};
+  xodr::RoadHeader connecting_road{};
+  connecting_road.id = xodr::RoadHeader::Id("2");
+  connecting_road.road_types = {{0., xodr::RoadType::Type::kMotorway, std::nullopt, {}}};
+
+  const std::map<xodr::RoadHeader::Id, xodr::RoadHeader> road_headers{{incoming_road.id, incoming_road},
+                                                                      {connecting_road.id, connecting_road}};
+  EXPECT_EQ(std::make_optional(true), DetermineJunctionIntersectionFromXodr(junction, road_headers));
+}
+
+GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, SecondUserDataEntrySetsOverride) {
+  xodr::Junction junction{};
+  junction.id = xodr::Junction::Id("10b");
+  junction.user_data = {
+      "<userData code=\"vectorJunction\"><vectorJunction "
+      "junctionId=\"123\"/></userData>",
+      "<userData code=\"junctionType\" value=\"nonIntersection\"/>"};
+  junction.connections = {
+      {xodr::Connection::Id("0"),
+       {xodr::Connection::Id("0"), "1", "2", xodr::Connection::ContactPoint::kStart, std::nullopt, std::nullopt, {}}}};
+
+  xodr::RoadHeader incoming_road{};
+  incoming_road.id = xodr::RoadHeader::Id("1");
+  incoming_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+  xodr::RoadHeader connecting_road{};
+  connecting_road.id = xodr::RoadHeader::Id("2");
+  connecting_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+
+  const std::map<xodr::RoadHeader::Id, xodr::RoadHeader> road_headers{{incoming_road.id, incoming_road},
+                                                                      {connecting_road.id, connecting_road}};
+  EXPECT_EQ(std::make_optional(false), DetermineJunctionIntersectionFromXodr(junction, road_headers));
+}
+
+GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, ConflictingUserDataEntriesYieldNoOverride) {
+  xodr::Junction junction{};
+  junction.id = xodr::Junction::Id("10c");
+  junction.user_data = {"<userData code=\"junctionType\" value=\"intersection\"/>",
+                        "<userData code=\"junctionType\" value=\"nonIntersection\"/>"};
+  junction.connections = {
+      {xodr::Connection::Id("0"),
+       {xodr::Connection::Id("0"), "1", "2", xodr::Connection::ContactPoint::kStart, std::nullopt, std::nullopt, {}}}};
+
+  xodr::RoadHeader incoming_road{};
+  incoming_road.id = xodr::RoadHeader::Id("1");
+  incoming_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+  xodr::RoadHeader connecting_road{};
+  connecting_road.id = xodr::RoadHeader::Id("2");
+  connecting_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+
+  const std::map<xodr::RoadHeader::Id, xodr::RoadHeader> road_headers{{incoming_road.id, incoming_road},
+                                                                      {connecting_road.id, connecting_road}};
+  EXPECT_EQ(std::nullopt, DetermineJunctionIntersectionFromXodr(junction, road_headers));
+}
+
+GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, MotorwayRoadTypeDisablesIntersection) {
+  xodr::Junction junction{};
+  junction.id = xodr::Junction::Id("11");
+  junction.connections = {
+      {xodr::Connection::Id("0"),
+       {xodr::Connection::Id("0"), "3", "4", xodr::Connection::ContactPoint::kStart, std::nullopt, std::nullopt, {}}}};
+
+  xodr::RoadHeader motorway_road{};
+  motorway_road.id = xodr::RoadHeader::Id("3");
+  motorway_road.road_types = {{0., xodr::RoadType::Type::kMotorway, std::nullopt, {}}};
+  xodr::RoadHeader town_road{};
+  town_road.id = xodr::RoadHeader::Id("4");
+  town_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+  const std::map<xodr::RoadHeader::Id, xodr::RoadHeader> road_headers{{motorway_road.id, motorway_road},
+                                                                      {town_road.id, town_road}};
+  EXPECT_EQ(std::make_optional(false), DetermineJunctionIntersectionFromXodr(junction, road_headers));
+}
+
+GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, ConnectionCountFallback) {
+  xodr::Junction junction{};
+  junction.id = xodr::Junction::Id("12");
+  for (int i = 0; i < 5; ++i) {
+    const std::string id = std::to_string(i);
+    junction.connections.emplace(xodr::Connection::Id(id), xodr::Connection{xodr::Connection::Id(id),
+                                                                            "5",
+                                                                            "6",
+                                                                            xodr::Connection::ContactPoint::kStart,
+                                                                            std::nullopt,
+                                                                            std::nullopt,
+                                                                            {}});
+  }
+  xodr::RoadHeader incoming_road{};
+  incoming_road.id = xodr::RoadHeader::Id("5");
+  incoming_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+  xodr::RoadHeader connecting_road{};
+  connecting_road.id = xodr::RoadHeader::Id("6");
+  connecting_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+  const std::map<xodr::RoadHeader::Id, xodr::RoadHeader> road_headers{{incoming_road.id, incoming_road},
+                                                                      {connecting_road.id, connecting_road}};
+
+  EXPECT_EQ(std::make_optional(true), DetermineJunctionIntersectionFromXodr(junction, road_headers));
 }
 
 }  // namespace

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -999,6 +999,32 @@ GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, MotorwayRoadTypeDisablesIn
   EXPECT_EQ(std::make_optional(false), DetermineJunctionIntersectionFromXodr(junction, road_headers));
 }
 
+GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, MixedRoadTypesIncludingMotorwayDisableIntersection) {
+  xodr::Junction junction{};
+  junction.id = xodr::Junction::Id("11b");
+  for (int i = 0; i < 5; ++i) {
+    const std::string id = std::to_string(i);
+    junction.connections.emplace(xodr::Connection::Id(id), xodr::Connection{xodr::Connection::Id(id),
+                                                                            "7",
+                                                                            "8",
+                                                                            xodr::Connection::ContactPoint::kStart,
+                                                                            std::nullopt,
+                                                                            std::nullopt,
+                                                                            {}});
+  }
+  xodr::RoadHeader mixed_road{};
+  mixed_road.id = xodr::RoadHeader::Id("7");
+  mixed_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}},
+                           {10., xodr::RoadType::Type::kMotorway, std::nullopt, {}}};
+  xodr::RoadHeader town_road{};
+  town_road.id = xodr::RoadHeader::Id("8");
+  town_road.road_types = {{0., xodr::RoadType::Type::kTown, std::nullopt, {}}};
+
+  const std::map<xodr::RoadHeader::Id, xodr::RoadHeader> road_headers{{mixed_road.id, mixed_road},
+                                                                      {town_road.id, town_road}};
+  EXPECT_EQ(std::make_optional(false), DetermineJunctionIntersectionFromXodr(junction, road_headers));
+}
+
 GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, ConnectionCountFallback) {
   xodr::Junction junction{};
   junction.id = xodr::Junction::Id("12");

--- a/test/regression/builder/road_geometry_configuration_test.cc
+++ b/test/regression/builder/road_geometry_configuration_test.cc
@@ -54,6 +54,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
   const double kAngularTolerance{5e-5};
   const double kScaleLength{2.};
   const double kIntegratorAccuracyMultiplier{0.1};
+  const bool kUseUserDataIntersections{true};
 
   void ExpectEqual(const RoadGeometryConfiguration& lhs, const RoadGeometryConfiguration& rhs) {
     EXPECT_EQ(lhs.id, rhs.id);
@@ -69,6 +70,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
     EXPECT_EQ(lhs.standard_strictness_policy, rhs.standard_strictness_policy);
     EXPECT_EQ(lhs.omit_nondrivable_lanes, rhs.omit_nondrivable_lanes);
     EXPECT_EQ(lhs.integrator_accuracy_multiplier, rhs.integrator_accuracy_multiplier);
+    EXPECT_EQ(lhs.use_userdata_intersections, rhs.use_userdata_intersections);
   }
 };
 
@@ -83,7 +85,9 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       kSimplificationPolicy,
       kStandardStrictnessPolicy,
       kOmitNondrivableLanes,
-      kIntegratorAccuracyMultiplier};
+      kIntegratorAccuracyMultiplier,
+      false /* use_userdata_traffic_direction */,
+      kUseUserDataIntersections};
 
   const std::map<std::string, std::string> rg_config_map{
       {params::kRoadGeometryId, kRgId},
@@ -100,6 +104,7 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
        RoadGeometryConfiguration::FromStandardStrictnessPolicyToStr(kStandardStrictnessPolicy)},
       {params::kOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
       {params::kIntegratorAccuracyMultiplier, std::to_string(kIntegratorAccuracyMultiplier)},
+      {params::kUseUserDataIntersections, (kUseUserDataIntersections ? "true" : "false")},
   };
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(rg_config_map)};
@@ -118,7 +123,9 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapUsingMaxLinearTolerance) {
       kSimplificationPolicy,
       kStandardStrictnessPolicy,
       kOmitNondrivableLanes,
-      kIntegratorAccuracyMultiplier};
+      kIntegratorAccuracyMultiplier,
+      false /* use_userdata_traffic_direction */,
+      kUseUserDataIntersections};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);
@@ -135,7 +142,9 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapNotUsingMaxLinearTolerance) {
       kSimplificationPolicy,
       kStandardStrictnessPolicy,
       kOmitNondrivableLanes,
-      kIntegratorAccuracyMultiplier};
+      kIntegratorAccuracyMultiplier,
+      false /* use_userdata_traffic_direction */,
+      kUseUserDataIntersections};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);

--- a/test/regression/builder/road_network_configuration_test.cc
+++ b/test/regression/builder/road_network_configuration_test.cc
@@ -62,6 +62,7 @@ class RoadNetworkConfigurationTest : public ::testing::Test {
   const double kMaxLinearTolerance{5e-4};
   const double kAngularTolerance{5e-5};
   const double kScaleLength{2.};
+  const bool kUseUserDataIntersections{true};
 
   void ExpectEqual(const RoadNetworkConfiguration& lhs, const RoadNetworkConfiguration& rhs) {
     // RoadNetworkConfiguration parameters.
@@ -92,6 +93,8 @@ class RoadNetworkConfigurationTest : public ::testing::Test {
               rhs.road_geometry_configuration.standard_strictness_policy);
     EXPECT_EQ(lhs.road_geometry_configuration.omit_nondrivable_lanes,
               rhs.road_geometry_configuration.omit_nondrivable_lanes);
+    EXPECT_EQ(lhs.road_geometry_configuration.use_userdata_intersections,
+              rhs.road_geometry_configuration.use_userdata_intersections);
   }
 };
 
@@ -105,7 +108,10 @@ TEST_F(RoadNetworkConfigurationTest, Constructor) {
       kBuildPolicy,
       kSimplificationPolicy,
       kStandardStrictnessPolicy,
-      kOmitNondrivableLanes};
+      kOmitNondrivableLanes,
+      1.0 /* integrator_accuracy_multiplier */,
+      false /* use_userdata_traffic_direction */,
+      kUseUserDataIntersections};
   RoadNetworkConfiguration dut1{rg_config,      kRuleRegistry,     kRoadRuleBook,          kTrafficLightBook,
                                 kPhaseRingBook, kIntersectionBook, kTrafficControlDeviceDb};
 
@@ -128,6 +134,7 @@ TEST_F(RoadNetworkConfigurationTest, Constructor) {
       {params::kPhaseRingBook, kPhaseRingBook.value()},
       {params::kIntersectionBook, kIntersectionBook.value()},
       {params::kTrafficControlDeviceDb, kTrafficControlDeviceDb.value()},
+      {params::kUseUserDataIntersections, (kUseUserDataIntersections ? "true" : "false")},
   };
 
   const RoadNetworkConfiguration dut2{RoadNetworkConfiguration::FromMap(rn_config_map)};
@@ -140,7 +147,8 @@ TEST_F(RoadNetworkConfigurationTest, ToStringMap) {
       {maliput::api::RoadGeometryId{kRgId}, kOpendriveFile,
        builder::RoadGeometryConfiguration::BuildTolerance{kLinearTolerance, kMaxLinearTolerance, kAngularTolerance},
        kScaleLength, kRandomVector, kBuildPolicy, kSimplificationPolicy, kStandardStrictnessPolicy,
-       kOmitNondrivableLanes},
+       kOmitNondrivableLanes, 1.0 /* integrator_accuracy_multiplier */, false /* use_userdata_traffic_direction */,
+       kUseUserDataIntersections},
       kRuleRegistry,
       kRoadRuleBook,
       kTrafficLightBook,

--- a/test/regression/xodr/parser_test.cc
+++ b/test/regression/xodr/parser_test.cc
@@ -1982,12 +1982,16 @@ TEST_F(ParsingTests, NodeParserConnection) {
 // @param junction_id The junction_id value.
 // @param junction_name The junction_name value.
 // @param junction_type The junction_type value.
+// @param user_data Vector of user_data entries to be added to the junction.
 // @returns A string that contains a XML description of a XODR Junction.
 std::string GetJunction(const std::string& junction_id, const std::string& junction_name,
-                        const std::string& junction_type) {
+                        const std::string& junction_type, const std::vector<std::string>& user_data = {}) {
   std::stringstream ss;
   ss << "<root>";
   ss << "<junction id='" << junction_id << "' name='" << junction_name << "' type='" << junction_type << "'>";
+  for (const auto& user_data_entry : user_data) {
+    ss << user_data_entry;
+  }
   ss << R"R(
     <connection id="10" incomingRoad="1" connectingRoad="2" contactPoint="start" connectionMaster="50" type="default">
         <laneLink from="1" to="1"/>
@@ -2022,11 +2026,11 @@ TEST_F(ParsingTests, NodeParserJunction) {
                                 {{Connection::LaneLink::Id("2"), Connection::LaneLink::Id("4")},
                                  {Connection::LaneLink::Id("1"), Connection::LaneLink::Id("3")}} /* lane_links */};
 
-  const Junction kExpectedJunction{
-      Junction::Id("358") /* id */,
-      "junctionTest" /* name */,
-      Junction::Type::kDefault /* type */,
-      {{kConnectionA.id, kConnectionA}, {kConnectionB.id, kConnectionB}} /* connections */};
+  const Junction kExpectedJunction{Junction::Id("358") /* id */,
+                                   "junctionTest" /* name */,
+                                   Junction::Type::kDefault /* type */,
+                                   {{kConnectionA.id, kConnectionA}, {kConnectionB.id, kConnectionB}} /* connections */,
+                                   {} /* user_data */};
 
   const std::string xml_description = GetJunction(kExpectedJunction.id.string(), kExpectedJunction.name.value(),
                                                   Junction::type_to_str(kExpectedJunction.type.value()));
@@ -2036,6 +2040,34 @@ TEST_F(ParsingTests, NodeParserJunction) {
   EXPECT_EQ(Junction::kJunctionTag, dut.GetName());
   const Junction junction = dut.As<Junction>();
   EXPECT_EQ(kExpectedJunction, junction);
+}
+
+TEST_F(ParsingTests, NodeParserJunctionWithUserDataEnabled) {
+  constexpr const char* kJunctionUserData = R"R(<userData code="junctionType" value="intersection"/>)R";
+  const std::string xml_description = GetJunction("358", "junctionTest", "default", {kJunctionUserData});
+
+  const NodeParser dut(
+      LoadXMLAndGetNodeByName(xml_description, Junction::kJunctionTag),
+      {kStrictParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors, kDontSupportUserData, true});
+  const Junction junction = dut.As<Junction>();
+  EXPECT_EQ(std::vector<std::string>({std::string(kJunctionUserData) + "\n"}), junction.user_data);
+}
+
+TEST_F(ParsingTests, NodeParserJunctionWithMultipleUserDataEnabled) {
+  constexpr const char* kVectorJunctionUserData =
+      R"R(<userData code="vectorJunction"><vectorJunction junctionId="123"/></userData>)R";
+  constexpr const char* kJunctionTypeUserData = R"R(<userData code="junctionType" value="nonIntersection"/>)R";
+  const std::string xml_description =
+      GetJunction("358", "junctionTest", "default", {kVectorJunctionUserData, kJunctionTypeUserData});
+
+  const NodeParser dut(
+      LoadXMLAndGetNodeByName(xml_description, Junction::kJunctionTag),
+      {kStrictParserSTolerance, kDontAllowSchemaErrors, kDontAllowSemanticErrors, kDontSupportUserData, true});
+  const Junction junction = dut.As<Junction>();
+  ASSERT_EQ(2u, junction.user_data.size());
+  EXPECT_NE(junction.user_data.at(0).find("code=\"vectorJunction\""), std::string::npos);
+  EXPECT_NE(junction.user_data.at(0).find("junctionId=\"123\""), std::string::npos);
+  EXPECT_EQ(std::string(kJunctionTypeUserData) + "\n", junction.user_data.at(1));
 }
 
 // Template of a XML description that contains a XODR Junction with no connections.


### PR DESCRIPTION
# 🎉 New feature

Closes #510 

## Summary
Implement `Junction::is_intersection()` API based on userData XODR node info in XODR Junction nodes.

### Detailed changelog
  - Added configurable intersection detection in road geometry config (`use_userdata_intersections`), and propagated it through parser and builder.
   - Extended XODR junction parsing to keep all `<userData>` siblings (not just the first).
   - Updated junction intersection override logic to scan all stored userData entries for `code="junctionType"`
     - uses `value=intersection` / `value=nonIntersection` when only one is provided,
     - treats conflicting values (multiple `<userData>` with different `code="junctionType"` values) as `std::nullopt` and logs a warning message,
     - then falls back to existing motorway/connection-count rules as described in #510 .
   - Added tests for: 
     - `road_geometry_configuration` parsing,
     - parser support for multiple junction `userData` entries,
     - builder override precedence and conflict handling.

### Suggested review order
   1. builder/road_geometry_configuration.h (and .cc) + builder/road_network_builder.cc + builder/xodr_parser_configuration.cc (feature flag)
   2. xodr/junction.h (and .cc) + xodr/parser.cc (userData parsing)
   3. builder/builder_tools.h (and .cc) (intersection decision logic)
   4. test/regression/xodr/parser_test.cc (parser behavior)
   5. test/regression/builder/builder_tools_test.cc and config tests (logic + edge cases)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
