### PR TITLE
Set TrafficLight related_lanes based on XODR signal orientation.

### DIFF
--- a/resources/SingleRoadBidirectionalLanes.xodr
+++ b/resources/SingleRoadBidirectionalLanes.xodr
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2026, Woven by Toyota. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+ Single road with bidirectional lanes to test direction filtering.
+
+ Road layout (RHT):
+     lane +1 (left)    — direction: AgainstS (reversed)
+     lane -1 (right)   — direction: WithS (standard)
+
+ Signals:
+   - S_WithS: orientation="+" (kWithS), covers lanes -1 to 1
+     Expected result: only lane -1 (WithS)
+   - S_AgainstS: orientation="-" (kAgainstS), covers lanes -1 to 1
+     Expected result: only lane +1 (AgainstS)
+   - S_Bidirectional: orientation="none" (kBidirectional), covers lanes -1 to 1
+     Expected result: lanes -1 and +1 (both)
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="4" name="SingleRoadBidirectionalLanes" rule="RHT"/>
+    <road name="Road 1" length="1.0000000000000000e+2" id="1" junction="-1" rule="RHT">
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="0.0000000000000000e+0" y="0.0000000000000000e+0" hdg="0.0000000000000000e+0" length="1.0000000000000000e+2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false" direction="standard">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false"/>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false" direction="standard">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <!-- Signal with orientation="+" (kWithS) -->
+            <signal id="S_WithS" name="S_WithS" s="5.0000000000000000e+1" t="0.0000000000000000e+0"
+                    zOffset="1.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="+" dynamic="no" country="OpenDRIVE"
+                    type="1000001" subtype="-1" value="-1" text=""
+                    height="1.0000000000000000e+0" width="5.0000000000000000e-1">
+            </signal>
+            <!-- Signal with orientation="-" (kAgainstS) -->
+            <signal id="S_AgainstS" name="S_AgainstS" s="5.5000000000000000e+1" t="0.0000000000000000e+0"
+                    zOffset="1.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="-" dynamic="no" country="OpenDRIVE"
+                    type="1000001" subtype="-1" value="-1" text=""
+                    height="1.0000000000000000e+0" width="5.0000000000000000e-1">
+            </signal>
+            <!-- Signal with orientation="none" (kBidirectional) -->
+            <signal id="S_Bidirectional" name="S_Bidirectional" s="6.0000000000000000e+1" t="0.0000000000000000e+0"
+                    zOffset="1.0000000000000000e+0" hOffset="0.0000000000000000e+0"
+                    roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0"
+                    orientation="none" dynamic="no" country="OpenDRIVE"
+                    type="1000001" subtype="-1" value="-1" text=""
+                    height="1.0000000000000000e+0" width="5.0000000000000000e-1">
+            </signal>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/resources/TwoRoadsWithTrafficLights.xodr
+++ b/resources/TwoRoadsWithTrafficLights.xodr
@@ -104,6 +104,14 @@
         <lanes>
             <laneSection s="0.0000000000000000e+0">
                 <left>
+                    <!-- <lane id="3" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
+                    </lane> -->
                     <lane id="1" type="driving" level="false">
                         <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
                     </lane>
@@ -115,6 +123,14 @@
                     <lane id="-1" type="driving" level="false">
                         <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
                     </lane>
+                    <!-- <lane id="-2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
+                    </lane>
+                    <lane id="-3" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane> -->
                 </right>
             </laneSection>
         </lanes>

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -790,12 +790,12 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& roa
 }
 
 std::vector<maliput::api::LaneId> ResolveLaneIds(
-    const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
+    const xodr::signal::Signal& signal, double s_coordinate, const xodr::RoadHeader::Id& road_id,
     const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
     const maliput::api::RoadGeometry* road_geometry) {
   std::set<maliput::api::LaneId, LaneIdStringLess> related_lanes;
 
-  AppendResolvedLaneIdsToSet(road_id, signal.s, signal.validities, signal.orientation, road_geometry, &related_lanes);
+  AppendResolvedLaneIdsToSet(road_id, s_coordinate, signal.validities, signal.orientation, road_geometry, &related_lanes);
 
   for (const auto& ref_ctx : signal_references) {
     AppendResolvedLaneIdsToSet(ref_ctx.road_id, ref_ctx.signal_reference.s, ref_ctx.signal_reference.validities,
@@ -806,16 +806,16 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(
 }
 
 std::vector<maliput::api::LaneId> ResolveLaneIds(
-    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+    const xodr::object::Object& object, double s_coordinate, const xodr::RoadHeader::Id& road_id,
     const std::vector<xodr::DBManager::ObjectReferenceOnRoad>& object_references,
     const maliput::api::RoadGeometry* road_geometry) {
   std::set<maliput::api::LaneId, LaneIdStringLess> related_lanes;
 
   if (object.orientation.has_value()) {
-    AppendResolvedLaneIdsToSet(road_id, object.s, object.validities, object.orientation.value(), road_geometry,
+    AppendResolvedLaneIdsToSet(road_id, s_coordinate, object.validities, object.orientation.value(), road_geometry,
                                &related_lanes);
   } else {
-    auto main_lanes = ResolveLaneIds(road_id, object.s, object.validities, road_geometry);
+    auto main_lanes = ResolveLaneIds(road_id, s_coordinate, object.validities, road_geometry);
     related_lanes.insert(main_lanes.begin(), main_lanes.end());
   }
 

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -29,7 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/builder/builder_tools.h"
 
-#include <algorithm>
 #include <cmath>
 #include <map>
 #include <set>
@@ -784,38 +783,7 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& roa
   return result;
 }
 
-std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& road_id, double s_coordinate,
-                                                 const std::vector<xodr::Validity>& validities,
-                                                 xodr::Orientation orientation,
-                                                 const maliput::api::RoadGeometry* road_geometry) {
-  std::set<maliput::api::LaneId, LaneIdStringLess> lane_ids;
-  AppendResolvedLaneIdsToSet(road_id, s_coordinate, validities, orientation, road_geometry, &lane_ids);
-  return LaneIdsFromSet(lane_ids);
-}
-
-std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
-    const xodr::RoadHeader::Id& road_id, double s_coordinate, const std::vector<xodr::Validity>& validities,
-    const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
-    const maliput::api::RoadGeometry* road_geometry) {
-  auto related_lanes = ResolveLaneIds(road_id, s_coordinate, validities, road_geometry);
-
-  for (const auto& ref_ctx : signal_references) {
-    auto ref_lanes =
-        ResolveLaneIds(ref_ctx.road_id, ref_ctx.signal_reference.s, ref_ctx.signal_reference.validities, road_geometry);
-    related_lanes.insert(related_lanes.end(), std::make_move_iterator(ref_lanes.begin()),
-                         std::make_move_iterator(ref_lanes.end()));
-  }
-
-  std::sort(related_lanes.begin(), related_lanes.end(),
-            [](const auto& a, const auto& b) { return a.string() < b.string(); });
-  related_lanes.erase(std::unique(related_lanes.begin(), related_lanes.end(),
-                                  [](const auto& a, const auto& b) { return a.string() == b.string(); }),
-                      related_lanes.end());
-
-  return related_lanes;
-}
-
-std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
+std::vector<maliput::api::LaneId> ResolveLaneIds(
     const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
     const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
     const maliput::api::RoadGeometry* road_geometry) {
@@ -826,6 +794,28 @@ std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
   for (const auto& ref_ctx : signal_references) {
     AppendResolvedLaneIdsToSet(ref_ctx.road_id, ref_ctx.signal_reference.s, ref_ctx.signal_reference.validities,
                                ref_ctx.signal_reference.orientation, road_geometry, &related_lanes);
+  }
+
+  return LaneIdsFromSet(related_lanes);
+}
+
+std::vector<maliput::api::LaneId> ResolveLaneIds(
+    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+    const std::vector<xodr::DBManager::ObjectReferenceOnRoad>& object_references,
+    const maliput::api::RoadGeometry* road_geometry) {
+  std::set<maliput::api::LaneId, LaneIdStringLess> related_lanes;
+
+  if (object.orientation.has_value()) {
+    AppendResolvedLaneIdsToSet(road_id, object.s, object.validities, object.orientation.value(), road_geometry,
+                               &related_lanes);
+  } else {
+    auto main_lanes = ResolveLaneIds(road_id, object.s, object.validities, road_geometry);
+    related_lanes.insert(main_lanes.begin(), main_lanes.end());
+  }
+
+  for (const auto& ref_ctx : object_references) {
+    AppendResolvedLaneIdsToSet(ref_ctx.road_id, ref_ctx.object_reference.s, ref_ctx.object_reference.validities,
+                               ref_ctx.object_reference.orientation, road_geometry, &related_lanes);
   }
 
   return LaneIdsFromSet(related_lanes);

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/builder/builder_tools.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <map>
@@ -799,7 +800,9 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(
                              &related_lanes);
 
   for (const auto& ref_ctx : signal_references) {
-    AppendResolvedLaneIdsToSet(ref_ctx.road_id, ref_ctx.signal_reference.s, ref_ctx.signal_reference.validities,
+    const double adjusted_ref_s = AdjustSCoordinateToLaneSection(
+        road_geometry, ref_ctx.road_id, ref_ctx.signal_reference.s, ref_ctx.signal_reference.signal_id.string());
+    AppendResolvedLaneIdsToSet(ref_ctx.road_id, adjusted_ref_s, ref_ctx.signal_reference.validities,
                                ref_ctx.signal_reference.orientation, road_geometry, &related_lanes);
   }
 
@@ -821,7 +824,9 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(
   }
 
   for (const auto& ref_ctx : object_references) {
-    AppendResolvedLaneIdsToSet(ref_ctx.road_id, ref_ctx.object_reference.s, ref_ctx.object_reference.validities,
+    const double adjusted_ref_s = AdjustSCoordinateToLaneSection(
+        road_geometry, ref_ctx.road_id, ref_ctx.object_reference.s, ref_ctx.object_reference.id.string());
+    AppendResolvedLaneIdsToSet(ref_ctx.road_id, adjusted_ref_s, ref_ctx.object_reference.validities,
                                ref_ctx.object_reference.orientation, road_geometry, &related_lanes);
   }
 

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -368,6 +368,10 @@ std::vector<maliput::api::LaneEnd> SolveLaneEndsForInnerLaneSection(
 
 namespace {
 
+static const char* kLaneDirectionBidirectional = "Bidirectional";
+static const char* kLaneDirectionWithS = "WithS";
+static const char* kLaneDirectionAgainstS = "AgainstS";
+
 const std::map<std::string, LaneTravelDirection::Direction> str_to_direction_map{
     {"undirected", LaneTravelDirection::Direction::kUndirected},
     {"forward", LaneTravelDirection::Direction::kForward},
@@ -375,10 +379,10 @@ const std::map<std::string, LaneTravelDirection::Direction> str_to_direction_map
     {"bidirectional", LaneTravelDirection::Direction::kBidirectional}};
 
 const std::map<LaneTravelDirection::Direction, std::string> xodr_to_maliput_direction{
-    {LaneTravelDirection::Direction::kUndirected, "Bidirectional"},
-    {LaneTravelDirection::Direction::kForward, "WithS"},
-    {LaneTravelDirection::Direction::kBackward, "AgainstS"},
-    {LaneTravelDirection::Direction::kBidirectional, "Bidirectional"}};
+    {LaneTravelDirection::Direction::kUndirected, kLaneDirectionBidirectional},
+    {LaneTravelDirection::Direction::kForward, kLaneDirectionWithS},
+    {LaneTravelDirection::Direction::kBackward, kLaneDirectionAgainstS},
+    {LaneTravelDirection::Direction::kBidirectional, kLaneDirectionBidirectional}};
 
 }  // namespace
 
@@ -640,6 +644,94 @@ std::optional<double> FindLocalMinFromCubicPol(double a, double b, double c, dou
   return p_local_min;
 }
 
+namespace {
+
+struct LaneIdStringLess {
+  bool operator()(const maliput::api::LaneId& lhs, const maliput::api::LaneId& rhs) const {
+    return lhs.string() < rhs.string();
+  }
+};
+
+bool LaneDirectionMatchesOrientation(const std::string& lane_direction, xodr::Orientation orientation) {
+  if (lane_direction == kLaneDirectionBidirectional || orientation == xodr::Orientation::kBidirectional) {
+    return true;
+  }
+  if (orientation == xodr::Orientation::kWithS) {
+    return lane_direction == kLaneDirectionWithS;
+  }
+  if (orientation == xodr::Orientation::kAgainstS) {
+    return lane_direction == kLaneDirectionAgainstS;
+  }
+  return false;
+}
+
+std::vector<maliput::api::LaneId> LaneIdsFromSet(const std::set<maliput::api::LaneId, LaneIdStringLess>& lane_ids) {
+  return {lane_ids.begin(), lane_ids.end()};
+}
+
+void AppendResolvedLaneIdsToSet(const xodr::RoadHeader::Id& road_id, double s_coordinate,
+                                const std::vector<xodr::Validity>& validities, xodr::Orientation orientation,
+                                const maliput::api::RoadGeometry* road_geometry,
+                                std::set<maliput::api::LaneId, LaneIdStringLess>* lane_ids) {
+  MALIDRIVE_THROW_UNLESS(lane_ids != nullptr);
+
+  const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry);
+  MALIDRIVE_VALIDATE(mali_rg != nullptr, maliput::common::road_geometry_construction_error,
+                     "RoadGeometry cannot be cast to malidrive::RoadGeometry.");
+
+  const auto& road_headers = mali_rg->get_manager()->GetRoadHeaders();
+  const auto it = road_headers.find(road_id);
+  MALIDRIVE_VALIDATE(it != road_headers.end(), maliput::common::road_geometry_construction_error,
+                     "Road header not found for road_id: " + road_id.string());
+
+  const auto& road_header = it->second;
+  const int xodr_track_id = std::stoi(road_id.string());
+  const int lane_section_index = road_header.GetLaneSectionIndex(s_coordinate);
+  const auto& lane_section = road_header.lanes.lanes_section.at(lane_section_index);
+
+  std::vector<int> xodr_lane_ids;
+  if (validities.empty()) {
+    for (const auto& lane : lane_section.left_lanes) {
+      xodr_lane_ids.push_back(std::stoi(lane.id.string()));
+    }
+    for (const auto& lane : lane_section.right_lanes) {
+      xodr_lane_ids.push_back(std::stoi(lane.id.string()));
+    }
+  } else {
+    for (const auto& validity : validities) {
+      const int from = std::stoi(validity.from_lane.string());
+      const int to = std::stoi(validity.to_lane.string());
+      for (int lane_id = from; lane_id <= to; ++lane_id) {
+        if (lane_id != 0) {
+          xodr_lane_ids.push_back(lane_id);
+        }
+      }
+    }
+  }
+
+  for (int xodr_lane_id : xodr_lane_ids) {
+    const auto lane_id = GetLaneId(xodr_track_id, lane_section_index, xodr_lane_id);
+    const maliput::api::Lane* lane = road_geometry->ById().GetLane(lane_id);
+    if (lane == nullptr) {
+      continue;
+    }
+
+    const auto* mali_lane = dynamic_cast<const malidrive::Lane*>(lane);
+    MALIDRIVE_THROW_UNLESS(mali_lane != nullptr);
+
+    const xodr::RoadHeader& xodr_road = GetXodrRoadFromMalidriveLane(mali_lane);
+    const xodr::Lane& xodr_lane = GetXodrLaneFromMalidriveLane(mali_lane);
+    const std::string lane_direction = GetDirectionUsageRuleStateType(xodr_road, xodr_lane);
+    if (!LaneDirectionMatchesOrientation(lane_direction, orientation)) {
+      continue;
+    }
+
+    lane_ids->insert(lane_id);
+  }
+}
+
+}  // namespace
+
 std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& road_id, double s_coordinate,
                                                  const std::vector<xodr::Validity>& validities,
                                                  const maliput::api::RoadGeometry* road_geometry) {
@@ -692,6 +784,15 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& roa
   return result;
 }
 
+std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& road_id, double s_coordinate,
+                                                 const std::vector<xodr::Validity>& validities,
+                                                 xodr::Orientation orientation,
+                                                 const maliput::api::RoadGeometry* road_geometry) {
+  std::set<maliput::api::LaneId, LaneIdStringLess> lane_ids;
+  AppendResolvedLaneIdsToSet(road_id, s_coordinate, validities, orientation, road_geometry, &lane_ids);
+  return LaneIdsFromSet(lane_ids);
+}
+
 std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
     const xodr::RoadHeader::Id& road_id, double s_coordinate, const std::vector<xodr::Validity>& validities,
     const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
@@ -712,6 +813,60 @@ std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
                       related_lanes.end());
 
   return related_lanes;
+}
+
+std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
+    const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
+    const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
+    const maliput::api::RoadGeometry* road_geometry) {
+  std::set<maliput::api::LaneId, LaneIdStringLess> related_lanes;
+
+  AppendResolvedLaneIdsToSet(road_id, signal.s, signal.validities, signal.orientation, road_geometry, &related_lanes);
+
+  for (const auto& ref_ctx : signal_references) {
+    AppendResolvedLaneIdsToSet(ref_ctx.road_id, ref_ctx.signal_reference.s, ref_ctx.signal_reference.validities,
+                               ref_ctx.signal_reference.orientation, road_geometry, &related_lanes);
+  }
+
+  return LaneIdsFromSet(related_lanes);
+}
+
+std::vector<maliput::api::LaneId> FilterLaneIdsBySignalOrientation(const std::vector<maliput::api::LaneId>& lane_ids,
+                                                                   xodr::Orientation signal_orientation,
+                                                                   const maliput::api::RoadGeometry* road_geometry) {
+  MALIDRIVE_THROW_UNLESS(road_geometry != nullptr);
+
+  // kBidirectional signal_orientation means no filtering: accept all lanes.
+  if (signal_orientation == xodr::Orientation::kBidirectional) {
+    return lane_ids;
+  }
+
+  std::vector<maliput::api::LaneId> filtered_lanes;
+  for (const auto& lane_id : lane_ids) {
+    const maliput::api::Lane* lane = road_geometry->ById().GetLane(lane_id);
+    const malidrive::Lane* mali_lane = dynamic_cast<const malidrive::Lane*>(lane);
+    MALIDRIVE_THROW_UNLESS(mali_lane != nullptr);
+
+    const xodr::RoadHeader& xodr_road = GetXodrRoadFromMalidriveLane(mali_lane);
+    const xodr::Lane& xodr_lane = GetXodrLaneFromMalidriveLane(mali_lane);
+
+    const std::string lane_direction = GetDirectionUsageRuleStateType(xodr_road, xodr_lane);
+
+    // Bidirectional lanes always match.
+    if (lane_direction == kLaneDirectionBidirectional) {
+      filtered_lanes.push_back(lane_id);
+      continue;
+    }
+
+    // Filter based on signal_orientation.
+    if (signal_orientation == xodr::Orientation::kWithS && lane_direction == kLaneDirectionWithS) {
+      filtered_lanes.push_back(lane_id);
+    } else if (signal_orientation == xodr::Orientation::kAgainstS && lane_direction == kLaneDirectionAgainstS) {
+      filtered_lanes.push_back(lane_id);
+    }
+  }
+
+  return filtered_lanes;
 }
 
 std::vector<std::unique_ptr<maliput::api::objects::Outline>> BuildOutlines(

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -30,8 +30,10 @@
 #include "maliput_malidrive/builder/builder_tools.h"
 
 #include <cmath>
+#include <iomanip>
 #include <map>
 #include <set>
+#include <sstream>
 
 #include <maliput/api/lane.h>
 #include <maliput/api/objects/road_object.h>
@@ -48,6 +50,8 @@
 #include "maliput_malidrive/xodr/road_link.h"
 
 using maliput::api::LaneId;
+
+static constexpr double kEpsilon{1e-10};
 
 namespace malidrive {
 namespace builder {
@@ -91,6 +95,8 @@ const std::map<xodr::Lane::Type, XodrLaneProperties> kXodrLaneTypesToMaliputProp
     {xodr::Lane::Type::kOffRamp, {true, "NonPedestrians", {}}},
     {xodr::Lane::Type::kConnectingRamp, {true, "NonPedestrians", {}}},
 };
+
+bool is_almost_equal(double a, double b) { return std::abs(a - b) < kEpsilon; }
 
 }  // namespace
 
@@ -906,6 +912,23 @@ std::vector<std::unique_ptr<maliput::api::objects::Outline>> BuildOutlines(
     ++outline_index;
   }
   return result;
+}
+
+double AdjustSCoordinateToLaneSection(const maliput::api::RoadGeometry* road_geometry,
+                                      const xodr::RoadHeader::Id& road_id, double s_coordinate, const std::string& id) {
+  const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry);
+  MALIDRIVE_VALIDATE(mali_rg != nullptr, maliput::common::assertion_error,
+                     "RoadGeometry cannot be cast to malidrive::RoadGeometry.");
+  if (is_almost_equal(s_coordinate, mali_rg->GetRoadCurve(road_id)->p1())) {
+    std::ostringstream s_str, adjusted_s_str;
+    s_str << std::fixed << std::setprecision(10) << s_coordinate;
+    adjusted_s_str << std::fixed << std::setprecision(10) << (s_coordinate - kEpsilon);
+    maliput::log()->warn("XODR element with ID ", id, " has s coordinate ", s_str.str(),
+                         " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
+                         " to avoid potential issues with lane association and orientation.");
+    s_coordinate -= kEpsilon;
+  }
+  return s_coordinate;
 }
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/builder_tools.cc
+++ b/src/maliput_malidrive/builder/builder_tools.cc
@@ -795,7 +795,8 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(
     const maliput::api::RoadGeometry* road_geometry) {
   std::set<maliput::api::LaneId, LaneIdStringLess> related_lanes;
 
-  AppendResolvedLaneIdsToSet(road_id, s_coordinate, signal.validities, signal.orientation, road_geometry, &related_lanes);
+  AppendResolvedLaneIdsToSet(road_id, s_coordinate, signal.validities, signal.orientation, road_geometry,
+                             &related_lanes);
 
   for (const auto& ref_ctx : signal_references) {
     AppendResolvedLaneIdsToSet(ref_ctx.road_id, ref_ctx.signal_reference.s, ref_ctx.signal_reference.validities,

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -453,12 +453,13 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& roa
 /// being returned.
 ///
 /// @param signal The signal whose related lanes are being resolved.
+/// @param s_coordinate The signal's s-coordinate along the road, could slightly vary from the @p signal due to adjustments.
 /// @param road_id The XODR road ID that contains the signal.
 /// @param signal_references Additional roads that reference the same signal.
 /// @param road_geometry Pointer to the built road geometry.
 /// @returns A sorted, deduplicated vector of maliput LaneIds.
 std::vector<maliput::api::LaneId> ResolveLaneIds(
-    const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
+    const xodr::signal::Signal& signal, double s_coordinate, const xodr::RoadHeader::Id& road_id,
     const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
     const maliput::api::RoadGeometry* road_geometry);
 
@@ -470,12 +471,13 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(
 /// being returned.
 ///
 /// @param object The object whose related lanes are being resolved.
+/// @param s_coordinate The object's s-coordinate along the road, could slightly vary from the @p object due to adjustments.
 /// @param road_id The XODR road ID that contains the object.
 /// @param object_references Additional roads that reference the same object.
 /// @param road_geometry Pointer to the built road geometry.
 /// @returns A sorted, deduplicated vector of maliput LaneIds.
 std::vector<maliput::api::LaneId> ResolveLaneIds(
-    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+    const xodr::object::Object& object, double s_coordinate, const xodr::RoadHeader::Id& road_id,
     const std::vector<xodr::DBManager::ObjectReferenceOnRoad>& object_references,
     const maliput::api::RoadGeometry* road_geometry);
 

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -453,7 +453,8 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& roa
 /// being returned.
 ///
 /// @param signal The signal whose related lanes are being resolved.
-/// @param s_coordinate The signal's s-coordinate along the road, could slightly vary from the @p signal due to adjustments.
+/// @param s_coordinate The signal's s-coordinate along the road, could slightly vary from the @p signal due to
+/// adjustments.
 /// @param road_id The XODR road ID that contains the signal.
 /// @param signal_references Additional roads that reference the same signal.
 /// @param road_geometry Pointer to the built road geometry.
@@ -471,7 +472,8 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(
 /// being returned.
 ///
 /// @param object The object whose related lanes are being resolved.
-/// @param s_coordinate The object's s-coordinate along the road, could slightly vary from the @p object due to adjustments.
+/// @param s_coordinate The object's s-coordinate along the road, could slightly vary from the @p object due to
+/// adjustments.
 /// @param road_id The XODR road ID that contains the object.
 /// @param object_references Additional roads that reference the same object.
 /// @param road_geometry Pointer to the built road geometry.

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -41,11 +41,13 @@
 #include "maliput_malidrive/base/lane.h"
 #include "maliput_malidrive/builder/rule_tools.h"
 #include "maliput_malidrive/common/macros.h"
+#include "maliput_malidrive/xodr/common.h"
 #include "maliput_malidrive/xodr/db_manager.h"
 #include "maliput_malidrive/xodr/junction.h"
 #include "maliput_malidrive/xodr/lane.h"
 #include "maliput_malidrive/xodr/object/object.h"
 #include "maliput_malidrive/xodr/road_header.h"
+#include "maliput_malidrive/xodr/signal/signal.h"
 #include "maliput_malidrive/xodr/validity.h"
 
 namespace malidrive {
@@ -443,6 +445,25 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& roa
                                                  const std::vector<xodr::Validity>& validities,
                                                  const maliput::api::RoadGeometry* road_geometry);
 
+/// Resolves lane IDs for a single signal-related source, applying both
+/// orientation-based lane selection and validity filtering in one pass.
+///
+/// The selected lanes are those that exist in the RoadGeometry, lie in the
+/// requested road section, and are compatible with @p orientation according to
+/// the road's traffic-direction rule. The validity ranges then prune that set
+/// further, but cannot introduce lanes that were not already candidates.
+///
+/// @param road_id The XODR road ID whose lane section should be inspected.
+/// @param s_coordinate The s-coordinate along the road, used to identify the target lane section.
+/// @param validities The XODR validity ranges. Empty means all lanes in the section.
+/// @param orientation The signal orientation used to filter lanes by travel direction.
+/// @param road_geometry Pointer to the built road geometry (must be castable to malidrive::RoadGeometry).
+/// @returns A vector of maliput LaneIds that satisfy orientation, validity, and built-lane constraints.
+std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& road_id, double s_coordinate,
+                                                 const std::vector<xodr::Validity>& validities,
+                                                 xodr::Orientation orientation,
+                                                 const maliput::api::RoadGeometry* road_geometry);
+
 /// Resolves the related lane IDs for a signal from its own road and from any
 /// signal references on other roads, then deduplicates the result.
 ///
@@ -462,6 +483,38 @@ std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
     const xodr::RoadHeader::Id& road_id, double s_coordinate, const std::vector<xodr::Validity>& validities,
     const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
     const maliput::api::RoadGeometry* road_geometry);
+
+/// Resolves and deduplicates the lane IDs related to a signal and its signal
+/// references in one pass per source.
+///
+/// Each source road is processed independently with its own orientation and
+/// validity. The resulting lane IDs are merged into a deduplicated set before
+/// being returned.
+///
+/// @param signal The signal whose related lanes are being resolved.
+/// @param road_id The XODR road ID that contains the signal.
+/// @param signal_references Additional roads that reference the same signal.
+/// @param road_geometry Pointer to the built road geometry.
+/// @returns A sorted, deduplicated vector of maliput LaneIds.
+std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
+    const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
+    const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
+    const maliput::api::RoadGeometry* road_geometry);
+
+/// Filters lane_ids to those whose travel direction is compatible with orientation.
+/// - kWithS:        keep lanes whose direction is "WithS" or "Bidirectional"
+/// - kAgainstS:     keep lanes whose direction is "AgainstS" or "Bidirectional"
+/// - kBidirectional: keep all (no filter)
+///
+/// @param lane_ids Candidate lane IDs (already resolved and built into the RG).
+/// @param orientation Signal/object orientation from XODR (unified xodr::Orientation enum).
+/// @param road_geometry Pointer to the road geometry (must not be nullptr).
+/// @returns Filtered subset of lane_ids.
+///
+/// @throws maliput::common::assertion_error When @p road_geometry is nullptr.
+std::vector<maliput::api::LaneId> FilterLaneIdsBySignalOrientation(const std::vector<maliput::api::LaneId>& lane_ids,
+                                                                   xodr::Orientation orientation,
+                                                                   const maliput::api::RoadGeometry* road_geometry);
 
 /// Converts XODR outline corners to maliput Outlines.
 ///

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -512,5 +512,16 @@ std::vector<std::unique_ptr<maliput::api::objects::Outline>> BuildOutlines(
     const maliput::api::RoadGeometry* road_geometry, const maliput::api::InertialPosition& object_inertial_pos,
     const maliput::api::Rotation& object_orientation);
 
+/// Adjusts the s-coordinate to be within the valid range of the road geometry.
+///
+/// @param road_geometry Pointer to the road geometry (must be castable to malidrive::RoadGeometry).
+/// @param road_id The ID of the road to which the s-coordinate belongs.
+/// @param s_coordinate The s-coordinate to be adjusted. It may be outside the valid range of the road.
+/// @param id The ID of the XODR element (e.g., signal, object) associated with the s-coordinate. This is used for
+/// logging and error messages.
+/// @return The adjusted s-coordinate, clamped to the valid range of the road geometry.
+double AdjustSCoordinateToLaneSection(const maliput::api::RoadGeometry* road_geometry,
+                                      const xodr::RoadHeader::Id& road_id, double s_coordinate, const std::string& id);
+
 }  // namespace builder
 }  // namespace malidrive

--- a/src/maliput_malidrive/builder/builder_tools.h
+++ b/src/maliput_malidrive/builder/builder_tools.h
@@ -445,46 +445,7 @@ std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& roa
                                                  const std::vector<xodr::Validity>& validities,
                                                  const maliput::api::RoadGeometry* road_geometry);
 
-/// Resolves lane IDs for a single signal-related source, applying both
-/// orientation-based lane selection and validity filtering in one pass.
-///
-/// The selected lanes are those that exist in the RoadGeometry, lie in the
-/// requested road section, and are compatible with @p orientation according to
-/// the road's traffic-direction rule. The validity ranges then prune that set
-/// further, but cannot introduce lanes that were not already candidates.
-///
-/// @param road_id The XODR road ID whose lane section should be inspected.
-/// @param s_coordinate The s-coordinate along the road, used to identify the target lane section.
-/// @param validities The XODR validity ranges. Empty means all lanes in the section.
-/// @param orientation The signal orientation used to filter lanes by travel direction.
-/// @param road_geometry Pointer to the built road geometry (must be castable to malidrive::RoadGeometry).
-/// @returns A vector of maliput LaneIds that satisfy orientation, validity, and built-lane constraints.
-std::vector<maliput::api::LaneId> ResolveLaneIds(const xodr::RoadHeader::Id& road_id, double s_coordinate,
-                                                 const std::vector<xodr::Validity>& validities,
-                                                 xodr::Orientation orientation,
-                                                 const maliput::api::RoadGeometry* road_geometry);
-
-/// Resolves the related lane IDs for a signal from its own road and from any
-/// signal references on other roads, then deduplicates the result.
-///
-/// This combines @ref ResolveLaneIds calls for the primary road and every
-/// @p signal_references entry, appending all results before performing a
-/// sort-then-unique deduplication. Duplicates are unlikely with well-formed
-/// XODR files but could occur when a road references its own signal via a
-/// `<signalReference>` element.
-///
-/// @param road_id The XODR road ID of the signal's own road.
-/// @param s_coordinate The s-coordinate of the signal on its own road.
-/// @param validities The XODR validity ranges for the signal's own road.
-/// @param signal_references Additional roads that reference the same signal.
-/// @param road_geometry Pointer to the built road geometry.
-/// @returns A sorted, deduplicated vector of maliput LaneIds.
-std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
-    const xodr::RoadHeader::Id& road_id, double s_coordinate, const std::vector<xodr::Validity>& validities,
-    const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
-    const maliput::api::RoadGeometry* road_geometry);
-
-/// Resolves and deduplicates the lane IDs related to a signal and its signal
+/// Resolves the lane IDs related to a signal and its signal
 /// references in one pass per source.
 ///
 /// Each source road is processed independently with its own orientation and
@@ -496,9 +457,26 @@ std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
 /// @param signal_references Additional roads that reference the same signal.
 /// @param road_geometry Pointer to the built road geometry.
 /// @returns A sorted, deduplicated vector of maliput LaneIds.
-std::vector<maliput::api::LaneId> ResolveAndDeduplicateLaneIds(
+std::vector<maliput::api::LaneId> ResolveLaneIds(
     const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
     const std::vector<xodr::DBManager::SignalReferenceOnRoad>& signal_references,
+    const maliput::api::RoadGeometry* road_geometry);
+
+/// Resolves the lane IDs related to an object and its object
+/// references in one pass per source.
+///
+/// Each source road is processed independently with its own orientation and
+/// validity. The resulting lane IDs are merged into a deduplicated set before
+/// being returned.
+///
+/// @param object The object whose related lanes are being resolved.
+/// @param road_id The XODR road ID that contains the object.
+/// @param object_references Additional roads that reference the same object.
+/// @param road_geometry Pointer to the built road geometry.
+/// @returns A sorted, deduplicated vector of maliput LaneIds.
+std::vector<maliput::api::LaneId> ResolveLaneIds(
+    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+    const std::vector<xodr::DBManager::ObjectReferenceOnRoad>& object_references,
     const maliput::api::RoadGeometry* road_geometry);
 
 /// Filters lane_ids to those whose travel direction is compatible with orientation.

--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -69,8 +69,14 @@ namespace builder {
 RoadMarkingBuilder::RoadMarkingBuilder(SourceType source_type, const xodr::signal::Signal& signal,
                                        const xodr::RoadHeader::Id& road_id,
                                        const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
-                                       const maliput::api::RoadGeometry* road_geometry)
-    : source_type_(source_type), signal_(&signal), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+                                       const maliput::api::RoadGeometry* road_geometry,
+                                       std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references)
+    : source_type_(source_type),
+      signal_(&signal),
+      road_id_(road_id),
+      loader_(loader),
+      road_geometry_(road_geometry),
+      signal_references_(std::move(signal_references)) {
   MALIDRIVE_VALIDATE(source_type_ == SourceType::kSignal, std::invalid_argument,
                      "RoadMarkingBuilder signal constructor requires SourceType::kSignal.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
@@ -79,8 +85,14 @@ RoadMarkingBuilder::RoadMarkingBuilder(SourceType source_type, const xodr::signa
 RoadMarkingBuilder::RoadMarkingBuilder(SourceType source_type, const xodr::object::Object& object,
                                        const xodr::RoadHeader::Id& road_id,
                                        const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
-                                       const maliput::api::RoadGeometry* road_geometry)
-    : source_type_(source_type), object_(&object), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+                                       const maliput::api::RoadGeometry* road_geometry,
+                                       std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references)
+    : source_type_(source_type),
+      object_(&object),
+      road_id_(road_id),
+      loader_(loader),
+      road_geometry_(road_geometry),
+      object_references_(std::move(object_references)) {
   MALIDRIVE_VALIDATE(source_type_ == SourceType::kObject, std::invalid_argument,
                      "RoadMarkingBuilder object constructor requires SourceType::kObject.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
@@ -167,7 +179,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
                                                     maliput::math::Vector3(bb_length, bb_width, bb_height),
                                                     maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
-      auto related_lanes = ResolveLaneIds(road_id_, object_s, object.validities, road_geometry_);
+      auto related_lanes = ResolveLaneIds(object, road_id_, object_references_, road_geometry_);
       auto outlines = BuildOutlines(object, road_id_, road_geometry_, inertial_pos, orientation);
 
       maliput::log()->debug("RoadMarkingBuilder: creating RoadMarking id='", object.id.string(),
@@ -243,7 +255,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
                                                     maliput::math::Vector3(bb_length, bb_width, bb_height),
                                                     maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
-      auto related_lanes = ResolveLaneIds(road_id_, signal_s, signal.validities, road_geometry_);
+      auto related_lanes = ResolveLaneIds(signal, road_id_, signal_references_, road_geometry_);
 
       maliput::log()->debug("RoadMarkingBuilder: creating RoadMarking id='", signal.id.string(),
                             "' type=", static_cast<int>(marking_type), " position=(", inertial_pos.x(), ", ",

--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -48,11 +48,7 @@
 #include "maliput_malidrive/common/macros.h"
 #include "maliput_malidrive/traffic_control_device/parser.h"
 
-static constexpr double kEpsilon{1e-10};
-
 namespace {
-
-bool is_almost_equal(double a, double b) { return std::abs(a - b) < kEpsilon; }
 
 std::optional<std::string> NormalizeSubtype(const std::string& subtype) {
   if (subtype.empty() || subtype == "-1" || subtype == "none") {
@@ -136,17 +132,11 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
                               "'. Defaulting to RoadMarkingType::kUnknown.");
       }
 
-      double object_s = object.s;
-      if (is_almost_equal(object.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
-        std::ostringstream s_str, adjusted_s_str;
-        s_str << std::fixed << std::setprecision(10) << object.s;
-        adjusted_s_str << std::fixed << std::setprecision(10) << (object.s - kEpsilon);
-        maliput::log()->warn("RoadMarkingBuilder: Object ", object.id.string(), " has s coordinate ", s_str.str(),
-                             " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
-                             " to avoid potential issues with lane association and orientation.");
-        object_s -= kEpsilon;
+      double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, object.s, object.id.string());
+      if (adjusted_s != object.s) {
+        object.s = adjusted_s;
       }
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object_s,
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object.s,
                                                                                 object.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
@@ -220,17 +210,12 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
                               "'. Defaulting to RoadMarkingType::kUnknown.");
       }
 
-      double signal_s = signal.s;
-      if (is_almost_equal(signal.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
-        std::ostringstream s_str, adjusted_s_str;
-        s_str << std::fixed << std::setprecision(10) << signal.s;
-        adjusted_s_str << std::fixed << std::setprecision(10) << (signal.s - kEpsilon);
-        maliput::log()->warn("RoadMarkingBuilder: Signal ", signal.id.string(), " has s coordinate ", s_str.str(),
-                             " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
-                             " to avoid potential issues with lane association and orientation.");
-        signal_s -= kEpsilon;
+      double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal_.s, signal_.id.string());
+      if (adjusted_s != signal_.s) {
+        signal_.s = adjusted_s;
       }
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal_s,
+
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal.s,
                                                                                 signal.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);

--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -133,8 +133,8 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
       }
 
       double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, object.s, object.id.string());
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
-                                                                                object.t};
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()),
+                                                                                adjusted_s, object.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
       maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
@@ -208,8 +208,8 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
       }
 
       double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal.s, signal.id.string());
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
-                                                                                signal.t};
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()),
+                                                                                adjusted_s, signal.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
       maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();

--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -133,10 +133,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
       }
 
       double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, object.s, object.id.string());
-      if (adjusted_s != object.s) {
-        object.s = adjusted_s;
-      }
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object.s,
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
                                                                                 object.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
@@ -169,7 +166,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
                                                     maliput::math::Vector3(bb_length, bb_width, bb_height),
                                                     maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
-      auto related_lanes = ResolveLaneIds(object, road_id_, object_references_, road_geometry_);
+      auto related_lanes = ResolveLaneIds(object, adjusted_s, road_id_, object_references_, road_geometry_);
       auto outlines = BuildOutlines(object, road_id_, road_geometry_, inertial_pos, orientation);
 
       maliput::log()->debug("RoadMarkingBuilder: creating RoadMarking id='", object.id.string(),
@@ -210,12 +207,8 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
                               "'. Defaulting to RoadMarkingType::kUnknown.");
       }
 
-      double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal_.s, signal_.id.string());
-      if (adjusted_s != signal_.s) {
-        signal_.s = adjusted_s;
-      }
-
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal.s,
+      double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal.s, signal.id.string());
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
                                                                                 signal.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
@@ -240,7 +233,7 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
                                                     maliput::math::Vector3(bb_length, bb_width, bb_height),
                                                     maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
-      auto related_lanes = ResolveLaneIds(signal, road_id_, signal_references_, road_geometry_);
+      auto related_lanes = ResolveLaneIds(signal, adjusted_s, road_id_, signal_references_, road_geometry_);
 
       maliput::log()->debug("RoadMarkingBuilder: creating RoadMarking id='", signal.id.string(),
                             "' type=", static_cast<int>(marking_type), " position=(", inertial_pos.x(), ", ",

--- a/src/maliput_malidrive/builder/road_marking_builder.h
+++ b/src/maliput_malidrive/builder/road_marking_builder.h
@@ -29,11 +29,13 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <maliput/api/objects/road_marking.h>
 #include <maliput/api/road_geometry.h>
 
 #include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
+#include "maliput_malidrive/xodr/db_manager.h"
 #include "maliput_malidrive/xodr/object/object.h"
 #include "maliput_malidrive/xodr/road_header.h"
 #include "maliput_malidrive/xodr/signal/signal.h"
@@ -69,10 +71,12 @@ class RoadMarkingBuilder {
   /// @param loader The @ref traffic_control_device::TrafficControlDeviceDatabaseLoader providing access
   ///        to the traffic control device YAML database.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
+  /// @param object_references Object references from other roads that point to @p object.
   /// @throws std::invalid_argument if @p source_type is not kObject or @p road_geometry is nullptr.
   RoadMarkingBuilder(SourceType source_type, const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
-                     const maliput::api::RoadGeometry* road_geometry);
+                     const maliput::api::RoadGeometry* road_geometry,
+                     std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references = {});
 
   /// Constructs a RoadMarkingBuilder.
   ///
@@ -82,10 +86,12 @@ class RoadMarkingBuilder {
   /// @param loader The @ref traffic_control_device::TrafficControlDeviceDatabaseLoader providing access
   ///        to the traffic control device YAML database.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
+  /// @param signal_references Signal references from other roads that point to @p signal.
   /// @throws std::invalid_argument if @p source_type is not kSignal or @p road_geometry is nullptr.
   RoadMarkingBuilder(SourceType source_type, const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
-                     const maliput::api::RoadGeometry* road_geometry);
+                     const maliput::api::RoadGeometry* road_geometry,
+                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {});
 
   /// Builds and returns the @ref maliput::api::objects::RoadMarking.
   ///
@@ -100,6 +106,8 @@ class RoadMarkingBuilder {
   const xodr::RoadHeader::Id& road_id_;
   const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader_;
   const maliput::api::RoadGeometry* road_geometry_;
+  const std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references_;
+  const std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references_;
 };
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -98,8 +98,14 @@ std::optional<maliput::api::objects::RoadObjectType> StringToRoadObjectType(cons
 RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::object::Object& object,
                                      const xodr::RoadHeader::Id& road_id,
                                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
-                                     const maliput::api::RoadGeometry* road_geometry)
-    : source_type_(source_type), object_(&object), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+                                     const maliput::api::RoadGeometry* road_geometry,
+                                     std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references)
+    : source_type_(source_type),
+      object_(&object),
+      road_id_(road_id),
+      loader_(loader),
+      road_geometry_(road_geometry),
+      object_references_(std::move(object_references)) {
   MALIDRIVE_VALIDATE(source_type_ == SourceType::kObject, std::invalid_argument,
                      "RoadObjectBuilder object constructor requires SourceType::kObject.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
@@ -108,8 +114,14 @@ RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::object:
 RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::signal::Signal& signal,
                                      const xodr::RoadHeader::Id& road_id,
                                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
-                                     const maliput::api::RoadGeometry* road_geometry)
-    : source_type_(source_type), signal_(&signal), road_id_(road_id), loader_(loader), road_geometry_(road_geometry) {
+                                     const maliput::api::RoadGeometry* road_geometry,
+                                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references)
+    : source_type_(source_type),
+      signal_(&signal),
+      road_id_(road_id),
+      loader_(loader),
+      road_geometry_(road_geometry),
+      signal_references_(std::move(signal_references)) {
   MALIDRIVE_VALIDATE(source_type_ == SourceType::kSignal, std::invalid_argument,
                      "RoadObjectBuilder signal constructor requires SourceType::kSignal.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
@@ -183,7 +195,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       // --- Type ---
       const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object.type, object.subtype);
       // --- Related lanes ---
-      auto related_lanes = ResolveLaneIds(road_id_, object_s, object.validities, road_geometry_);
+      auto related_lanes = ResolveLaneIds(object, road_id_, object_references_, road_geometry_);
       // --- Outlines ---
       auto outlines = BuildOutlines(object, road_id_, road_geometry_, inertial_pos, orientation);
 
@@ -262,7 +274,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
                                                     maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
       // --- Related lanes ---
-      auto related_lanes = ResolveLaneIds(road_id_, signal_s, signal.validities, road_geometry_);
+      auto related_lanes = ResolveLaneIds(signal, road_id_, signal_references_, road_geometry_);
       // --- Type ---
       const auto type = type_from_db.value_or(maliput::api::objects::RoadObjectType::kUnknown);
 

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -144,11 +144,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
 
       // --- Position ---
       double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, object.s, object.id.string());
-      if (adjusted_s != object.s) {
-        object.s = adjusted_s;
-      }
-
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object.s,
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
                                                                                 object.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
@@ -182,7 +178,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       // --- Type ---
       const maliput::api::objects::RoadObjectType type = MapXodrObjectType(object.type, object.subtype);
       // --- Related lanes ---
-      auto related_lanes = ResolveLaneIds(object, road_id_, object_references_, road_geometry_);
+      auto related_lanes = ResolveLaneIds(object, adjusted_s, road_id_, object_references_, road_geometry_);
       // --- Outlines ---
       auto outlines = BuildOutlines(object, road_id_, road_geometry_, inertial_pos, orientation);
 
@@ -220,12 +216,8 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       }
 
       // --- Position ---
-      double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal_.s, signal_.id.string());
-      if (adjusted_s != signal_.s) {
-        signal_.s = adjusted_s;
-      }
-
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal.s,
+      double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal.s, signal.id.string());
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
                                                                                 signal.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
@@ -255,7 +247,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
                                                     maliput::math::RollPitchYaw(0., 0., 0.), 1e-3};
 
       // --- Related lanes ---
-      auto related_lanes = ResolveLaneIds(signal, road_id_, signal_references_, road_geometry_);
+      auto related_lanes = ResolveLaneIds(signal, adjusted_s, road_id_, signal_references_, road_geometry_);
       // --- Type ---
       const auto type = type_from_db.value_or(maliput::api::objects::RoadObjectType::kUnknown);
 

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -144,8 +144,8 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
 
       // --- Position ---
       double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, object.s, object.id.string());
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
-                                                                                object.t};
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()),
+                                                                                adjusted_s, object.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
       maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
@@ -217,8 +217,8 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
 
       // --- Position ---
       double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal.s, signal.id.string());
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
-                                                                                signal.t};
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()),
+                                                                                adjusted_s, signal.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
       maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -48,13 +48,6 @@
 #include "maliput_malidrive/builder/road_object_type_mapper.h"
 #include "maliput_malidrive/common/macros.h"
 
-static constexpr double kEpsilon{1e-10};
-
-namespace {
-
-bool is_almost_equal(double a, double b) { return std::abs(a - b) < kEpsilon; }
-
-}  // namespace
 namespace malidrive {
 namespace builder {
 
@@ -150,18 +143,12 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       }
 
       // --- Position ---
-      double object_s = object.s;
-      if (is_almost_equal(object.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
-        std::ostringstream s_str, adjusted_s_str;
-        s_str << std::fixed << std::setprecision(10) << object.s;
-        adjusted_s_str << std::fixed << std::setprecision(10) << (object.s - kEpsilon);
-        maliput::log()->warn("RoadObjectBuilder: Object ", object.id.string(), " has s coordinate ", s_str.str(),
-                             " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
-                             " to avoid potential issues with lane association and orientation.");
-        object_s -= kEpsilon;
+      double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, object.s, object.id.string());
+      if (adjusted_s != object.s) {
+        object.s = adjusted_s;
       }
 
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object_s,
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), object.s,
                                                                                 object.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
@@ -233,18 +220,12 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       }
 
       // --- Position ---
-      double signal_s = signal.s;
-      if (is_almost_equal(signal.s, mali_rg->GetRoadCurve(road_id_)->p1())) {
-        std::ostringstream s_str, adjusted_s_str;
-        s_str << std::fixed << std::setprecision(10) << signal.s;
-        adjusted_s_str << std::fixed << std::setprecision(10) << (signal.s - kEpsilon);
-        maliput::log()->warn("RoadObjectBuilder: Signal ", signal.id.string(), " has s coordinate ", s_str.str(),
-                             " equal to the road length. Adjusting s to ", adjusted_s_str.str(),
-                             " to avoid potential issues with lane association and orientation.");
-        signal_s -= kEpsilon;
+      double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal_.s, signal_.id.string());
+      if (adjusted_s != signal_.s) {
+        signal_.s = adjusted_s;
       }
 
-      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal_s,
+      const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal.s,
                                                                                 signal.t};
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);

--- a/src/maliput_malidrive/builder/road_object_builder.h
+++ b/src/maliput_malidrive/builder/road_object_builder.h
@@ -29,11 +29,13 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <maliput/api/objects/road_object.h>
 #include <maliput/api/road_geometry.h>
 
 #include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
+#include "maliput_malidrive/xodr/db_manager.h"
 #include "maliput_malidrive/xodr/object/object.h"
 #include "maliput_malidrive/xodr/road_header.h"
 #include "maliput_malidrive/xodr/signal/signal.h"
@@ -61,10 +63,12 @@ class RoadObjectBuilder {
   /// @param road_id The XODR road's ID the @p object belongs to.
   /// @param loader Database loader for looking up object device definitions.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
+  /// @param object_references Object references from other roads that point to @p object.
   /// @throws std::invalid_argument if @p source_type is not kObject or @p road_geometry is nullptr.
   RoadObjectBuilder(SourceType source_type, const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
-                    const maliput::api::RoadGeometry* road_geometry);
+                    const maliput::api::RoadGeometry* road_geometry,
+                    std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references = {});
 
   /// Constructs a RoadObjectBuilder.
   ///
@@ -73,10 +77,12 @@ class RoadObjectBuilder {
   /// @param road_id The XODR road's ID the @p signal belongs to.
   /// @param loader Database loader for looking up signal device definitions.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
+  /// @param signal_references Signal references from other roads that point to @p signal.
   /// @throws std::invalid_argument if @p source_type is not kSignal or @p road_geometry is nullptr.
   RoadObjectBuilder(SourceType source_type, const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
-                    const maliput::api::RoadGeometry* road_geometry);
+                    const maliput::api::RoadGeometry* road_geometry,
+                    std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {});
 
   /// Builds and returns the @ref maliput::api::objects::RoadObject.
   ///
@@ -90,6 +96,8 @@ class RoadObjectBuilder {
   const xodr::RoadHeader::Id& road_id_;
   const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader_;
   const maliput::api::RoadGeometry* road_geometry_;
+  const std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references_;
+  const std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references_;
 };
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -86,6 +86,8 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
 
   // Pre-build the signal-reference index once.
   const auto signal_refs_by_id = mali_rg->get_manager()->GetSignalReferencesBySignalId();
+  // Pre-build the object-reference index once.
+  const auto object_refs_by_id = mali_rg->get_manager()->GetObjectReferencesByObjectId();
 
   // --- Signals pass: route to TrafficLightBook or TrafficSignBook ---
   for (const auto& [road_id, road_header] : mali_rg->get_manager()->GetRoadHeaders()) {
@@ -141,13 +143,14 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
           tsb->AddTrafficSign(std::move(ts));
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
-        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal, road_id, loader, road_geometry_)();
+        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal, road_id, loader, road_geometry_,
+                                    std::move(refs))();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadMarking) {
-        auto rm =
-            RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kSignal, signal, road_id, loader, road_geometry_)();
+        auto rm = RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kSignal, signal, road_id, loader, road_geometry_,
+                                     std::move(refs))();
         if (rm) {
           rmb->AddRoadMarking(std::move(rm));
         }
@@ -172,6 +175,12 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
       }
     }
     for (const auto& object : road_header.objects->objects) {
+      std::vector<xodr::DBManager::ObjectReferenceOnRoad> refs;
+      const auto refs_it = object_refs_by_id.find(object.id.string());
+      if (refs_it != object_refs_by_id.end()) {
+        refs = refs_it->second;
+      }
+
       const std::string type_str =
           object.type.has_value() ? xodr::object::Object::object_type_to_str(object.type.value()) : "";
 
@@ -187,7 +196,8 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         maliput::log()->debug("TrafficControlDeviceBooksBuilder: no definition found for object id='",
                               object.id.string(), "' type='", type_str, "' subtype='", object.subtype.value_or(""),
                               "' name='", object.name.value_or(""), "'.");
-        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_)();
+        auto ro =
+            RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_, refs)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }
@@ -197,13 +207,14 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
       const auto& definition = definition_opt.value();
 
       if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadMarking) {
-        auto rm =
-            RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kObject, object, road_id, loader, road_geometry_)();
+        auto rm = RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kObject, object, road_id, loader, road_geometry_,
+                                     std::move(refs))();
         if (rm) {
           rmb->AddRoadMarking(std::move(rm));
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
-        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_)();
+        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_,
+                                    std::move(refs))();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -85,9 +85,9 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
                      "RoadGeometry cannot be cast to malidrive::RoadGeometry.");
 
   // Pre-build the signal-reference index once.
-  const auto signal_refs_by_id = mali_rg->get_manager()->GetSignalReferencesBySignalId();
+  const auto& signal_refs_by_id = mali_rg->get_manager()->GetSignalReferencesBySignalId();
   // Pre-build the object-reference index once.
-  const auto object_refs_by_id = mali_rg->get_manager()->GetObjectReferencesByObjectId();
+  const auto& object_refs_by_id = mali_rg->get_manager()->GetObjectReferencesByObjectId();
 
   // --- Signals pass: route to TrafficLightBook or TrafficSignBook ---
   for (const auto& [road_id, road_header] : mali_rg->get_manager()->GetRoadHeaders()) {

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -139,8 +139,7 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
       maliput::api::Rotation::FromRpy(signal_.roll.value_or(0.), signal_.pitch.value_or(0.),
                                       orientation + (signal_.orientation != xodr::Orientation::kAgainstS ? M_PI : 0.));
 
-  auto related_lanes =
-      ResolveAndDeduplicateLaneIds(road_id_, signal_.s, signal_.validities, signal_references_, road_geometry_);
+  auto related_lanes = ResolveAndDeduplicateLaneIds(signal_, road_id_, signal_references_, road_geometry_);
 
   maliput::log()->debug("TrafficLightBuilder: creating TrafficLight for signal id='", signal_.id.string(), "' type='",
                         signal_.type, "' subtype='", signal_.subtype, "'. TrafficLight position: (x=", pos.x(),

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -139,7 +139,7 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
       maliput::api::Rotation::FromRpy(signal_.roll.value_or(0.), signal_.pitch.value_or(0.),
                                       orientation + (signal_.orientation != xodr::Orientation::kAgainstS ? M_PI : 0.));
 
-  auto related_lanes = ResolveAndDeduplicateLaneIds(signal_, road_id_, signal_references_, road_geometry_);
+  auto related_lanes = ResolveLaneIds(signal_, road_id_, signal_references_, road_geometry_);
 
   maliput::log()->debug("TrafficLightBuilder: creating TrafficLight for signal id='", signal_.id.string(), "' type='",
                         signal_.type, "' subtype='", signal_.subtype, "'. TrafficLight position: (x=", pos.x(),

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -125,6 +125,11 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
       maliput::api::InertialPosition(0., 0., 0.), maliput::api::Rotation(), std::move(bulbs)));
 
   const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry_);
+  double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal_.s, signal_.id.string());
+  if (adjusted_s != signal_.s) {
+    signal_.s = adjusted_s;
+  }
+
   malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal_.s,
                                                                       signal_.t};
   // We allow off-road positions conversions here since traffic lights in XODR files tend to be placed slightly off the

--- a/src/maliput_malidrive/builder/traffic_light_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_light_builder.cc
@@ -126,11 +126,7 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
 
   const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry_);
   double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal_.s, signal_.id.string());
-  if (adjusted_s != signal_.s) {
-    signal_.s = adjusted_s;
-  }
-
-  malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal_.s,
+  malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
                                                                       signal_.t};
   // We allow off-road positions conversions here since traffic lights in XODR files tend to be placed slightly off the
   // road.
@@ -144,7 +140,7 @@ std::unique_ptr<const maliput::api::rules::TrafficLight> TrafficLightBuilder::op
       maliput::api::Rotation::FromRpy(signal_.roll.value_or(0.), signal_.pitch.value_or(0.),
                                       orientation + (signal_.orientation != xodr::Orientation::kAgainstS ? M_PI : 0.));
 
-  auto related_lanes = ResolveLaneIds(signal_, road_id_, signal_references_, road_geometry_);
+  auto related_lanes = ResolveLaneIds(signal_, adjusted_s, road_id_, signal_references_, road_geometry_);
 
   maliput::log()->debug("TrafficLightBuilder: creating TrafficLight for signal id='", signal_.id.string(), "' type='",
                         signal_.type, "' subtype='", signal_.subtype, "'. TrafficLight position: (x=", pos.x(),

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -126,6 +126,11 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
   }
 
   const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry_);
+  double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal_.s, signal_.id.string());
+  if (adjusted_s != signal_.s) {
+    signal_.s = adjusted_s;
+  }
+
   malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal_.s,
                                                                       signal_.t};
   // We allow off-road positions conversions here since traffic signs in XODR files tend to be placed slightly off

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -127,11 +127,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
 
   const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry_);
   double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry_, road_id_, signal_.s, signal_.id.string());
-  if (adjusted_s != signal_.s) {
-    signal_.s = adjusted_s;
-  }
-
-  malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), signal_.s,
+  malidrive::RoadGeometry::OpenScenarioRoadPosition osc_road_position{std::stoi(road_id_.string()), adjusted_s,
                                                                       signal_.t};
   // We allow off-road positions conversions here since traffic signs in XODR files tend to be placed slightly off
   // the road.
@@ -145,7 +141,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
       maliput::api::Rotation::FromRpy(signal_.roll.value_or(0.), signal_.pitch.value_or(0.),
                                       orientation + (signal_.orientation != xodr::Orientation::kAgainstS ? M_PI : 0.));
 
-  auto related_lanes = ResolveLaneIds(signal_, road_id_, signal_references_, road_geometry_);
+  auto related_lanes = ResolveLaneIds(signal_, adjusted_s, road_id_, signal_references_, road_geometry_);
 
   // Build a bounding box from the signal's physical dimensions when available.
   // The bounding box position and orientation are expressed in the sign's local frame.

--- a/src/maliput_malidrive/builder/traffic_sign_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_sign_builder.cc
@@ -140,8 +140,7 @@ std::unique_ptr<const maliput::api::rules::TrafficSign> TrafficSignBuilder::oper
       maliput::api::Rotation::FromRpy(signal_.roll.value_or(0.), signal_.pitch.value_or(0.),
                                       orientation + (signal_.orientation != xodr::Orientation::kAgainstS ? M_PI : 0.));
 
-  auto related_lanes =
-      ResolveAndDeduplicateLaneIds(road_id_, signal_.s, signal_.validities, signal_references_, road_geometry_);
+  auto related_lanes = ResolveLaneIds(signal_, road_id_, signal_references_, road_geometry_);
 
   // Build a bounding box from the signal's physical dimensions when available.
   // The bounding box position and orientation are expressed in the sign's local frame.

--- a/src/maliput_malidrive/xodr/db_manager.cc
+++ b/src/maliput_malidrive/xodr/db_manager.cc
@@ -134,6 +134,8 @@ class DBManager::Impl {
     AnalyzeLaneSectionsLength();
     MALIDRIVE_TRACE("Collecting signal references by signal ID.");
     CollectSignalReferences();
+    MALIDRIVE_TRACE("Collecting object references by object ID.");
+    CollectObjectReferences();
   }
 
   // @returns A constant reference to xodr header.
@@ -149,6 +151,12 @@ class DBManager::Impl {
   const std::unordered_map<std::string, std::vector<DBManager::SignalReferenceOnRoad>>&
   get_signal_references_by_signal_id() const {
     return signal_refs_by_id_;
+  }
+
+  // @returns A constant reference to the object references grouped by object ID.
+  const std::unordered_map<std::string, std::vector<DBManager::ObjectReferenceOnRoad>>&
+  get_object_references_by_object_id() const {
+    return object_refs_by_id_;
   }
 
   // @returns Data from the shortest Geometry in the entire XODR description.
@@ -886,6 +894,20 @@ class DBManager::Impl {
     }
   }
 
+  // Collects all object references across all roads, grouped by the referenced object ID.
+  void CollectObjectReferences() {
+    for (const auto& [road_id, road_header] : road_headers_) {
+      if (!road_header.objects.has_value()) {
+        continue;
+      }
+      for (const auto& object : road_header.objects->objects) {
+        for (const auto& ref : object.object_references) {
+          object_refs_by_id_[ref.id.string()].push_back(DBManager::ObjectReferenceOnRoad{road_id, ref});
+        }
+      }
+    }
+  }
+
   // Optional tolerance.
   ParserConfiguration parser_configuration_{};
   // Header of the XODR map.
@@ -922,6 +944,8 @@ class DBManager::Impl {
 
   // Holds signal references grouped by signal ID.
   std::unordered_map<std::string, std::vector<DBManager::SignalReferenceOnRoad>> signal_refs_by_id_;
+  // Holds object references grouped by object ID.
+  std::unordered_map<std::string, std::vector<DBManager::ObjectReferenceOnRoad>> object_refs_by_id_;
 };
 
 DBManager::~DBManager() = default;
@@ -941,6 +965,11 @@ const std::map<Junction::Id, Junction>& DBManager::GetJunctions() const { return
 const std::unordered_map<std::string, std::vector<DBManager::SignalReferenceOnRoad>>&
 DBManager::GetSignalReferencesBySignalId() const {
   return impl_->get_signal_references_by_signal_id();
+}
+
+const std::unordered_map<std::string, std::vector<DBManager::ObjectReferenceOnRoad>>&
+DBManager::GetObjectReferencesByObjectId() const {
+  return impl_->get_object_references_by_object_id();
 }
 
 const DBManager::XodrGeometryLengthData& DBManager::GetShortestGeometry() const {

--- a/src/maliput_malidrive/xodr/db_manager.h
+++ b/src/maliput_malidrive/xodr/db_manager.h
@@ -41,6 +41,7 @@
 #include "maliput_malidrive/common/macros.h"
 #include "maliput_malidrive/xodr/header.h"
 #include "maliput_malidrive/xodr/junction.h"
+#include "maliput_malidrive/xodr/object/object_reference.h"
 #include "maliput_malidrive/xodr/parser_configuration.h"
 #include "maliput_malidrive/xodr/road_header.h"
 #include "maliput_malidrive/xodr/signal/signal_reference.h"
@@ -69,6 +70,14 @@ class DBManager {
   struct SignalReferenceOnRoad {
     RoadHeader::Id road_id;
     signal::SignalReference signal_reference;
+  };
+
+  /// Pairs an @ref object::ObjectReference with the ID of the road on which
+  /// the reference appears. This allows consumers to resolve lanes from
+  /// multiple roads that reference the same physical object.
+  struct ObjectReferenceOnRoad {
+    RoadHeader::Id road_id;
+    object::ObjectReference object_reference;
   };
 
   /// Holds Geometry related information:
@@ -165,6 +174,15 @@ class DBManager {
   /// @returns A map from signal-ID string to all @ref SignalReferenceOnRoad
   ///          entries referencing it.
   const std::unordered_map<std::string, std::vector<SignalReferenceOnRoad>>& GetSignalReferencesBySignalId() const;
+
+  /// Collects all object references from every road, grouped by the referenced object ID.
+  ///
+  /// The returned map keys are object ID strings; the values are vectors of
+  /// @ref ObjectReferenceOnRoad entries that reference that object.
+  ///
+  /// @returns A map from object-ID string to all @ref ObjectReferenceOnRoad
+  ///          entries referencing it.
+  const std::unordered_map<std::string, std::vector<ObjectReferenceOnRoad>>& GetObjectReferencesByObjectId() const;
 
   /// @{ Xodr geometry introspection queries.
 

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -1179,7 +1179,7 @@ TEST_F(ResolveLaneIdsSignalReferenceTest, AppliesSignalReferenceOrientation) {
   signal_reference.signal_reference.s = 50.;
   signal_reference.signal_reference.validities = {};
 
-  const auto related_lanes = ResolveLaneIds(signal, xodr::RoadHeader::Id("1"), {signal_reference}, road_geometry_);
+  const auto related_lanes = ResolveLaneIds(signal, signal.s, xodr::RoadHeader::Id("1"), {signal_reference}, road_geometry_);
 
   ASSERT_EQ(2u, related_lanes.size());
   EXPECT_NE(std::find(related_lanes.begin(), related_lanes.end(), maliput::api::LaneId("1_0_-1")), related_lanes.end());

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -1149,7 +1149,7 @@ TEST_F(FilterLaneIdsBySignalOrientationTest, SingleLaneAgainstSNoMatch) {
   EXPECT_EQ(filtered.size(), 0);  // WithS doesn't match AgainstS filter
 }
 
-class ResolveAndDeduplicateLaneIdsSignalReferenceTest : public ::testing::Test {
+class ResolveLaneIdsSignalReferenceTest : public ::testing::Test {
  protected:
   void SetUp() override {
     const std::string xodr_file_path =
@@ -1168,7 +1168,7 @@ class ResolveAndDeduplicateLaneIdsSignalReferenceTest : public ::testing::Test {
   const maliput::api::RoadGeometry* road_geometry_{};
 };
 
-TEST_F(ResolveAndDeduplicateLaneIdsSignalReferenceTest, AppliesSignalReferenceOrientation) {
+TEST_F(ResolveLaneIdsSignalReferenceTest, AppliesSignalReferenceOrientation) {
   xodr::signal::Signal signal{50., 0., xodr::signal::Signal::Id("S1")};
   signal.orientation = xodr::Orientation::kWithS;
   signal.validities = {{xodr::Validity::Id("-1"), xodr::Validity::Id("-1")}};
@@ -1179,14 +1179,11 @@ TEST_F(ResolveAndDeduplicateLaneIdsSignalReferenceTest, AppliesSignalReferenceOr
   signal_reference.signal_reference.s = 50.;
   signal_reference.signal_reference.validities = {};
 
-  const auto related_lanes = ResolveAndDeduplicateLaneIds(signal, xodr::RoadHeader::Id("1"), {signal_reference},
-                                                          road_geometry_);
+  const auto related_lanes = ResolveLaneIds(signal, xodr::RoadHeader::Id("1"), {signal_reference}, road_geometry_);
 
   ASSERT_EQ(2u, related_lanes.size());
-  EXPECT_NE(std::find(related_lanes.begin(), related_lanes.end(), maliput::api::LaneId("1_0_-1")),
-            related_lanes.end());
-  EXPECT_NE(std::find(related_lanes.begin(), related_lanes.end(), maliput::api::LaneId("2_0_-1")),
-            related_lanes.end());
+  EXPECT_NE(std::find(related_lanes.begin(), related_lanes.end(), maliput::api::LaneId("1_0_-1")), related_lanes.end());
+  EXPECT_NE(std::find(related_lanes.begin(), related_lanes.end(), maliput::api::LaneId("2_0_-1")), related_lanes.end());
 }
 
 }  // namespace

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -1076,6 +1076,119 @@ GTEST_TEST(DetermineJunctionIntersectionFromXodrTest, FewConnectionsFallbackToNo
   EXPECT_EQ(std::make_optional(false), DetermineJunctionIntersectionFromXodr(junction, road_headers));
 }
 
+class FilterLaneIdsBySignalOrientationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("SingleRoadBidirectionalLanes.xodr", kMalidriveResourceFolder);
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = road_network_->road_geometry();
+    ASSERT_NE(road_geometry_, nullptr);
+  }
+
+  // Helper to get lane IDs by lane ID string
+  std::vector<maliput::api::LaneId> GetLaneIds(const std::vector<std::string>& lane_id_strings) const {
+    std::vector<maliput::api::LaneId> result;
+    for (const auto& id_str : lane_id_strings) {
+      result.push_back(maliput::api::LaneId(id_str));
+    }
+    return result;
+  }
+
+  std::unique_ptr<maliput::api::RoadNetwork> road_network_;
+  const maliput::api::RoadGeometry* road_geometry_;
+};
+
+// Test FilterLaneIdsBySignalOrientation with kWithS orientation
+TEST_F(FilterLaneIdsBySignalOrientationTest, FilterWithS) {
+  const auto lane_ids = GetLaneIds({"1_0_-1", "1_0_1"});
+  const auto filtered = FilterLaneIdsBySignalOrientation(lane_ids, xodr::Orientation::kWithS, road_geometry_);
+  EXPECT_EQ(filtered.size(), 1);
+  EXPECT_EQ(filtered[0].string(), "1_0_-1");  // Only WithS lane
+}
+
+// Test FilterLaneIdsBySignalOrientation with kAgainstS orientation
+TEST_F(FilterLaneIdsBySignalOrientationTest, FilterAgainstS) {
+  const auto lane_ids = GetLaneIds({"1_0_-1", "1_0_1"});
+  const auto filtered = FilterLaneIdsBySignalOrientation(lane_ids, xodr::Orientation::kAgainstS, road_geometry_);
+  EXPECT_EQ(filtered.size(), 1);
+  EXPECT_EQ(filtered[0].string(), "1_0_1");  // Only AgainstS lane
+}
+
+// Test FilterLaneIdsBySignalOrientation with kBidirectional orientation
+TEST_F(FilterLaneIdsBySignalOrientationTest, FilterBidirectional) {
+  const auto lane_ids = GetLaneIds({"1_0_-1", "1_0_1"});
+  const auto filtered = FilterLaneIdsBySignalOrientation(lane_ids, xodr::Orientation::kBidirectional, road_geometry_);
+  EXPECT_EQ(filtered.size(), 2);  // Both lanes pass through
+}
+
+// Test FilterLaneIdsBySignalOrientation with empty lane IDs
+TEST_F(FilterLaneIdsBySignalOrientationTest, EmptyLaneIds) {
+  const auto lane_ids = GetLaneIds({});
+  const auto filtered = FilterLaneIdsBySignalOrientation(lane_ids, xodr::Orientation::kWithS, road_geometry_);
+  EXPECT_EQ(filtered.size(), 0);
+}
+
+// Test FilterLaneIdsBySignalOrientation with single lane (WithS)
+TEST_F(FilterLaneIdsBySignalOrientationTest, SingleLaneWithS) {
+  const auto lane_ids = GetLaneIds({"1_0_-1"});
+  const auto filtered = FilterLaneIdsBySignalOrientation(lane_ids, xodr::Orientation::kWithS, road_geometry_);
+  EXPECT_EQ(filtered.size(), 1);
+  EXPECT_EQ(filtered[0].string(), "1_0_-1");
+}
+
+// Test FilterLaneIdsBySignalOrientation with single lane (AgainstS, doesn't match)
+TEST_F(FilterLaneIdsBySignalOrientationTest, SingleLaneAgainstSNoMatch) {
+  const auto lane_ids = GetLaneIds({"1_0_-1"});  // WithS lane
+  const auto filtered = FilterLaneIdsBySignalOrientation(lane_ids, xodr::Orientation::kAgainstS, road_geometry_);
+  EXPECT_EQ(filtered.size(), 0);  // WithS doesn't match AgainstS filter
+}
+
+class ResolveAndDeduplicateLaneIdsSignalReferenceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("TwoRoadsWithTrafficLights.xodr", kMalidriveResourceFolder);
+    const RoadNetworkConfiguration rn_config{RoadNetworkConfiguration::FromMap({
+        {params::kOpendriveFile, xodr_file_path},
+        {params::kOmitNonDrivableLanes, "false"},
+    })};
+    road_network_ = RoadNetworkBuilder(rn_config.ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = road_network_->road_geometry();
+    ASSERT_NE(road_geometry_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::RoadGeometry* road_geometry_{};
+};
+
+TEST_F(ResolveAndDeduplicateLaneIdsSignalReferenceTest, AppliesSignalReferenceOrientation) {
+  xodr::signal::Signal signal{50., 0., xodr::signal::Signal::Id("S1")};
+  signal.orientation = xodr::Orientation::kWithS;
+  signal.validities = {{xodr::Validity::Id("-1"), xodr::Validity::Id("-1")}};
+
+  xodr::DBManager::SignalReferenceOnRoad signal_reference{
+      xodr::RoadHeader::Id("2"), xodr::signal::SignalReference{xodr::signal::SignalReference::SignalId("S2")}};
+  signal_reference.signal_reference.orientation = xodr::Orientation::kWithS;
+  signal_reference.signal_reference.s = 50.;
+  signal_reference.signal_reference.validities = {};
+
+  const auto related_lanes = ResolveAndDeduplicateLaneIds(signal, xodr::RoadHeader::Id("1"), {signal_reference},
+                                                          road_geometry_);
+
+  ASSERT_EQ(2u, related_lanes.size());
+  EXPECT_NE(std::find(related_lanes.begin(), related_lanes.end(), maliput::api::LaneId("1_0_-1")),
+            related_lanes.end());
+  EXPECT_NE(std::find(related_lanes.begin(), related_lanes.end(), maliput::api::LaneId("2_0_-1")),
+            related_lanes.end());
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace builder

--- a/test/regression/builder/builder_tools_test.cc
+++ b/test/regression/builder/builder_tools_test.cc
@@ -1179,7 +1179,8 @@ TEST_F(ResolveLaneIdsSignalReferenceTest, AppliesSignalReferenceOrientation) {
   signal_reference.signal_reference.s = 50.;
   signal_reference.signal_reference.validities = {};
 
-  const auto related_lanes = ResolveLaneIds(signal, signal.s, xodr::RoadHeader::Id("1"), {signal_reference}, road_geometry_);
+  const auto related_lanes =
+      ResolveLaneIds(signal, signal.s, xodr::RoadHeader::Id("1"), {signal_reference}, road_geometry_);
 
   ASSERT_EQ(2u, related_lanes.size());
   EXPECT_NE(std::find(related_lanes.begin(), related_lanes.end(), maliput::api::LaneId("1_0_-1")), related_lanes.end());

--- a/test/regression/builder/road_marking_builder_test.cc
+++ b/test/regression/builder/road_marking_builder_test.cc
@@ -69,6 +69,22 @@ odr_signal_types:
         height: 0.0
 )";
 
+const char kDirectionFilterSignalRoadMarkingDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      name: "*"
+    properties:
+      device_type: RoadMarking
+      device_semantics: StopLine
+      default_bounding_box:
+        length: 3.0
+        width: 0.61
+        height: 0.0
+)";
+
 // ---------------------------------------------------------------------------
 // RoadMarkingBuilder tests.
 // Uses the RoadWithRoadMarkings.xodr resource and road_marking_test_db.yaml.
@@ -152,8 +168,9 @@ TEST_F(RoadMarkingBuilderTest, BuildStopLine) {
   EXPECT_NEAR(bb.box_size().y(), 7.0, 1e-3);
   EXPECT_NEAR(bb.box_size().z(), 0.0, 1e-3);
 
-  // Related lanes: both lanes.
-  EXPECT_GE(road_marking->related_lanes().size(), 2u);
+  // Related lanes: with orientation="+", only WithS lane survives.
+  ASSERT_EQ(road_marking->related_lanes().size(), 1u);
+  EXPECT_EQ(road_marking->related_lanes()[0].string(), "1_0_-1");
 }
 
 TEST_F(RoadMarkingBuilderTest, BuildCrosswalk) {
@@ -321,6 +338,83 @@ TEST_F(RoadMarkingBuilderSignalTest, BuildRoadMarkingFromSignal) {
   EXPECT_EQ(road_marking->related_lanes().size(), 1u);
   EXPECT_NEAR(road_marking->bounding_box().box_size().x(), 3.0, 1e-6);
   EXPECT_NEAR(road_marking->bounding_box().box_size().y(), 0.61, 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+
+class RoadMarkingBuilderDirectionFilterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file =
+        utility::FindResourceInPath("SingleRoadBidirectionalLanes.xodr", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+
+    const auto* manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+    const auto road_headers = manager->GetRoadHeaders();
+    const auto road_header_it = road_headers.find(road_id_);
+    ASSERT_NE(road_header_it, road_headers.end());
+    ASSERT_TRUE(road_header_it->second.signals.has_value());
+    signals_ = road_header_it->second.signals->signals;
+    loader_ = std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(
+        kDirectionFilterSignalRoadMarkingDb);
+  }
+
+  const xodr::signal::Signal& FindSignal(const std::string& id) const {
+    for (const auto& signal : signals_) {
+      if (signal.id.string() == id) return signal;
+    }
+    MALIPUT_THROW_MESSAGE("Signal " + id + " not found");
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  std::vector<xodr::signal::Signal> signals_;
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+  const xodr::RoadHeader::Id road_id_{"1"};
+};
+
+// Verifies that road markings created from signals with orientation="+" (kWithS) filter related_lanes correctly.
+TEST_F(RoadMarkingBuilderDirectionFilterTest, SignalOrientationWithSFilters) {
+  const auto& signal = FindSignal("S_WithS");
+  const auto rm =
+      RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kSignal, signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(rm, nullptr);
+  // Only lane -1 (WithS) should be included
+  EXPECT_EQ(rm->related_lanes().size(), 1);
+  EXPECT_EQ(rm->related_lanes()[0].string(), "1_0_-1");
+}
+
+// Verifies that road markings created from signals with orientation="-" (kAgainstS) filter related_lanes correctly.
+TEST_F(RoadMarkingBuilderDirectionFilterTest, SignalOrientationAgainstSFilters) {
+  const auto& signal = FindSignal("S_AgainstS");
+  const auto rm =
+      RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kSignal, signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(rm, nullptr);
+  // Only lane +1 (AgainstS) should be included
+  EXPECT_EQ(rm->related_lanes().size(), 1);
+  EXPECT_EQ(rm->related_lanes()[0].string(), "1_0_1");
+}
+
+// Verifies that road markings created from signals with orientation="none" (kBidirectional) don't filter related_lanes.
+TEST_F(RoadMarkingBuilderDirectionFilterTest, SignalOrientationBidirectionalNoFilter) {
+  const auto& signal = FindSignal("S_Bidirectional");
+  const auto rm =
+      RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kSignal, signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(rm, nullptr);
+  // Both lanes should be included (no filter)
+  EXPECT_EQ(rm->related_lanes().size(), 2);
+  const auto lane_ids = rm->related_lanes();
+  EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_-1"; }));
+  EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_1"; }));
 }
 
 }  // namespace

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -646,6 +646,82 @@ TEST_F(RoadObjectBuilderTest, FindInRadius) {
   EXPECT_TRUE(far_away.empty());
 }
 
+// ---------------------------------------------------------------------------
+
+class RoadObjectBuilderDirectionFilterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file =
+        utility::FindResourceInPath("SingleRoadBidirectionalLanes.xodr", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+
+    const auto* manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+    const auto road_headers = manager->GetRoadHeaders();
+    const auto road_header_it = road_headers.find(road_id_);
+    ASSERT_NE(road_header_it, road_headers.end());
+    ASSERT_TRUE(road_header_it->second.signals.has_value());
+    signals_ = road_header_it->second.signals->signals;
+    loader_ = std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(kSignalRoadObjectDb);
+  }
+
+  const xodr::signal::Signal& FindSignal(const std::string& id) const {
+    for (const auto& signal : signals_) {
+      if (signal.id.string() == id) return signal;
+    }
+    MALIPUT_THROW_MESSAGE("Signal " + id + " not found");
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  std::vector<xodr::signal::Signal> signals_;
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+  const xodr::RoadHeader::Id road_id_{"1"};
+};
+
+// Verifies that road objects created from signals with orientation="+" (kWithS) filter related_lanes correctly.
+TEST_F(RoadObjectBuilderDirectionFilterTest, SignalOrientationWithSFilters) {
+  const auto& signal = FindSignal("S_WithS");
+  const auto ro =
+      RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(ro, nullptr);
+  // Only lane -1 (WithS) should be included
+  EXPECT_EQ(ro->related_lanes().size(), 1);
+  EXPECT_EQ(ro->related_lanes()[0].string(), "1_0_-1");
+}
+
+// Verifies that road objects created from signals with orientation="-" (kAgainstS) filter related_lanes correctly.
+TEST_F(RoadObjectBuilderDirectionFilterTest, SignalOrientationAgainstSFilters) {
+  const auto& signal = FindSignal("S_AgainstS");
+  const auto ro =
+      RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(ro, nullptr);
+  // Only lane +1 (AgainstS) should be included
+  EXPECT_EQ(ro->related_lanes().size(), 1);
+  EXPECT_EQ(ro->related_lanes()[0].string(), "1_0_1");
+}
+
+// Verifies that road objects created from signals with orientation="none" (kBidirectional) don't filter related_lanes.
+TEST_F(RoadObjectBuilderDirectionFilterTest, SignalOrientationBidirectionalNoFilter) {
+  const auto& signal = FindSignal("S_Bidirectional");
+  const auto ro =
+      RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(ro, nullptr);
+  // Both lanes should be included (no filter)
+  EXPECT_EQ(ro->related_lanes().size(), 2);
+  const auto lane_ids = ro->related_lanes();
+  EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_-1"; }));
+  EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_1"; }));
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace builder

--- a/test/regression/builder/traffic_light_builder_test.cc
+++ b/test/regression/builder/traffic_light_builder_test.cc
@@ -398,18 +398,17 @@ TEST_F(TrafficLightBuilderTwoRoadsTest, TrafficLightS1Fields) {
 
   // Related lanes for S1:
   //   - From signal's own validity (fromLane=-1, toLane=-1) on road 1 → {"1_0_-1"}
-  //   - From signalReference to S2 on road 2 (no validity) → all lanes of road 2 at s=50 → {"2_0_1", "2_0_-1"}
-  // Total (sorted): {"1_0_-1", "2_0_-1", "2_0_1"}
+  //   - From signalReference to S1 on road 2 (orientation="+") → lane "2_0_1"
+  // Total (sorted): {"1_0_-1", "2_0_1"}
   const auto& related = tl->related_lanes();
-  ASSERT_EQ(3u, related.size());
+  ASSERT_EQ(2u, related.size());
   std::vector<std::string> lane_ids;
   for (const auto& lid : related) {
     lane_ids.push_back(lid.string());
   }
   std::sort(lane_ids.begin(), lane_ids.end());
   EXPECT_EQ("1_0_-1", lane_ids[0]);
-  EXPECT_EQ("2_0_-1", lane_ids[1]);
-  EXPECT_EQ("2_0_1", lane_ids[2]);
+  EXPECT_EQ("2_0_1", lane_ids[1]);
 }
 
 // Verifies all fields of the TrafficLight created from signal S2.
@@ -445,20 +444,19 @@ TEST_F(TrafficLightBuilderTwoRoadsTest, TrafficLightS2Fields) {
   EXPECT_NE(bulb_groups[0]->GetBulb(maliput::api::rules::Bulb::Id("GreenBulb")), nullptr);
 
   // Related lanes for S2:
-  //   - From signal's own validity (empty → all lanes) on road 2 at s=40 → {"2_0_1", "2_0_-1"}
-  //   - From signalReference to S1 on road 1 (no validity) → all lanes of road 1 at s=40 → {"1_0_1", "1_0_-1"}
-  // Total (sorted): {"1_0_-1", "1_0_1", "2_0_-1", "2_0_1"}
+  //   - From signal's own validity (empty → all lanes) on road 2 at s=40 and orientation="-"
+  //     → lane "2_0_1"
+  //   - From signalReference to S2 on road 1 (orientation="+") → lane "1_0_-1"
+  // Total (sorted): {"1_0_-1", "2_0_1"}
   const auto& related = tl->related_lanes();
-  ASSERT_EQ(4u, related.size());
+  ASSERT_EQ(2u, related.size());
   std::vector<std::string> lane_ids;
   for (const auto& lid : related) {
     lane_ids.push_back(lid.string());
   }
   std::sort(lane_ids.begin(), lane_ids.end());
   EXPECT_EQ("1_0_-1", lane_ids[0]);
-  EXPECT_EQ("1_0_1", lane_ids[1]);
-  EXPECT_EQ("2_0_-1", lane_ids[2]);
-  EXPECT_EQ("2_0_1", lane_ids[3]);
+  EXPECT_EQ("2_0_1", lane_ids[1]);
 }
 
 // ---------------------------------------------------------------------------
@@ -514,6 +512,60 @@ TEST_F(TrafficLightBuilderOrientationAttributesTest, OrientationAttributesAreApp
   EXPECT_NEAR(kExpectedRotation.roll(), rot.roll(), 1e-6);
   EXPECT_NEAR(kExpectedRotation.pitch(), rot.pitch(), 1e-6);
   EXPECT_NEAR(kExpectedRotation.yaw(), rot.yaw(), 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+
+class TrafficLightBuilderDirectionFilterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file =
+        utility::FindResourceInPath("SingleRoadBidirectionalLanes.xodr", kMalidriveResourceFolder);
+    const std::string yaml_db = utility::FindResourceInPath(
+        "traffic_control_device_db/traffic_control_device_db_example.yaml", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file},
+                                                                             {params::kTrafficControlDeviceDb, yaml_db},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    traffic_light_book_ = road_network_->traffic_light_book();
+    ASSERT_NE(traffic_light_book_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::rules::TrafficLightBook* traffic_light_book_{};
+};
+
+// Verifies that traffic lights with orientation="+" (kWithS) filter related_lanes correctly.
+TEST_F(TrafficLightBuilderDirectionFilterTest, OrientationWithSFilters) {
+  const auto* tl = traffic_light_book_->GetTrafficLight(maliput::api::rules::TrafficLight::Id("S_WithS"));
+  ASSERT_NE(tl, nullptr);
+  // Only lane -1 (WithS) should be included
+  EXPECT_EQ(tl->related_lanes().size(), 1);
+  EXPECT_EQ(tl->related_lanes()[0].string(), "1_0_-1");
+}
+
+// Verifies that traffic lights with orientation="-" (kAgainstS) filter related_lanes correctly.
+TEST_F(TrafficLightBuilderDirectionFilterTest, OrientationAgainstSFilters) {
+  const auto* tl = traffic_light_book_->GetTrafficLight(maliput::api::rules::TrafficLight::Id("S_AgainstS"));
+  ASSERT_NE(tl, nullptr);
+  // Only lane +1 (AgainstS) should be included
+  EXPECT_EQ(tl->related_lanes().size(), 1);
+  EXPECT_EQ(tl->related_lanes()[0].string(), "1_0_1");
+}
+
+// Verifies that traffic lights with orientation="none" (kBidirectional) don't filter related_lanes.
+TEST_F(TrafficLightBuilderDirectionFilterTest, OrientationBidirectionalNoFilter) {
+  const auto* tl = traffic_light_book_->GetTrafficLight(maliput::api::rules::TrafficLight::Id("S_Bidirectional"));
+  ASSERT_NE(tl, nullptr);
+  // Both lanes should be included (no filter)
+  EXPECT_EQ(tl->related_lanes().size(), 2);
+  const auto lane_ids = tl->related_lanes();
+  EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_-1"; }));
+  EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_1"; }));
 }
 
 }  // namespace

--- a/test/regression/builder/traffic_sign_builder_test.cc
+++ b/test/regression/builder/traffic_sign_builder_test.cc
@@ -61,6 +61,18 @@ namespace {
 
 // Resource folder path defined via compile definition.
 static constexpr char kMalidriveResourceFolder[] = DEF_MALIDRIVE_RESOURCES;
+const char kDirectionFilterSignalTrafficSignDb[] = R"(
+odr_signal_types:
+  - odr_representation:
+      type: "1000001"
+      subtype: "-1"
+      country: "OpenDRIVE"
+      name: "*"
+    properties:
+      device_type: TrafficSign
+      device_semantics: Stop
+      is_position_dynamic: true
+)";
 
 // Test fixture for TrafficSignBuilder.
 // Builds a RoadNetwork from the figure8_trafficlights XODR (which contains
@@ -326,18 +338,17 @@ TEST_F(TrafficSignBuilderTwoRoadsTest, TrafficSignSS1Fields) {
 
   // Related lanes for SS1:
   //   - From signal's own validity (fromLane=-1, toLane=-1) on road 1 → {"1_0_-1"}
-  //   - From signalReference to SS2 on road 2 (no validity) → all lanes of road 2 → {"2_0_1", "2_0_-1"}
-  // Total (sorted): {"1_0_-1", "2_0_-1", "2_0_1"}
+  //   - From signalReference on road 2 (uses referenced signal orientation="-") → {"2_0_1"}
+  // Total (sorted): {"1_0_-1", "2_0_1"}
   const auto& related = ts->related_lanes();
-  ASSERT_EQ(3u, related.size());
+  ASSERT_EQ(2u, related.size());
   std::vector<std::string> lane_ids;
   for (const auto& lid : related) {
     lane_ids.push_back(lid.string());
   }
   std::sort(lane_ids.begin(), lane_ids.end());
   EXPECT_EQ("1_0_-1", lane_ids[0]);
-  EXPECT_EQ("2_0_-1", lane_ids[1]);
-  EXPECT_EQ("2_0_1", lane_ids[2]);
+  EXPECT_EQ("2_0_1", lane_ids[1]);
 
   const auto& properties = ts->properties();
   EXPECT_EQ(properties.at("type"), "206");
@@ -375,20 +386,18 @@ TEST_F(TrafficSignBuilderTwoRoadsTest, TrafficSignSS2Fields) {
   EXPECT_NEAR(0., std::abs(rot.yaw()), 1e-1);
 
   // Related lanes for SS2:
-  //   - From signal's own validity (empty → all lanes) on road 2 → {"2_0_1", "2_0_-1"}
-  //   - From signalReference to SS1 on road 1 (no validity) → all lanes of road 1 → {"1_0_1", "1_0_-1"}
-  // Total (sorted): {"1_0_-1", "1_0_1", "2_0_-1", "2_0_1"}
+  //   - From signal's own orientation "-" on road 2 → {"2_0_1"}
+  //   - From signalReference on road 1 (uses referenced signal orientation="+") → {"1_0_-1"}
+  // Total (sorted): {"1_0_-1", "2_0_1"}
   const auto& related = ts->related_lanes();
-  ASSERT_EQ(4u, related.size());
+  ASSERT_EQ(2u, related.size());
   std::vector<std::string> lane_ids;
   for (const auto& lid : related) {
     lane_ids.push_back(lid.string());
   }
   std::sort(lane_ids.begin(), lane_ids.end());
   EXPECT_EQ("1_0_-1", lane_ids[0]);
-  EXPECT_EQ("1_0_1", lane_ids[1]);
-  EXPECT_EQ("2_0_-1", lane_ids[2]);
-  EXPECT_EQ("2_0_1", lane_ids[3]);
+  EXPECT_EQ("2_0_1", lane_ids[1]);
 
   const auto& properties = ts->properties();
   EXPECT_EQ(properties.at("type"), "206");
@@ -605,6 +614,80 @@ TEST_F(TrafficSignBuilderOrientationAttributesTest, OrientationAttributesAreAppl
   EXPECT_NEAR(kExpectedRotation.roll(), rot.roll(), 1e-6);
   EXPECT_NEAR(kExpectedRotation.pitch(), rot.pitch(), 1e-6);
   EXPECT_NEAR(kExpectedRotation.yaw(), rot.yaw(), 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+
+class TrafficSignBuilderDirectionFilterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file =
+        utility::FindResourceInPath("SingleRoadBidirectionalLanes.xodr", kMalidriveResourceFolder);
+
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_geometry_ = dynamic_cast<const malidrive::RoadGeometry*>(road_network_->road_geometry());
+    ASSERT_NE(road_geometry_, nullptr);
+
+    const auto* manager = road_geometry_->get_manager();
+    ASSERT_NE(manager, nullptr);
+    const auto road_headers = manager->GetRoadHeaders();
+    const auto road_header_it = road_headers.find(road_id_);
+    ASSERT_NE(road_header_it, road_headers.end());
+    ASSERT_TRUE(road_header_it->second.signals.has_value());
+    signals_ = road_header_it->second.signals->signals;
+    loader_ = std::make_unique<traffic_control_device::TrafficControlDeviceDatabaseLoader>(
+        kDirectionFilterSignalTrafficSignDb);
+  }
+
+  const xodr::signal::Signal& FindSignal(const std::string& id) const {
+    for (const auto& signal : signals_) {
+      if (signal.id.string() == id) return signal;
+    }
+    MALIPUT_THROW_MESSAGE("Signal " + id + " not found");
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const malidrive::RoadGeometry* road_geometry_{};
+  std::vector<xodr::signal::Signal> signals_;
+  std::unique_ptr<traffic_control_device::TrafficControlDeviceDatabaseLoader> loader_;
+  const xodr::RoadHeader::Id road_id_{"1"};
+};
+
+// Verifies that signals with orientation="+" (kWithS) filter related_lanes correctly.
+TEST_F(TrafficSignBuilderDirectionFilterTest, OrientationWithSFilters) {
+  const auto& signal = FindSignal("S_WithS");
+  const auto ts = TrafficSignBuilder(signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(ts, nullptr);
+  // Only lane -1 (WithS) should be included
+  EXPECT_EQ(ts->related_lanes().size(), 1);
+  EXPECT_EQ(ts->related_lanes()[0].string(), "1_0_-1");
+}
+
+// Verifies that signals with orientation="-" (kAgainstS) filter related_lanes correctly.
+TEST_F(TrafficSignBuilderDirectionFilterTest, OrientationAgainstSFilters) {
+  const auto& signal = FindSignal("S_AgainstS");
+  const auto ts = TrafficSignBuilder(signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(ts, nullptr);
+  // Only lane +1 (AgainstS) should be included
+  EXPECT_EQ(ts->related_lanes().size(), 1);
+  EXPECT_EQ(ts->related_lanes()[0].string(), "1_0_1");
+}
+
+// Verifies that signals with orientation="none" (kBidirectional) don't filter related_lanes.
+TEST_F(TrafficSignBuilderDirectionFilterTest, OrientationBidirectionalNoFilter) {
+  const auto& signal = FindSignal("S_Bidirectional");
+  const auto ts = TrafficSignBuilder(signal, road_id_, *loader_, road_geometry_)();
+  ASSERT_NE(ts, nullptr);
+  // Both lanes should be included (no filter)
+  EXPECT_EQ(ts->related_lanes().size(), 2);
+  const auto lane_ids = ts->related_lanes();
+  EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_-1"; }));
+  EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_1"; }));
 }
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature

## Summary
* Added direction-aware related-lane resolution for traffic devices, using XODR signal/object orientation (`+`, `-`, `none`) to select lanes compatible with travel direction.
* Extended related-lane resolution to include cross-road references:
  * `signalReference` now contributes related lanes using the reference’s own `s`, validity range, and orientation.
  * `objectReference` now contributes related lanes using the reference’s own `s`, validity range, and orientation.
* Unified lane resolution behavior across builders so `TrafficSignBuilder`, `RoadObjectBuilder`, and `RoadMarkingBuilder` follow the same `ResolveAndDeduplicateLaneIds(...)`  flow as `TrafficLightBuilder`.
* Refactored `ResolveLaneIds`  / `ResolveAndDeduplicateLaneIds`  responsibilities to make orientation filtering and validity pruning explicit.
  * Used an `std::set` internally to avoid any `LaneId` duplication.
* Added object-reference indexing in the XODR DB layer (grouped by referenced object id), mirroring existing signal-reference indexing.
* Refactored s-coordinate boundary handling so lane-resolution lookups clamp road-end  s  values safely and avoid falling outside lane-section ranges.

## Test it

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
