### PR TITLE
Map XODR object subtypes to specific RoadObjectTypes.

### DIFF
--- a/src/maliput_malidrive/builder/road_object_type_mapper.cc
+++ b/src/maliput_malidrive/builder/road_object_type_mapper.cc
@@ -37,6 +37,8 @@ namespace builder {
 static const char* kGuardRailSubtype = "guardRail";
 static const char* kWallSubtype = "wall";
 static const char* kJerseySubtype = "jerseyBarrier";
+static const char* kRoadBlockageSubtype = "roadBlockage";
+static const char* kPermanentDelineatorSubtype = "permanentDelineator";
 
 maliput::api::objects::RoadObjectType MapXodrObjectType(
     const std::optional<xodr::object::Object::ObjectType>& xodr_type, std::optional<std::string> xodr_subtype) {
@@ -68,10 +70,12 @@ maliput::api::objects::RoadObjectType MapXodrObjectType(
     // @}
     // @{
     case XodrType::kObstacle:
+      if (subtype == kRoadBlockageSubtype) return MaliputType::kPylon;
       return MaliputType::kObstacle;
     // @}
     // @{
     case XodrType::kPole:
+      if (subtype == kPermanentDelineatorSubtype) return MaliputType::kDelineator;
     case XodrType::kWind:
     case XodrType::kStreetLamp:
       return MaliputType::kPole;

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -128,6 +128,14 @@ TEST_F(RoadObjectTypeMapperTest, SubtypeMappings) {
   EXPECT_EQ(MaliputType::kGuardWall, MapXodrObjectType(XodrType::kBarrier, "jerseyBarrier"));
   EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kBarrier, "otherSubtype"));
   EXPECT_EQ(MaliputType::kBarrier, MapXodrObjectType(XodrType::kBarrier, std::nullopt));
+
+  EXPECT_EQ(MaliputType::kPylon, MapXodrObjectType(XodrType::kObstacle, "roadBlockage"));
+  EXPECT_EQ(MaliputType::kObstacle, MapXodrObjectType(XodrType::kObstacle, "otherSubtype"));
+  EXPECT_EQ(MaliputType::kObstacle, MapXodrObjectType(XodrType::kObstacle, std::nullopt));
+
+  EXPECT_EQ(MaliputType::kDelineator, MapXodrObjectType(XodrType::kPole, "permanentDelineator"));
+  EXPECT_EQ(MaliputType::kPole, MapXodrObjectType(XodrType::kPole, "otherSubtype"));
+  EXPECT_EQ(MaliputType::kPole, MapXodrObjectType(XodrType::kPole, std::nullopt));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# 🎉 New feature

Closes #512

## Summary
Maps:
* XODR Object type=obstacle subtype=roadBlockage to `RoadObjectType::kPylon`
* XODR Object type=pole subtype=permanentDelineator to `RoadObjectType::kDelineator`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

