### PR TITLE
Prepare for maliput_malidrive release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package maliput_malidrive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.28.0 (2026-06-30)
+-------------------
+* Map XODR object subtypes to specific RoadObjectTypes. (`#513 <https://github.com/maliput/maliput_malidrive/issues/513>`_)
+* Implement Junction::is_intersection API  (`#511 <https://github.com/maliput/maliput_malidrive/issues/511>`_)
+* Align bounding box's bottom-center with device's s-t-z_offset position. (`#509 <https://github.com/maliput/maliput_malidrive/issues/509>`_)
+* Contributors: Santiago Lopez
+
 0.27.0 (2026-06-22)
 -------------------
 * RoadMarkingBuilder accepts XODR signals as input. (`#507 <https://github.com/maliput/maliput_malidrive/issues/507>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##############################################################################
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(maliput_malidrive LANGUAGES C CXX VERSION 0.27.0)
+project(maliput_malidrive LANGUAGES C CXX VERSION 0.28.0)
 
 ##############################################################################
 # CMake Support

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,14 +5,14 @@ Welcome to Maliput Malidrive!
 module(
     name = "maliput_malidrive",
     compatibility_level = 1,
-    version = "0.27.0",
+    version = "0.28.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.20.0")
+bazel_dep(name = "maliput", version = "1.21.0")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>maliput_malidrive</name>
-  <version>0.27.0</version>
+  <version>0.28.0</version>
   <description>maliput_malidrive backend</description>
   <license file="LICENSE">BSD Clause 3</license>
   <maintainer email="andrew.best@tri.global">Andrew Best</maintainer>


### PR DESCRIPTION
# 🎈 Release

## Summary
* Point to maliput version 1.21.0.
* Prepare for maliput_malidrive 0.28.0 release.

## After PR is merged
Push git tag 0.28.0 to trigger release workflow.

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
