### PR TITLE
Prepare for maliput_malidrive release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package maliput_malidrive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.29.0 (2026-07-06)
+-------------------
+* Improve TrafficControlDevice::Lookup by passing XODR element type (`#517 <https://github.com/maliput/maliput_malidrive/issues/517>`_)
+* Ignore heading offset when creating RoadObject from an XODR object. (`#520 <https://github.com/maliput/maliput_malidrive/issues/520>`_)
+* Contributors: Santiago Lopez
+
 0.28.1 (2026-07-01)
 -------------------
 * Avoid using not-owned db_manager. (`#515 <https://github.com/maliput/maliput_malidrive/issues/515>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##############################################################################
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(maliput_malidrive LANGUAGES C CXX VERSION 0.28.1)
+project(maliput_malidrive LANGUAGES C CXX VERSION 0.29.0)
 
 ##############################################################################
 # CMake Support

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ Welcome to Maliput Malidrive!
 module(
     name = "maliput_malidrive",
     compatibility_level = 1,
-    version = "0.28.1",
+    version = "0.29.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>maliput_malidrive</name>
-  <version>0.28.1</version>
+  <version>0.29.0</version>
   <description>maliput_malidrive backend</description>
   <license file="LICENSE">BSD Clause 3</license>
   <maintainer email="andrew.best@tri.global">Andrew Best</maintainer>


### PR DESCRIPTION
# 🎈 Release

## Summary
Prepare for maliput_malidrive 0.29.0 release.

## After PR is merged
Push git tag 0.29.0 to trigger release workflow.

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
