### PR TITLE
Fixing bug in OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition

### DIFF
--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -564,12 +564,19 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsT
   MALIPUT_THROW_UNLESS(reference_segment != nullptr);
   const road_curve::RoadCurve* reference_road_curve = reference_segment->road_curve();
 
-  maliput::api::RoadPosition target_position;
   // Target is in the same road.
   if (target_s >= reference_road_curve->p0() && target_s <= reference_road_curve->p1()) {
+    const Lane* target_lane = ApplyOffsetToLane(reference_lane, d_lane);
+    if (target_lane == nullptr) {
+      MALIDRIVE_THROW_MESSAGE(
+          "A maliput lane can't be found for the given OpenSCENARIO lane position: "
+          "RoadID: " +
+          std::to_string(xodr_reference_lane_position.road_id) + ", s: " + std::to_string(target_s) +
+          ", LaneID: " + std::to_string(xodr_reference_lane_position.lane_id) + ", offset: " + std::to_string(offset));
+    }
     const OpenScenarioLanePosition new_os_lane_pos{xodr_reference_lane_position.road_id, target_s,
-                                                   xodr_reference_lane_position.lane_id, offset};
-    target_position = OpenScenarioLanePositionToMaliputRoadPosition(new_os_lane_pos);
+                                                   target_lane->get_lane_id(), offset};
+    return OpenScenarioLanePositionToMaliputRoadPosition(new_os_lane_pos);
   } else {
     // The target_s falls outside this xodr_road.
     // We cover the case where:
@@ -613,22 +620,6 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsT
     return OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(new_xodr_reference_lane_position, new_d_lane,
                                                                        new_xodr_ds, offset);
   }
-
-  const Lane* target_lane = ApplyOffsetToLane(reference_lane, d_lane);
-  if (target_lane == nullptr) {
-    MALIDRIVE_THROW_MESSAGE(
-        "A maliput lane can't be found for the given OpenSCENARIO lane position: "
-        "RoadID: " +
-        std::to_string(xodr_reference_lane_position.road_id) + ", s: " + std::to_string(target_s) +
-        ", LaneID: " + std::to_string(xodr_reference_lane_position.lane_id) + ", offset: " + std::to_string(offset));
-  }
-  const OpenScenarioLanePosition new_os_lane_pos{
-      xodr_reference_lane_position.road_id,
-      target_s,
-      target_lane->get_lane_id(),
-      offset,
-  };
-  return OpenScenarioLanePositionToMaliputRoadPosition(new_os_lane_pos);
 }
 
 maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(

--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -610,7 +610,7 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsT
     const OpenScenarioLanePosition new_xodr_reference_lane_position{
         ToMalidrive(lane_end->lane)->get_track(), new_xodr_reference_s, ToMalidrive(lane_end->lane)->get_lane_id(),
         xodr_reference_lane_position.offset};
-    return OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(new_xodr_reference_lane_position, new_d_lane,
+    return OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(new_xodr_reference_lane_position, new_d_lane,
                                                                            new_xodr_ds, offset);
   }
 
@@ -622,8 +622,13 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsT
         std::to_string(xodr_reference_lane_position.road_id) + ", s: " + std::to_string(target_s) +
         ", LaneID: " + std::to_string(xodr_reference_lane_position.lane_id) + ", offset: " + std::to_string(offset));
   }
-  target_position.lane = target_lane;
-  return target_position;
+  const OpenScenarioLanePosition new_os_lane_pos{
+      xodr_reference_lane_position.road_id,
+      target_s,
+      target_lane->get_lane_id(),
+      offset,
+  };
+  return OpenScenarioLanePositionToMaliputRoadPosition(new_os_lane_pos);
 }
 
 maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(

--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -577,49 +577,47 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsT
     const OpenScenarioLanePosition new_os_lane_pos{xodr_reference_lane_position.road_id, target_s,
                                                    target_lane->get_lane_id(), offset};
     return OpenScenarioLanePositionToMaliputRoadPosition(new_os_lane_pos);
-  } else {
-    // The target_s falls outside this xodr_road.
-    // We cover the case where:
-    //  - we move backwards (negative ds) and next road is geometrically constructed in the opposite direction.
-    //  - we move backwards (negative ds) and next road is geometrically constructed in the same direction.
-    //  - we move forwards (positive ds) and next road is geometrically constructed in the opposite direction.
-    //  - we move forwards (positive ds) and next road is geometrically constructed in the same direction.
-    const bool forward_direction = xodr_ds >= 0.;
-    const double xodr_s_to_road_end = forward_direction ? reference_road_curve->p1() - xodr_reference_lane_position.s
-                                                        : reference_road_curve->p0() - xodr_reference_lane_position.s;
-    const double new_raw_xodr_ds = xodr_ds - xodr_s_to_road_end;
-    const maliput::api::RoadPosition last_road_position_before_branching =
-        OpenScenarioLanePositionToMaliputRoadPosition(
-            OpenScenarioLanePosition{xodr_reference_lane_position.road_id,
-                                     forward_direction ? reference_road_curve->p1() : reference_road_curve->p0(),
-                                     xodr_reference_lane_position.lane_id, xodr_reference_lane_position.offset});
-    const std::optional<LaneEnd> lane_end = last_road_position_before_branching.lane->GetDefaultBranch(
-        forward_direction ? LaneEnd::Which::kFinish : LaneEnd::Which::kStart);
-    if (lane_end == std::nullopt) {
-      // There is no default branch.
-      MALIDRIVE_THROW_MESSAGE("There is no connection road for the given OpenSCENARIO lane position: RoadID: " +
-                              std::to_string(xodr_reference_lane_position.road_id) +
-                              ", s: " + std::to_string(xodr_reference_lane_position.s) +
-                              ", LaneID: " + std::to_string(xodr_reference_lane_position.lane_id) +
-                              ", offset: " + std::to_string(xodr_reference_lane_position.offset));
-    }
-    const Segment* new_target_segment = ToMalidrive(lane_end->lane->segment());
-    const road_curve::RoadCurve* new_reference_road_curve = new_target_segment->road_curve();
-    const double new_xodr_reference_s =
-        lane_end->end == LaneEnd::Which::kFinish ? new_reference_road_curve->p1() : new_reference_road_curve->p0();
-    // Forward direction true + laneEnd::kStart -> no sign change for deltas
-    // Forward direction true + laneEnd::kFinish -> sign change for deltas
-    // Forward direction false + laneEnd::kStart -> sign change for deltas
-    // Forward direction false + laneEnd::kFinish -> no sign change for deltas
-    const double sign_for_new_deltas = forward_direction == (lane_end->end == LaneEnd::Which::kStart) ? 1. : -1.;
-    const double new_xodr_ds = sign_for_new_deltas * new_raw_xodr_ds;
-    const int new_d_lane = sign_for_new_deltas * d_lane;
-    const OpenScenarioLanePosition new_xodr_reference_lane_position{
-        ToMalidrive(lane_end->lane)->get_track(), new_xodr_reference_s, ToMalidrive(lane_end->lane)->get_lane_id(),
-        xodr_reference_lane_position.offset};
-    return OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(new_xodr_reference_lane_position, new_d_lane,
-                                                                       new_xodr_ds, offset);
   }
+  // The target_s falls outside this xodr_road.
+  // We cover the case where:
+  //  - we move backwards (negative ds) and next road is geometrically constructed in the opposite direction.
+  //  - we move backwards (negative ds) and next road is geometrically constructed in the same direction.
+  //  - we move forwards (positive ds) and next road is geometrically constructed in the opposite direction.
+  //  - we move forwards (positive ds) and next road is geometrically constructed in the same direction.
+  const bool forward_direction = xodr_ds >= 0.;
+  const double xodr_s_to_road_end = forward_direction ? reference_road_curve->p1() - xodr_reference_lane_position.s
+                                                      : reference_road_curve->p0() - xodr_reference_lane_position.s;
+  const double new_raw_xodr_ds = xodr_ds - xodr_s_to_road_end;
+  const maliput::api::RoadPosition last_road_position_before_branching = OpenScenarioLanePositionToMaliputRoadPosition(
+      OpenScenarioLanePosition{xodr_reference_lane_position.road_id,
+                               forward_direction ? reference_road_curve->p1() : reference_road_curve->p0(),
+                               xodr_reference_lane_position.lane_id, xodr_reference_lane_position.offset});
+  const std::optional<LaneEnd> lane_end = last_road_position_before_branching.lane->GetDefaultBranch(
+      forward_direction ? LaneEnd::Which::kFinish : LaneEnd::Which::kStart);
+  if (lane_end == std::nullopt) {
+    // There is no default branch.
+    MALIDRIVE_THROW_MESSAGE("There is no connection road for the given OpenSCENARIO lane position: RoadID: " +
+                            std::to_string(xodr_reference_lane_position.road_id) +
+                            ", s: " + std::to_string(xodr_reference_lane_position.s) +
+                            ", LaneID: " + std::to_string(xodr_reference_lane_position.lane_id) +
+                            ", offset: " + std::to_string(xodr_reference_lane_position.offset));
+  }
+  const Segment* new_target_segment = ToMalidrive(lane_end->lane->segment());
+  const road_curve::RoadCurve* new_reference_road_curve = new_target_segment->road_curve();
+  const double new_xodr_reference_s =
+      lane_end->end == LaneEnd::Which::kFinish ? new_reference_road_curve->p1() : new_reference_road_curve->p0();
+  // Forward direction true + laneEnd::kStart -> no sign change for deltas
+  // Forward direction true + laneEnd::kFinish -> sign change for deltas
+  // Forward direction false + laneEnd::kStart -> sign change for deltas
+  // Forward direction false + laneEnd::kFinish -> no sign change for deltas
+  const double sign_for_new_deltas = forward_direction == (lane_end->end == LaneEnd::Which::kStart) ? 1. : -1.;
+  const double new_xodr_ds = sign_for_new_deltas * new_raw_xodr_ds;
+  const int new_d_lane = sign_for_new_deltas * d_lane;
+  const OpenScenarioLanePosition new_xodr_reference_lane_position{
+      ToMalidrive(lane_end->lane)->get_track(), new_xodr_reference_s, ToMalidrive(lane_end->lane)->get_lane_id(),
+      xodr_reference_lane_position.offset};
+  return OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(new_xodr_reference_lane_position, new_d_lane,
+                                                                     new_xodr_ds, offset);
 }
 
 maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition(

--- a/src/maliput_malidrive/base/road_geometry.cc
+++ b/src/maliput_malidrive/base/road_geometry.cc
@@ -611,7 +611,7 @@ maliput::api::RoadPosition RoadGeometry::OpenScenarioRelativeLanePositionWithDsT
         ToMalidrive(lane_end->lane)->get_track(), new_xodr_reference_s, ToMalidrive(lane_end->lane)->get_lane_id(),
         xodr_reference_lane_position.offset};
     return OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(new_xodr_reference_lane_position, new_d_lane,
-                                                                           new_xodr_ds, offset);
+                                                                       new_xodr_ds, offset);
   }
 
   const Lane* target_lane = ApplyOffsetToLane(reference_lane, d_lane);

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -579,6 +579,33 @@ TEST_F(RoadGeometryOpenScenarioConversionsArcLane, OpenScenarioRelativeRoadPosit
       AssertCompare(IsLanePositionClose(expected_lane_position, mali_road_pos.pos, constants::kLinearTolerance)));
 }
 
+TEST_F(RoadGeometryOpenScenarioConversionsArcLane,
+       OpenScenarioRelativeLanePositionWithDsToMaliputRoadPositionRoundTripAcrossLaneChange) {
+  auto rg = dynamic_cast<const RoadGeometry*>(road_network_->road_geometry());
+
+  // Regression guard for d_lane + ds: on curved roads neighboring lanes can have
+  // different LaneSFromTrackS/TrackSFromLaneS mappings. After changing lanes, the
+  // final lane-s must be computed in the target lane parametrization.
+  const RoadGeometry::OpenScenarioLanePosition reference{1, 50., -1, 0.};
+
+  for (const double xodr_ds : {5., -5.}) {
+    const int d_lane = 1;
+    const double offset = 0.;
+    const double expected_xodr_s = reference.s + xodr_ds;
+
+    const maliput::api::RoadPosition mali_road_pos =
+        rg->OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition(reference, d_lane, xodr_ds, offset);
+    EXPECT_EQ(maliput::api::LaneId("1_0_1"), mali_road_pos.lane->id());
+
+    const RoadGeometry::OpenScenarioLanePosition round_trip =
+        rg->MaliputRoadPositionToOpenScenarioLanePosition(mali_road_pos);
+    EXPECT_EQ(reference.road_id, round_trip.road_id);
+    EXPECT_EQ(1, round_trip.lane_id);
+    EXPECT_NEAR(expected_xodr_s, round_trip.s, constants::kLinearTolerance);
+    EXPECT_NEAR(offset, round_trip.offset, constants::kLinearTolerance);
+  }
+}
+
 class RoadGeometryOpenScenarioConversionsArcLaneRolled : public ::testing::Test {
  protected:
   void SetUp() override {

--- a/test/regression/base/road_geometry_test.cc
+++ b/test/regression/base/road_geometry_test.cc
@@ -1509,7 +1509,7 @@ std::vector<CommandsInputOutputs> InstanciateCommandsInputOutputsParameters() {
       {{"MaliputRoadPositionToOpenScenarioRoadPosition,1_0_1,48.75,0.,0."}, {"1,50.000000,1.000000"}},
       {{"OpenScenarioRelativeRoadPositionToMaliputRoadPosition,1,0.,1.,50.,1."}, {"1_0_1,48.750000,1.000000,0.000000"}},
       {{"OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition,1,1,0.,-1,50.,-0.8"},
-       {"1_0_-1,48.750000,-0.800000,0.000000"}},
+       {"1_0_-1,51.250000,-0.800000,0.000000"}},
       {{"OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition,1,-1,0.,1,50.,0.8"},
        {"1_0_1,50.000000,0.800000,0.000000"}},
       {{"GetRoadOrientationAtOpenScenarioRoadPosition,1,50.,0."}, {"0.000000,-0.000000,1.250000"}},


### PR DESCRIPTION
# 🦟 Bug fix

No issue attached

## Summary

Fixes two bugs on the `OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition` function:

- Function was not calling itself recursively as it should have
- Function was returning the incorrect lane when finishing the recursive call

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.