### PR TITLE
Add roll and pitch to signal's orientation.

### DIFF
--- a/resources/SingleRoadOrientationAttributes.xodr
+++ b/resources/SingleRoadOrientationAttributes.xodr
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2026, Woven by Toyota. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+ Single straight road carrying two signals with non-default orientation
+ attributes (hOffset, roll, pitch) to exercise the builder orientation logic.
+
+ Road layout (viewed from above):
+
+     Road 1 (100 m, hdg=0)
+   ========================
+        lane 1
+   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+   (0,0) ──────── (100,0)
+   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+        lane -1
+   ========================
+       TL_OA at s=50    SS_OA at s=70
+
+ Signal TL_OA (traffic light, on road 1):
+   - type="1000001", subtype="-1", country="OpenDRIVE"
+   - orientation="+", s=50, t=2, zOffset=5
+   - hOffset=0.5, roll=0.1, pitch=0.2
+   - Resulting orientation: roll=0.1, pitch=0.2,
+     yaw = lane_yaw(0) + hOffset(0.5) + pi = pi + 0.5
+
+ Signal SS_OA (traffic sign, on road 1):
+   - type="206", subtype="-1", country="OpenDRIVE"
+   - orientation="-", s=70, t=-2, zOffset=1
+   - hOffset=0.3, roll=0.15, pitch=0.25
+   - Resulting orientation: roll=0.15, pitch=0.25,
+     yaw = lane_yaw(0) + hOffset(0.3) = 0.3  (orientation="-" does not add pi)
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="4" name="SingleRoadOrientationAttributes"/>
+    <road name="Road 1" length="1.0000000000000000e+2" id="1" junction="-1">
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="0.0000000000000000e+0" y="0.0000000000000000e+0" hdg="0.0000000000000000e+0" length="1.0000000000000000e+2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false"/>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <signal id="TL_OA" name="TrafficLight_OrientationAttributes" s="5.0000000000000000e+1" t="2.0000000000000000e+0"
+                    zOffset="5.0000000000000000e+0" hOffset="5.0000000000000000e-1"
+                    roll="1.0000000000000000e-1" pitch="2.0000000000000000e-1"
+                    orientation="+" dynamic="yes" country="OpenDRIVE"
+                    type="1000001" subtype="-1" value="-1" text=""
+                    height="1.0000000000000000e+0" width="5.0000000000000000e-1">
+            </signal>
+            <signal id="SS_OA" name="TrafficSign_OrientationAttributes" s="7.0000000000000000e+1" t="-2.0000000000000000e+0"
+                    zOffset="1.0000000000000000e+0" hOffset="3.0000000000000000e-1"
+                    roll="1.5000000000000001e-1" pitch="2.5000000000000000e-1"
+                    orientation="-" dynamic="no" country="OpenDRIVE"
+                    type="206" subtype="-1" value="-1" text=""
+                    height="6.1000000000000000e-1" width="6.1000000000000000e-1">
+            </signal>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -136,7 +136,8 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
   double orientation =
       rp.lane->GetOrientation(rp.pos).yaw() + (signal_.h_offset.has_value() ? signal_.h_offset.value() : 0.);
   maliput::api::Rotation orientation_road_network = maliput::api::Rotation::FromRpy(
-      0., 0., orientation + (signal_.orientation != xodr::signal::Orientation::kAgainstS ? M_PI : 0.));
+      signal_.roll.value_or(0.), signal_.pitch.value_or(0.),
+      orientation + (signal_.orientation != xodr::signal::Orientation::kAgainstS ? M_PI : 0.));
 
   auto related_lanes =
       ResolveAndDeduplicateLaneIds(road_id_, signal_.s, signal_.validities, signal_references_, road_geometry_);

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -137,7 +137,8 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   const double orientation =
       rp.lane->GetOrientation(rp.pos).yaw() + (signal_.h_offset.has_value() ? signal_.h_offset.value() : 0.);
   const maliput::api::Rotation orientation_road_network = maliput::api::Rotation::FromRpy(
-      0., 0., orientation + (signal_.orientation != xodr::signal::Orientation::kAgainstS ? M_PI : 0.));
+      signal_.roll.value_or(0.), signal_.pitch.value_or(0.),
+      orientation + (signal_.orientation != xodr::signal::Orientation::kAgainstS ? M_PI : 0.));
 
   auto related_lanes =
       ResolveAndDeduplicateLaneIds(road_id_, signal_.s, signal_.validities, signal_references_, road_geometry_);

--- a/test/regression/builder/traffic_light_builder_test.cc
+++ b/test/regression/builder/traffic_light_builder_test.cc
@@ -435,6 +435,61 @@ TEST_F(TrafficLightBuilderTwoRoadsTest, TrafficLightS2Fields) {
   EXPECT_EQ("2_0_1", lane_ids[3]);
 }
 
+// ---------------------------------------------------------------------------
+// Tests using SingleRoadOrientationAttributes.xodr /
+// traffic_control_device_db/traffic_control_device_db_example.yaml.
+//
+// This map defines a single straight road (Road 1, hdg=0) with a traffic-light
+// signal that carries non-default hOffset, roll, and pitch attributes:
+//
+//   Signal TL_OA: type="1000001", orientation="+", s=50, t=2, zOffset=5,
+//                 hOffset=0.5, roll=0.1, pitch=0.2
+//
+// Because the road is straight (hdg=0) the lane yaw at any s is 0.  The
+// builder computes:
+//   orientation_yaw = lane_yaw(0) + hOffset(0.5) + pi  (orientation="+" adds pi)
+//                   = pi + 0.5
+//   rotation = FromRpy(roll=0.1, pitch=0.2, yaw=pi+0.5)
+// ---------------------------------------------------------------------------
+
+class TrafficLightBuilderOrientationAttributesTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file =
+        utility::FindResourceInPath("SingleRoadOrientationAttributes.xodr", kMalidriveResourceFolder);
+    const std::string yaml_db = utility::FindResourceInPath(
+        "traffic_control_device_db/traffic_control_device_db_example.yaml", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file},
+                                                                             {params::kTrafficControlDeviceDb, yaml_db},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    traffic_light_book_ = road_network_->traffic_light_book();
+    ASSERT_NE(traffic_light_book_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::rules::TrafficLightBook* traffic_light_book_{};
+};
+
+// Verifies that hOffset, roll, and pitch from the XODR signal are correctly
+// propagated to the TrafficLight orientation.
+TEST_F(TrafficLightBuilderOrientationAttributesTest, OrientationAttributesAreApplied) {
+  const auto* tl = traffic_light_book_->GetTrafficLight(maliput::api::rules::TrafficLight::Id("TL_OA"));
+  ASSERT_NE(tl, nullptr);
+
+  // Road hdg=0 → lane_yaw = 0.  Builder adds hOffset then pi (orientation="+").
+  const maliput::api::Rotation kExpectedRotation = maliput::api::Rotation::FromRpy(0.1, 0.2, M_PI + 0.5);
+
+  const auto& rot = tl->orientation_road_network();
+  EXPECT_NEAR(kExpectedRotation.roll(), rot.roll(), 1e-6);
+  EXPECT_NEAR(kExpectedRotation.pitch(), rot.pitch(), 1e-6);
+  EXPECT_NEAR(kExpectedRotation.yaw(), rot.yaw(), 1e-6);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace builder

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -552,6 +552,61 @@ TEST_F(TrafficSignBuilderDependencyTest, StopSignsExposeAllWayAsDependentSigns) 
   }
 }
 
+// ---------------------------------------------------------------------------
+// Tests using SingleRoadOrientationAttributes.xodr /
+// traffic_control_device_db/traffic_control_device_db_example.yaml.
+//
+// This map defines a single straight road (Road 1, hdg=0) with a traffic-sign
+// signal that carries non-default hOffset, roll, and pitch attributes:
+//
+//   Signal SS_OA: type="206", orientation="-", s=70, t=-2, zOffset=1,
+//                 hOffset=0.3, roll=0.15, pitch=0.25
+//
+// Because the road is straight (hdg=0) the lane yaw at any s is 0.  The
+// builder computes:
+//   orientation_yaw = lane_yaw(0) + hOffset(0.3)  (orientation="-" does not add pi)
+//                   = 0.3
+//   rotation = FromRpy(roll=0.15, pitch=0.25, yaw=0.3)
+// ---------------------------------------------------------------------------
+
+class TrafficSignBuilderOrientationAttributesTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file =
+        utility::FindResourceInPath("SingleRoadOrientationAttributes.xodr", kMalidriveResourceFolder);
+    const std::string yaml_db = utility::FindResourceInPath(
+        "traffic_control_device_db/traffic_control_device_db_example.yaml", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file},
+                                                                             {params::kTrafficControlDeviceDb, yaml_db},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    traffic_sign_book_ = road_network_->traffic_sign_book();
+    ASSERT_NE(traffic_sign_book_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::rules::TrafficSignBook* traffic_sign_book_{};
+};
+
+// Verifies that hOffset, roll, and pitch from the XODR signal are correctly
+// propagated to the TrafficSign orientation.
+TEST_F(TrafficSignBuilderOrientationAttributesTest, OrientationAttributesAreApplied) {
+  const auto* ts = traffic_sign_book_->GetTrafficSign(maliput::api::rules::TrafficSign::Id("SS_OA"));
+  ASSERT_NE(ts, nullptr);
+
+  // Road hdg=0 → lane_yaw = 0.  Builder adds hOffset only (orientation="-" does not add pi).
+  const maliput::api::Rotation kExpectedRotation = maliput::api::Rotation::FromRpy(0.15, 0.25, 0.3);
+
+  const auto& rot = ts->orientation_road_network();
+  EXPECT_NEAR(kExpectedRotation.roll(), rot.roll(), 1e-6);
+  EXPECT_NEAR(kExpectedRotation.pitch(), rot.pitch(), 1e-6);
+  EXPECT_NEAR(kExpectedRotation.yaw(), rot.yaw(), 1e-6);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace builder


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
* Add the parsed roll and pitch to TrafficSign and TrafficLight orientations.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
