### PR TITLE
Ignore heading offset when creating RoadObject from an XODR object.

### DIFF
--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -164,12 +164,9 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       const double hdg = object.hdg.value_or(0.);
       const double pitch = perp_to_road ? 0. : object.pitch.value_or(0.);
       const double roll = perp_to_road ? 0. : object.roll.value_or(0.);
-      const double orientation_offset =
-          (object.orientation.has_value() && object.orientation.value() == xodr::object::Orientation::kNegative) ? M_PI
-                                                                                                                 : 0.;
       const maliput::api::Rotation orientation =
           maliput::api::Rotation::FromRpy(road_orientation.roll_angle() + roll, road_orientation.pitch_angle() + pitch,
-                                          road_orientation.yaw_angle() + hdg + orientation_offset);
+                                          road_orientation.yaw_angle() + hdg);
 
       // --- Bounding box ---
       double bb_length = object.length.value_or(0.);

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -502,6 +502,29 @@ TEST_F(RoadObjectBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
   EXPECT_GT(std::abs(road_object_z - object_.z_offset), 1.0);
 }
 
+TEST_F(RoadObjectBuilderElevatedRoadTest, ObjectOrientationMinusDoesNotAffectYaw) {
+  xodr::object::Object object_with_positive_orientation = object_;
+  object_with_positive_orientation.orientation = xodr::object::Orientation::kPositive;
+  object_with_positive_orientation.hdg = 0.;
+
+  xodr::object::Object object_with_negative_orientation = object_;
+  object_with_negative_orientation.orientation = xodr::object::Orientation::kNegative;
+  object_with_negative_orientation.hdg = 0.;
+
+  const auto positive_orientation_road_object =
+      RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object_with_positive_orientation,
+                        xodr::RoadHeader::Id("1"), *loader_, road_geometry_)();
+  ASSERT_NE(positive_orientation_road_object, nullptr);
+
+  const auto negative_orientation_road_object =
+      RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object_with_negative_orientation,
+                        xodr::RoadHeader::Id("1"), *loader_, road_geometry_)();
+  ASSERT_NE(negative_orientation_road_object, nullptr);
+
+  EXPECT_NEAR(positive_orientation_road_object->orientation().yaw(), 0., 1e-5);
+  EXPECT_NEAR(negative_orientation_road_object->orientation().yaw(), 0., 1e-5);
+}
+
 class RoadObjectBuilderSignalTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -554,6 +577,29 @@ TEST_F(RoadObjectBuilderSignalTest, BuildRoadObjectFromSignal) {
   EXPECT_EQ(road_object->related_lanes().size(), 1u);
   EXPECT_NEAR(road_object->bounding_box().box_size().x(), 1.0, 1e-6);
   EXPECT_NEAR(road_object->bounding_box().box_size().y(), 0.5, 1e-6);
+}
+
+TEST_F(RoadObjectBuilderSignalTest, SignalOrientationMinusAppliesYawOffset) {
+  xodr::signal::Signal signal_with_positive_orientation = FindSignal("TL1");
+  signal_with_positive_orientation.orientation = xodr::signal::Orientation::kWithS;
+  signal_with_positive_orientation.h_offset = 0.;
+
+  xodr::signal::Signal signal_with_negative_orientation = FindSignal("TL1");
+  signal_with_negative_orientation.orientation = xodr::signal::Orientation::kAgainstS;
+  signal_with_negative_orientation.h_offset = 0.;
+
+  const auto positive_orientation_road_object =
+      RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal_with_positive_orientation,
+                        xodr::RoadHeader::Id("1"), *loader_, road_geometry_)();
+  ASSERT_NE(positive_orientation_road_object, nullptr);
+
+  const auto negative_orientation_road_object =
+      RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal_with_negative_orientation,
+                        xodr::RoadHeader::Id("1"), *loader_, road_geometry_)();
+  ASSERT_NE(negative_orientation_road_object, nullptr);
+
+  EXPECT_NEAR(positive_orientation_road_object->orientation().yaw(), M_PI, 1e-5);
+  EXPECT_NEAR(negative_orientation_road_object->orientation().yaw(), 0., 1e-5);
 }
 
 TEST_F(RoadObjectBuilderTest, FindByLane) {

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -502,7 +502,7 @@ TEST_F(RoadObjectBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
   EXPECT_GT(std::abs(road_object_z - object_.z_offset), 1.0);
 }
 
-TEST_F(RoadObjectBuilderElevatedRoadTest, ObjectOrientationMinusDoesNotAffectYaw) {
+TEST_F(RoadObjectBuilderElevatedRoadTest, ObjectOrientationDoesNotAffectYaw) {
   xodr::object::Object object_with_positive_orientation = object_;
   object_with_positive_orientation.orientation = xodr::object::Orientation::kPositive;
   object_with_positive_orientation.hdg = 0.;
@@ -579,7 +579,7 @@ TEST_F(RoadObjectBuilderSignalTest, BuildRoadObjectFromSignal) {
   EXPECT_NEAR(road_object->bounding_box().box_size().y(), 0.5, 1e-6);
 }
 
-TEST_F(RoadObjectBuilderSignalTest, SignalOrientationMinusAppliesYawOffset) {
+TEST_F(RoadObjectBuilderSignalTest, SignalOrientationAppliesYawOffset) {
   xodr::signal::Signal signal_with_positive_orientation = FindSignal("TL1");
   signal_with_positive_orientation.orientation = xodr::signal::Orientation::kWithS;
   signal_with_positive_orientation.h_offset = 0.;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #519 

## Summary
Ignore heading offset when creating RoadObject from an XODR object.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
