### PR TITLE
Prepare for maliput_malidrive release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package maliput_malidrive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.30.0 (2026-07-17)
+-----------
+* XODR object orientation doesn't affect RoadMarking yaw-orientation. (`#529 <https://github.com/maliput/maliput_malidrive/issues/529>`_)
+* Set TrafficControlDevice related_lanes based on XODR signal/object orientation. (`#528 <https://github.com/maliput/maliput_malidrive/issues/528>`_)
+* Adding new RoadObject types (`#523 <https://github.com/maliput/maliput_malidrive/issues/523>`_)
+* Refactor object::Orientation and signal::Orientation into the same module. (`#527 <https://github.com/maliput/maliput_malidrive/issues/527>`_)
+* Initilize bulb state on builder. (`#525 <https://github.com/maliput/maliput_malidrive/issues/525>`_)
+* Add roll and pitch to signal's orientation. (`#524 <https://github.com/maliput/maliput_malidrive/issues/524>`_)
+* Contributors: Juan Carosella, Santiago Lopez
+
 0.29.0 (2026-07-06)
 -------------------
 * Improve TrafficControlDevice::Lookup by passing XODR element type (`#517 <https://github.com/maliput/maliput_malidrive/issues/517>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##############################################################################
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(maliput_malidrive LANGUAGES C CXX VERSION 0.29.0)
+project(maliput_malidrive LANGUAGES C CXX VERSION 0.30.0)
 
 ##############################################################################
 # CMake Support

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,14 +5,14 @@ Welcome to Maliput Malidrive!
 module(
     name = "maliput_malidrive",
     compatibility_level = 1,
-    version = "0.29.0",
+    version = "0.30.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
 bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "gflags", version = "2.2.2")
-bazel_dep(name = "maliput", version = "1.21.0")
+bazel_dep(name = "maliput", version = "1.22.1")
 bazel_dep(name = "tinyxml2", version = "9.0.0")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>maliput_malidrive</name>
-  <version>0.29.0</version>
+  <version>0.30.0</version>
   <description>maliput_malidrive backend</description>
   <license file="LICENSE">BSD Clause 3</license>
   <maintainer email="andrew.best@tri.global">Andrew Best</maintainer>


### PR DESCRIPTION
# 🎈 Release

## Summary
* Prepare for maliput_malidrive 0.30.0 release.
* Points to maliput 1.22.0 version.

## After PR is merged
Push git tag 0.30.0 to trigger release workflow.
```
git checkout main
git pull origin main
git tag 0.30.0
git push origin 0.30.0
```

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
