### PR TITLE
Initilize bulb state on builder.

### DIFF
--- a/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
+++ b/resources/traffic_control_device_db/traffic_control_device_db_example.yaml
@@ -232,6 +232,8 @@ odr_signal_types:
           color: "Red"
           type: "Round"
           states: ["Off", "On"]
+          # Pedestrian signals default to "Don't Walk" (Red On) at startup.
+          initial_state: "On"
 
         # Black background with Green walking figure (Walk).
         - id: "WalkBulb"
@@ -240,6 +242,7 @@ odr_signal_types:
           color: "Green"
           type: "Round"
           states: ["Off", "On", "Blinking"]
+          initial_state: "Off"
 
       rule_states:
         - conditions:

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -113,7 +113,7 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
         maliput::api::rules::Bulb::Id(bulb_def.id),
         maliput::api::InertialPosition::FromXyz(bulb_def.position_traffic_light),
         maliput::api::Rotation::FromQuat(bulb_def.orientation_traffic_light), bulb_def.color, bulb_def.type,
-        bulb_def.arrow_orientation_rad, states_opt, bulb_def.bounding_box));
+        bulb_def.arrow_orientation_rad, states_opt, bulb_def.bounding_box, bulb_def.initial_state));
   }
 
   maliput::api::rules::TrafficLight::Id traffic_light_id =

--- a/test/regression/builder/traffic_light_builder_test.cc
+++ b/test/regression/builder/traffic_light_builder_test.cc
@@ -189,6 +189,32 @@ TEST_F(TrafficLightBuilderFigure8Test, PositionOfTrafficLight) {
   EXPECT_NEAR(position.y(), -2.8325, 1e-3);
 }
 
+// Verifies that GetInitialState() on each bulb reflects the initial_state field
+// from the YAML database rather than always being kOff.
+//
+// Uses the pedestrian-signal type "1000002" whose database entry sets:
+//   DontWalkBulb → initial_state: "On"
+//   WalkBulb     → initial_state: "Off"
+TEST_F(TrafficLightBuilderFigure8Test, BulbInitialStateFromDatabase) {
+  xodr::signal::Signal pedestrian_signal = signal_;
+  pedestrian_signal.type = "1000002";
+
+  TrafficLightBuilder builder(pedestrian_signal, xodr::RoadHeader::Id("44"), *loader_, road_geometry_);
+  const auto traffic_light = builder();
+  ASSERT_NE(traffic_light, nullptr);
+
+  const auto bulb_groups = traffic_light->bulb_groups();
+  ASSERT_EQ(1u, bulb_groups.size());
+
+  const auto* dont_walk = bulb_groups[0]->GetBulb(maliput::api::rules::Bulb::Id("DontWalkBulb"));
+  ASSERT_NE(dont_walk, nullptr);
+  EXPECT_EQ(maliput::api::rules::BulbState::kOn, dont_walk->GetInitialState());
+
+  const auto* walk = bulb_groups[0]->GetBulb(maliput::api::rules::Bulb::Id("WalkBulb"));
+  ASSERT_NE(walk, nullptr);
+  EXPECT_EQ(maliput::api::rules::BulbState::kOff, walk->GetInitialState());
+}
+
 class TrafficLightBuilderElevatedRoadTest : public ::testing::Test {
  protected:
   void SetUp() override {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
* Passes the parsed initial state value to the Bulb constructor.
* Modifies example DB to test behavior.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
