### PR TITLE
Improve TrafficControlDevice::Lookup by passing XODR element type

### DIFF
--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -102,7 +102,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
           type_str, object.subtype, std::nullopt, std::nullopt, object.name,
       };
 
-      const auto definition_opt = loader_.Lookup(fingerprint);
+      const auto definition_opt = loader_.Lookup(fingerprint, traffic_control_device::OpenDriveElementType::kObject);
       if (!definition_opt.has_value()) {
         maliput::log()->debug("RoadMarkingBuilder: no definition found for object id='", object.id.string(), "' type='",
                               type_str, "' subtype='", object.subtype.value_or(""), "' name='",
@@ -187,7 +187,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
           signal.type, NormalizeSubtype(signal.subtype), signal.country, signal.country_revision, signal.name,
       };
 
-      const auto definition_opt = loader_.Lookup(fingerprint);
+      const auto definition_opt = loader_.Lookup(fingerprint, traffic_control_device::OpenDriveElementType::kSignal);
       if (!definition_opt.has_value()) {
         maliput::log()->debug("RoadMarkingBuilder: no definition found for signal id='", signal.id.string(), "' type='",
                               signal.type, "' subtype='", signal.subtype, "' name='", signal.name.value_or(""),

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -131,7 +131,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
           type_str, object.subtype, std::nullopt, std::nullopt, object.name,
       };
       bool is_movable = false;
-      const auto definition_opt = loader_.Lookup(fingerprint);
+      const auto definition_opt = loader_.Lookup(fingerprint, traffic_control_device::OpenDriveElementType::kObject);
       if (definition_opt.has_value() &&
           definition_opt.value().device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
         is_movable = definition_opt.value().is_position_dynamic;
@@ -214,7 +214,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       };
       bool is_movable = false;
       std::optional<maliput::api::objects::RoadObjectType> type_from_db;
-      const auto definition_opt = loader_.Lookup(fingerprint);
+      const auto definition_opt = loader_.Lookup(fingerprint, traffic_control_device::OpenDriveElementType::kSignal);
       if (definition_opt.has_value() &&
           definition_opt.value().device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
         is_movable = definition_opt.value().is_position_dynamic;

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -112,7 +112,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
           signal.name,
       };
 
-      const auto definition_opt = loader.Lookup(fingerprint);
+      const auto definition_opt = loader.Lookup(fingerprint, traffic_control_device::OpenDriveElementType::kSignal);
       if (!definition_opt.has_value()) {
         maliput::log()->debug("TrafficControlDeviceBooksBuilder: no definition found for signal id='",
                               signal.id.string(), "' type='", signal.type, "' subtype='", signal.subtype,
@@ -182,7 +182,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
           object.name,
       };
 
-      const auto definition_opt = loader.Lookup(fingerprint);
+      const auto definition_opt = loader.Lookup(fingerprint, traffic_control_device::OpenDriveElementType::kObject);
       if (!definition_opt.has_value()) {
         maliput::log()->debug("TrafficControlDeviceBooksBuilder: no definition found for object id='",
                               object.id.string(), "' type='", type_str, "' subtype='", object.subtype.value_or(""),

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -82,7 +82,7 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
       signal_.country_revision,
   };
 
-  const auto definition_opt = loader_.Lookup(fingerprint);
+  const auto definition_opt = loader_.Lookup(fingerprint, traffic_control_device::OpenDriveElementType::kSignal);
   if (!definition_opt.has_value()) {
     maliput::log()->debug("TrafficLightBuilder: no definition found for signal id='", signal_.id.string(), "' type='",
                           signal_.type, "' subtype='", signal_.subtype, "'. Skipping TrafficLight creation.");

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -102,7 +102,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
       signal_.country_revision,
   };
 
-  const auto definition_opt = loader_.Lookup(fingerprint);
+  const auto definition_opt = loader_.Lookup(fingerprint, traffic_control_device::OpenDriveElementType::kSignal);
   if (!definition_opt.has_value()) {
     maliput::log()->debug("TrafficSignBuilder: no definition found for signal id='", signal_.id.string(), "' type='",
                           signal_.type, "' subtype='", signal_.subtype, "'. Skipping TrafficSign creation.");

--- a/src/maliput_malidrive/traffic_control_device/parser.cc
+++ b/src/maliput_malidrive/traffic_control_device/parser.cc
@@ -378,6 +378,7 @@ TrafficControlDeviceDefinition ParseSignalDefinition(const YAML::Node& entry_nod
                          maliput::common::road_network_description_parser_error);
 
   TrafficControlDeviceDefinition tcd_definition;
+  tcd_definition.odr_element_type = OpenDriveElementType::kSignal;
 
   // --- Parse fingerprint from odr_representation ---
   tcd_definition.fingerprint.type = GetRequiredStringField(repr_node, TrafficControlDeviceConstants::kType);
@@ -503,6 +504,7 @@ TrafficControlDeviceDefinition ParseObjectDefinition(const YAML::Node& entry_nod
                          maliput::common::road_network_description_parser_error);
 
   TrafficControlDeviceDefinition tcd_definition;
+  tcd_definition.odr_element_type = OpenDriveElementType::kObject;
 
   // --- Parse fingerprint from odr_representation ---
   tcd_definition.fingerprint.type = GetRequiredStringField(repr_node, TrafficControlDeviceConstants::kType);

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -45,6 +45,7 @@ namespace traffic_control_device {
 
 /// OpenDRIVE element category that originated a DB entry or lookup query.
 enum class OpenDriveElementType {
+  kUnknown = 0,
   kSignal,
   kObject,
 };
@@ -150,7 +151,7 @@ struct TrafficControlDeviceFingerprint {
 /// Describes the complete structure and rule logic for a particular signal.
 struct TrafficControlDeviceDefinition {
   /// OpenDRIVE element category this DB entry belongs to (`odr_signal_types` or `odr_object_types`).
-  OpenDriveElementType odr_element_type{OpenDriveElementType::kSignal};
+  OpenDriveElementType odr_element_type{OpenDriveElementType::kUnknown};
   /// Unique identifier for this signal definition.
   TrafficControlDeviceFingerprint fingerprint;
   /// Human-readable description of this signal definition.

--- a/src/maliput_malidrive/traffic_control_device/parser.h
+++ b/src/maliput_malidrive/traffic_control_device/parser.h
@@ -43,6 +43,12 @@
 namespace malidrive {
 namespace traffic_control_device {
 
+/// OpenDRIVE element category that originated a DB entry or lookup query.
+enum class OpenDriveElementType {
+  kSignal,
+  kObject,
+};
+
 /// Represents a bulb state condition in a rule definition.
 /// Specifies that a particular bulb must be in a particular state.
 struct BulbStateCondition {
@@ -143,6 +149,8 @@ struct TrafficControlDeviceFingerprint {
 /// Represents a traffic signal definition loaded from the database.
 /// Describes the complete structure and rule logic for a particular signal.
 struct TrafficControlDeviceDefinition {
+  /// OpenDRIVE element category this DB entry belongs to (`odr_signal_types` or `odr_object_types`).
+  OpenDriveElementType odr_element_type{OpenDriveElementType::kSignal};
   /// Unique identifier for this signal definition.
   TrafficControlDeviceFingerprint fingerprint;
   /// Human-readable description of this signal definition.
@@ -165,7 +173,8 @@ struct TrafficControlDeviceDefinition {
   std::vector<RuleState> rule_states;
 
   bool operator==(const TrafficControlDeviceDefinition& other) const {
-    return fingerprint == other.fingerprint && description == other.description && device_type == other.device_type &&
+    return odr_element_type == other.odr_element_type && fingerprint == other.fingerprint &&
+           description == other.description && device_type == other.device_type &&
            device_semantics == other.device_semantics && is_position_dynamic == other.is_position_dynamic &&
            default_bounding_box == other.default_bounding_box && bulbs == other.bulbs &&
            rule_states == other.rule_states;

--- a/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.cc
+++ b/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.cc
@@ -73,6 +73,9 @@ std::optional<TrafficControlDeviceDefinition> TrafficControlDeviceDatabaseLoader
 
   for (const auto& def : definitions_) {
     if (def.odr_element_type != query_source) {
+      MALIDRIVE_VALIDATE(query_source != OpenDriveElementType::kUnknown,
+                         maliput::common::road_network_description_parser_error,
+                         "Invalid OpenDriveElementType for lookup: " + std::to_string(static_cast<int>(query_source)));
       continue;
     }
     if (TrafficControlDeviceParser::Matches(def.fingerprint, fingerprint)) {

--- a/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.cc
+++ b/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.cc
@@ -62,13 +62,21 @@ TrafficControlDeviceDatabaseLoader::TrafficControlDeviceDatabaseLoader(const std
 }
 
 std::optional<TrafficControlDeviceDefinition> TrafficControlDeviceDatabaseLoader::Lookup(
-    const TrafficControlDeviceFingerprint& fingerprint) const {
+    const TrafficControlDeviceFingerprint& fingerprint, OpenDriveElementType query_source) const {
+  const auto specificity_for = [query_source](const TrafficControlDeviceFingerprint& fp) {
+    return query_source == OpenDriveElementType::kSignal ? TrafficControlDeviceParser::Specificity(fp)
+                                                         : TrafficControlDeviceParser::SpecificityForObject(fp);
+  };
+
   const TrafficControlDeviceDefinition* best = nullptr;
   int best_specificity = -1;
 
   for (const auto& def : definitions_) {
+    if (def.odr_element_type != query_source) {
+      continue;
+    }
     if (TrafficControlDeviceParser::Matches(def.fingerprint, fingerprint)) {
-      const int specificity = TrafficControlDeviceParser::Specificity(def.fingerprint);
+      const int specificity = specificity_for(def.fingerprint);
       if (specificity > best_specificity) {
         best_specificity = specificity;
         best = &def;

--- a/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h
+++ b/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h
@@ -63,6 +63,8 @@ class TrafficControlDeviceDatabaseLoader {
   /// @param query_source Whether the lookup is for an OpenDRIVE `signal` or `object`.
   /// @returns An optional containing the matching @ref TrafficControlDeviceDefinition
   ///          if found, std::nullopt otherwise.
+  /// @throws maliput::common::road_network_description_parser_error if @p query_source is
+  ///         OpenDriveElementType::kUnknown.
   std::optional<TrafficControlDeviceDefinition> Lookup(const TrafficControlDeviceFingerprint& fingerprint,
                                                        OpenDriveElementType query_source) const;
 

--- a/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h
+++ b/src/maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h
@@ -60,9 +60,11 @@ class TrafficControlDeviceDatabaseLoader {
   /// Looks up a TrafficControlDeviceDefinition by fingerprint.
   ///
   /// @param fingerprint The @ref TrafficControlDeviceFingerprint to look up.
+  /// @param query_source Whether the lookup is for an OpenDRIVE `signal` or `object`.
   /// @returns An optional containing the matching @ref TrafficControlDeviceDefinition
   ///          if found, std::nullopt otherwise.
-  std::optional<TrafficControlDeviceDefinition> Lookup(const TrafficControlDeviceFingerprint& fingerprint) const;
+  std::optional<TrafficControlDeviceDefinition> Lookup(const TrafficControlDeviceFingerprint& fingerprint,
+                                                       OpenDriveElementType query_source) const;
 
  private:
   TrafficControlDeviceDatabaseLoader() = delete;

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -1603,8 +1603,7 @@ odr_signal_types:
   EXPECT_EQ(result->device_type, TrafficControlDeviceType::kRoadMarking);
 }
 
-GTEST_TEST(SourceAwareLookupTest, SignalLookupIgnoresObjectEntries) {
-  const char kDb[] = R"(
+const char kSourceAwareLookupTestDb[] = R"(
 odr_signal_types:
   - odr_representation:
       type: "roadMark"
@@ -1624,7 +1623,9 @@ odr_object_types:
       device_semantics: ObjectStopLine
       description: "Object stop line"
 )";
-  const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kDb});
+
+GTEST_TEST(SourceAwareLookupTest, SignalLookupIgnoresObjectEntries) {
+  const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kSourceAwareLookupTestDb});
   const TrafficControlDeviceFingerprint query{.type = "roadMark",
                                               .subtype = std::nullopt,
                                               .country = std::nullopt,
@@ -1637,25 +1638,7 @@ odr_object_types:
 }
 
 GTEST_TEST(SourceAwareLookupTest, ObjectLookupIgnoresSignalEntries) {
-  const char kDb[] = R"(
-odr_signal_types:
-  - odr_representation:
-      type: "roadMark"
-      name: "StopLine"
-    properties:
-      device_type: RoadMarking
-      device_semantics: SignalStopLine
-      description: "Signal stop line"
-odr_object_types:
-  - odr_representation:
-      type: "roadMark"
-      name: "StopLine"
-    properties:
-      device_type: RoadMarking
-      device_semantics: ObjectStopLine
-      description: "Object stop line"
-)";
-  const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kDb});
+  const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kSourceAwareLookupTestDb});
   const TrafficControlDeviceFingerprint query{.type = "roadMark",
                                               .subtype = std::nullopt,
                                               .country = std::nullopt,
@@ -1665,6 +1648,17 @@ odr_object_types:
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->odr_element_type, OpenDriveElementType::kObject);
   EXPECT_EQ(result->device_semantics, "ObjectStopLine");
+}
+
+GTEST_TEST(SourceAwareLookupTest, UnknownQuerySourceThrows) {
+  const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kSourceAwareLookupTestDb});
+  const TrafficControlDeviceFingerprint query{.type = "roadMark",
+                                              .subtype = std::nullopt,
+                                              .country = std::nullopt,
+                                              .country_revision = std::nullopt,
+                                              .name = "StopLine"};
+  EXPECT_THROW(loader.Lookup(query, OpenDriveElementType::kUnknown),
+               maliput::common::road_network_description_parser_error);
 }
 
 // ============================================================================

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -1573,6 +1573,36 @@ odr_signal_types:
   EXPECT_EQ(result->device_semantics, "concrete_name");
 }
 
+GTEST_TEST(SourceAwareLookupTest, DistinguishEntriesByOdrElementType) {
+  const char kDb[] = R"(
+odr_object_types:
+  - odr_representation:
+      type: "roadMark"
+    properties:
+      device_type: RoadMarking
+      device_semantics: None
+
+odr_signal_types:
+  - odr_representation:
+      type: "roadMark"
+      name: "StopLine"
+    properties:
+      device_type: RoadMarking
+      device_semantics: StopLine
+)";
+  const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kDb});
+  const TrafficControlDeviceFingerprint query{.type = "roadMark",
+                                              .subtype = std::nullopt,
+                                              .country = std::nullopt,
+                                              .country_revision = std::nullopt,
+                                              .name = "StopLine"};
+  const auto result = loader.Lookup(query, OpenDriveElementType::kSignal);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->odr_element_type, OpenDriveElementType::kSignal);
+  EXPECT_EQ(result->device_semantics, "StopLine");
+  EXPECT_EQ(result->device_type, TrafficControlDeviceType::kRoadMarking);
+}
+
 GTEST_TEST(SourceAwareLookupTest, SignalLookupIgnoresObjectEntries) {
   const char kDb[] = R"(
 odr_signal_types:

--- a/test/regression/traffic_control_device/parser_test.cc
+++ b/test/regression/traffic_control_device/parser_test.cc
@@ -1492,7 +1492,7 @@ GTEST_TEST(WildcardLookupTest, ExactMatchPreferredOverWildcard) {
                                               .country = "OpenDRIVE",
                                               .country_revision = std::nullopt,
                                               .name = std::nullopt};
-  const auto result = loader.Lookup(query);
+  const auto result = loader.Lookup(query, OpenDriveElementType::kSignal);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "exact_match");
 }
@@ -1504,7 +1504,7 @@ GTEST_TEST(WildcardLookupTest, PartialWildcardPreferredOverCatchAll) {
                                               .country = "OpenDRIVE",
                                               .country_revision = std::nullopt,
                                               .name = std::nullopt};
-  const auto result = loader.Lookup(query);
+  const auto result = loader.Lookup(query, OpenDriveElementType::kSignal);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "partial_wildcard");
 }
@@ -1516,7 +1516,7 @@ GTEST_TEST(WildcardLookupTest, FallbackToCatchAll) {
                                               .country = std::nullopt,
                                               .country_revision = std::nullopt,
                                               .name = std::nullopt};
-  const auto result = loader.Lookup(query);
+  const auto result = loader.Lookup(query, OpenDriveElementType::kSignal);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "catch_all");
 }
@@ -1528,7 +1528,7 @@ GTEST_TEST(WildcardLookupTest, NoMatchReturnsNullopt) {
                                               .country = std::nullopt,
                                               .country_revision = std::nullopt,
                                               .name = std::nullopt};
-  const auto result = loader.Lookup(query);
+  const auto result = loader.Lookup(query, OpenDriveElementType::kSignal);
   EXPECT_FALSE(result.has_value());
 }
 
@@ -1539,7 +1539,7 @@ GTEST_TEST(WildcardLookupTest, CatchAllMatchesAnyQuery) {
                                               .country = "any_country",
                                               .country_revision = "rev1",
                                               .name = "any_name"};
-  const auto result = loader.Lookup(query);
+  const auto result = loader.Lookup(query, OpenDriveElementType::kSignal);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "generic");
 }
@@ -1568,9 +1568,73 @@ odr_signal_types:
 )";
   const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kNameLookupDb});
   const TrafficControlDeviceFingerprint query{.type = "1000001", .name = "stop_sign"};
-  const auto result = loader.Lookup(query);
+  const auto result = loader.Lookup(query, OpenDriveElementType::kSignal);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->device_semantics, "concrete_name");
+}
+
+GTEST_TEST(SourceAwareLookupTest, SignalLookupIgnoresObjectEntries) {
+  const char kDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "roadMark"
+      name: "StopLine"
+      country: null
+      country_revision: null
+    properties:
+      device_type: RoadMarking
+      device_semantics: SignalStopLine
+      description: "Signal stop line"
+odr_object_types:
+  - odr_representation:
+      type: "roadMark"
+      name: "StopLine"
+    properties:
+      device_type: RoadMarking
+      device_semantics: ObjectStopLine
+      description: "Object stop line"
+)";
+  const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kDb});
+  const TrafficControlDeviceFingerprint query{.type = "roadMark",
+                                              .subtype = std::nullopt,
+                                              .country = std::nullopt,
+                                              .country_revision = std::nullopt,
+                                              .name = "StopLine"};
+  const auto result = loader.Lookup(query, OpenDriveElementType::kSignal);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->odr_element_type, OpenDriveElementType::kSignal);
+  EXPECT_EQ(result->device_semantics, "SignalStopLine");
+}
+
+GTEST_TEST(SourceAwareLookupTest, ObjectLookupIgnoresSignalEntries) {
+  const char kDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "roadMark"
+      name: "StopLine"
+    properties:
+      device_type: RoadMarking
+      device_semantics: SignalStopLine
+      description: "Signal stop line"
+odr_object_types:
+  - odr_representation:
+      type: "roadMark"
+      name: "StopLine"
+    properties:
+      device_type: RoadMarking
+      device_semantics: ObjectStopLine
+      description: "Object stop line"
+)";
+  const TrafficControlDeviceDatabaseLoader loader(std::optional<std::string>{kDb});
+  const TrafficControlDeviceFingerprint query{.type = "roadMark",
+                                              .subtype = std::nullopt,
+                                              .country = std::nullopt,
+                                              .country_revision = std::nullopt,
+                                              .name = "StopLine"};
+  const auto result = loader.Lookup(query, OpenDriveElementType::kObject);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->odr_element_type, OpenDriveElementType::kObject);
+  EXPECT_EQ(result->device_semantics, "ObjectStopLine");
 }
 
 // ============================================================================
@@ -2122,7 +2186,7 @@ odr_object_types:
       .name = "LadderCrosswalk",  // Specific name, but should match wildcard in DB
   };
 
-  const auto result = loader.Lookup(query);
+  const auto result = loader.Lookup(query, OpenDriveElementType::kObject);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->fingerprint.type, "crosswalk");
   EXPECT_EQ(result->device_semantics, "Crosswalk");
@@ -2151,7 +2215,7 @@ odr_object_types:
       .name = "LadderCrosswalk",  // Specific name query
   };
 
-  const auto result = loader.Lookup(query);
+  const auto result = loader.Lookup(query, OpenDriveElementType::kObject);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->fingerprint.type, "crosswalk");
   EXPECT_EQ(result->fingerprint.name, "LadderCrosswalk");


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #516 

## Summary
Add XODR signal or object type enum to TrafficControlDevice element definition for better Lookup results.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
