### PR TITLE
XODR object orientation doesn't affect RoadMarking yaw-orientation.

### DIFF
--- a/src/maliput_malidrive/builder/road_marking_builder.cc
+++ b/src/maliput_malidrive/builder/road_marking_builder.cc
@@ -147,11 +147,9 @@ std::unique_ptr<maliput::api::objects::RoadMarking> RoadMarkingBuilder::operator
       const double hdg = object.hdg.value_or(0.);
       const double pitch = perp_to_road ? 0. : object.pitch.value_or(0.);
       const double roll = perp_to_road ? 0. : object.roll.value_or(0.);
-      const double orientation_offset =
-          (object.orientation.has_value() && object.orientation.value() == xodr::Orientation::kAgainstS) ? M_PI : 0.;
       const maliput::api::Rotation orientation =
           maliput::api::Rotation::FromRpy(road_orientation.roll_angle() + roll, road_orientation.pitch_angle() + pitch,
-                                          road_orientation.yaw_angle() + hdg + orientation_offset);
+                                          road_orientation.yaw_angle() + hdg);
 
       const auto default_bounding_box =
           definition.default_bounding_box.value_or(traffic_control_device::BoundingBoxDimensions{});

--- a/test/regression/builder/road_marking_builder_test.cc
+++ b/test/regression/builder/road_marking_builder_test.cc
@@ -287,6 +287,29 @@ TEST_F(RoadMarkingBuilderElevatedRoadTest, PositionZIsRelativeToRoadSurface) {
   EXPECT_GT(std::abs(road_marking_z - object_.z_offset), 1.0);
 }
 
+TEST_F(RoadMarkingBuilderElevatedRoadTest, ObjectOrientationDoesNotAffectYaw) {
+  xodr::object::Object object_with_positive_orientation = object_;
+  object_with_positive_orientation.orientation = xodr::Orientation::kWithS;
+  object_with_positive_orientation.hdg = 0.;
+
+  xodr::object::Object object_with_negative_orientation = object_;
+  object_with_negative_orientation.orientation = xodr::Orientation::kAgainstS;
+  object_with_negative_orientation.hdg = 0.;
+
+  const auto positive_orientation_road_marking =
+      RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kObject, object_with_positive_orientation,
+                         xodr::RoadHeader::Id("1"), *loader_, road_geometry_)();
+  ASSERT_NE(positive_orientation_road_marking, nullptr);
+
+  const auto negative_orientation_road_marking =
+      RoadMarkingBuilder(RoadMarkingBuilder::SourceType::kObject, object_with_negative_orientation,
+                         xodr::RoadHeader::Id("1"), *loader_, road_geometry_)();
+  ASSERT_NE(negative_orientation_road_marking, nullptr);
+
+  EXPECT_NEAR(positive_orientation_road_marking->orientation().yaw(), 0., 1e-5);
+  EXPECT_NEAR(negative_orientation_road_marking->orientation().yaw(), 0., 1e-5);
+}
+
 class RoadMarkingBuilderSignalTest : public ::testing::Test {
  protected:
   void SetUp() override {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #519 

## Summary
Ditto.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
