### PR TITLE
Implement ContinuousObject API in RoadObjectBuilder.

### DIFF
--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -212,6 +212,15 @@ static constexpr char const* kUseUserDataTrafficDirection{"use_userdata_traffic_
 ///   - Default: @e "false"
 static constexpr char const* kUseUserDataIntersections{"use_userdata_intersections"};
 
+/// Number of continuous-object samples to take per road length unit when
+/// generating RoadObject continuous properties from XODR `<repeat>` records.
+///
+/// For a road of length L and value N, the nominal spacing is L / N.
+/// Repeat start and end points are always included even when spacing does not
+/// land exactly on those boundaries.
+///   - Default: @e "10"
+static constexpr char const* kContinuousObjectSamplesPerRoad{"continuous_object_samples_per_road"};
+
 /// @}
 
 }  // namespace params

--- a/include/maliput_malidrive/builder/params.h
+++ b/include/maliput_malidrive/builder/params.h
@@ -212,14 +212,14 @@ static constexpr char const* kUseUserDataTrafficDirection{"use_userdata_traffic_
 ///   - Default: @e "false"
 static constexpr char const* kUseUserDataIntersections{"use_userdata_intersections"};
 
-/// Number of continuous-object samples to take per road length unit when
-/// generating RoadObject continuous properties from XODR `<repeat>` records.
+/// Distance, in meters, between consecutive samples when generating RoadObject
+/// continuous properties from XODR `<repeat>` records.
 ///
-/// For a road of length L and value N, the nominal spacing is L / N.
-/// Repeat start and end points are always included even when spacing does not
-/// land exactly on those boundaries.
-///   - Default: @e "10"
-static constexpr char const* kContinuousObjectSamplesPerRoad{"continuous_object_samples_per_road"};
+/// Consecutive samples are spaced this distance apart in road s-coordinate.
+/// Repeat start and end points are always included, even if the final segment
+/// ends up shorter than this distance.
+///   - Default: @e "1.0" (#malidrive::constants::kContinuousObjectSamplingDistance)
+static constexpr char const* kContinuousObjectSamplingDistance{"continuous_object_sampling_distance"};
 
 /// @}
 

--- a/include/maliput_malidrive/constants.h
+++ b/include/maliput_malidrive/constants.h
@@ -46,6 +46,8 @@ static constexpr double kBaseLinearTolerance{1e-6};  // [m]
 static constexpr double kToleranceStepMultiplier{1.1};
 /// Default length of the adapting lane widths functions.
 static constexpr double kDefaultAdaptingFunctionLength{1e-1};  // [m]
+/// Default distance between consecutive ContinuousObject samples generated from XODR `<repeat>` records.
+static constexpr double kContinuousObjectSamplingDistance{1.};  // [m]
 
 /// Stricter tolerances.
 static constexpr double kStrictLinearTolerance{1e-12};   // [m]

--- a/resources/ArcLaneOffsetWithGuardRail.xodr
+++ b/resources/ArcLaneOffsetWithGuardRail.xodr
@@ -43,7 +43,6 @@
         <elevationProfile>
         </elevationProfile>
         <lateralProfile>
-            <superelevation s="0.0000000000000000e+00" a="-0.78539816339e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
         </lateralProfile>
         <lanes>
             <laneOffset s="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
@@ -91,9 +90,9 @@
                     hdg="0.0" orientation="+" dynamic="no">
                 <validity fromLane="1" toLane="1"/>
                 <repeat s="50.0" length="50.0" distance="0.0"
-                        tStart="4.5" tEnd="4.5"
+                        tStart="4.5" tEnd="5.0"
                         heightStart="1.0" heightEnd="1.0"
-                        widthStart="0.3" widthEnd="0.3"
+                        widthStart="0.3" widthEnd="1.3"
                         zOffsetStart="0.0" zOffsetEnd="0.0"/>
             </object>
             <object id="guardrail_detached_boundary" name="DetachedBoundaryGuardRail" type="barrier" subtype="guardRail"

--- a/resources/ArcLaneRolledAndOffsetWithGuardRail.xodr
+++ b/resources/ArcLaneRolledAndOffsetWithGuardRail.xodr
@@ -2,8 +2,7 @@
 <!--
  BSD 3-Clause License
 
- Copyright (c) 2022, Woven Planet. All rights reserved.
- Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
+ Copyright (c) 2026, Woven Planet. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
@@ -93,6 +92,17 @@
                 <validity fromLane="1" toLane="1"/>
                 <repeat s="50.0" length="50.0" distance="0.0"
                         tStart="4.5" tEnd="4.5"
+                        heightStart="1.0" heightEnd="1.0"
+                        widthStart="0.3" widthEnd="0.3"
+                        zOffsetStart="0.0" zOffsetEnd="0.0"/>
+            </object>
+            <object id="guardrail_detached_boundary" name="DetachedBoundaryGuardRail" type="barrier" subtype="guardRail"
+                    s="0.0" t="-0.5" zOffset="0.0"
+                    length="50.0" width="0.3" height="1.0"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="-1"/>
+                <repeat s="0.0" length="50.0" distance="0.0" detachFromReferenceLine="true"
+                        tStart="-0.5" tEnd="-0.5"
                         heightStart="1.0" heightEnd="1.0"
                         widthStart="0.3" widthEnd="0.3"
                         zOffsetStart="0.0" zOffsetEnd="0.0"/>

--- a/resources/ArcLaneRolledAndOffsetWithGuardRail.xodr
+++ b/resources/ArcLaneRolledAndOffsetWithGuardRail.xodr
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2022, Woven Planet. All rights reserved.
+ Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="1" name="ArcLaneRolledAndOffsetWithGuardRail" version="1.00" date="Wed Mar 06 12:00:00 2025" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
+    </header>
+    <road name="" length="100.0" id="1" junction="-1">
+        <link>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="100.0">
+                <arc curvature="0.025"/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+        </elevationProfile>
+        <lateralProfile>
+            <superelevation s="0.0000000000000000e+00" a="-0.78539816339e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </lateralProfile>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="1" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+            <object id="guardrail_right_boundary" name="RightBoundaryGuardRail" type="barrier" subtype="guardRail"
+                    s="0.0" t="-0.5" zOffset="0.0"
+                    length="50.0" width="0.3" height="1.0"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="-1" toLane="-1"/>
+                <repeat s="0.0" length="50.0" distance="0.0"
+                        tStart="-0.5" tEnd="-0.5"
+                        heightStart="1.0" heightEnd="1.0"
+                        widthStart="0.3" widthEnd="0.3"
+                        zOffsetStart="0.0" zOffsetEnd="0.0"/>
+            </object>
+            <object id="guardrail_left_boundary" name="LeftBoundaryGuardRail" type="barrier" subtype="guardRail"
+                    s="50.0" t="4.5" zOffset="0.0"
+                    length="50.0" width="0.3" height="1.0"
+                    hdg="0.0" orientation="+" dynamic="no">
+                <validity fromLane="1" toLane="1"/>
+                <repeat s="50.0" length="50.0" distance="0.0"
+                        tStart="4.5" tEnd="4.5"
+                        heightStart="1.0" heightEnd="1.0"
+                        widthStart="0.3" widthEnd="0.3"
+                        zOffsetStart="0.0" zOffsetEnd="0.0"/>
+            </object>
+        </objects>
+        <signals>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/src/maliput_malidrive/builder/road_geometry_configuration.cc
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.cc
@@ -180,6 +180,10 @@ RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(
   if (it != road_geometry_configuration.end()) {
     rg_config.use_userdata_intersections = ParseBoolean(it->second);
   }
+  it = road_geometry_configuration.find(params::kContinuousObjectSamplesPerRoad);
+  if (it != road_geometry_configuration.end()) {
+    rg_config.continuous_object_samples_per_road = std::stoi(it->second);
+  }
   return rg_config;
 }
 
@@ -206,6 +210,7 @@ std::map<std::string, std::string> RoadGeometryConfiguration::ToStringMap() cons
   config_map.emplace(params::kIntegratorAccuracyMultiplier, std::to_string(integrator_accuracy_multiplier));
   config_map.emplace(params::kUseUserDataTrafficDirection, use_userdata_traffic_direction ? "true" : "false");
   config_map.emplace(params::kUseUserDataIntersections, use_userdata_intersections ? "true" : "false");
+  config_map.emplace(params::kContinuousObjectSamplesPerRoad, std::to_string(continuous_object_samples_per_road));
   return config_map;
 }
 

--- a/src/maliput_malidrive/builder/road_geometry_configuration.cc
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.cc
@@ -180,9 +180,9 @@ RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(
   if (it != road_geometry_configuration.end()) {
     rg_config.use_userdata_intersections = ParseBoolean(it->second);
   }
-  it = road_geometry_configuration.find(params::kContinuousObjectSamplesPerRoad);
+  it = road_geometry_configuration.find(params::kContinuousObjectSamplingDistance);
   if (it != road_geometry_configuration.end()) {
-    rg_config.continuous_object_samples_per_road = std::stoi(it->second);
+    rg_config.continuous_object_sampling_distance = std::stod(it->second);
   }
   return rg_config;
 }
@@ -210,7 +210,7 @@ std::map<std::string, std::string> RoadGeometryConfiguration::ToStringMap() cons
   config_map.emplace(params::kIntegratorAccuracyMultiplier, std::to_string(integrator_accuracy_multiplier));
   config_map.emplace(params::kUseUserDataTrafficDirection, use_userdata_traffic_direction ? "true" : "false");
   config_map.emplace(params::kUseUserDataIntersections, use_userdata_intersections ? "true" : "false");
-  config_map.emplace(params::kContinuousObjectSamplesPerRoad, std::to_string(continuous_object_samples_per_road));
+  config_map.emplace(params::kContinuousObjectSamplingDistance, std::to_string(continuous_object_sampling_distance));
   return config_map;
 }
 

--- a/src/maliput_malidrive/builder/road_geometry_configuration.h
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.h
@@ -185,6 +185,10 @@ struct RoadGeometryConfiguration {
   double integrator_accuracy_multiplier{1.0};
   bool use_userdata_traffic_direction{false};
   bool use_userdata_intersections{false};
+  /// Sampling density for creating ContinuousObject entries from XODR repeats.
+  /// A value N means nominal step = road_length / N, with repeat endpoints
+  /// always sampled.
+  int continuous_object_samples_per_road{10};
   /// @}
 };
 

--- a/src/maliput_malidrive/builder/road_geometry_configuration.h
+++ b/src/maliput_malidrive/builder/road_geometry_configuration.h
@@ -185,10 +185,9 @@ struct RoadGeometryConfiguration {
   double integrator_accuracy_multiplier{1.0};
   bool use_userdata_traffic_direction{false};
   bool use_userdata_intersections{false};
-  /// Sampling density for creating ContinuousObject entries from XODR repeats.
-  /// A value N means nominal step = road_length / N, with repeat endpoints
-  /// always sampled.
-  int continuous_object_samples_per_road{10};
+  /// Distance, in meters, between consecutive ContinuousObject samples generated
+  /// from XODR repeats, with repeat endpoints always sampled.
+  double continuous_object_sampling_distance{constants::kContinuousObjectSamplingDistance};
   /// @}
 };
 

--- a/src/maliput_malidrive/builder/road_network_builder.cc
+++ b/src/maliput_malidrive/builder/road_network_builder.cc
@@ -90,7 +90,7 @@ std::unique_ptr<maliput::api::RoadNetwork> RoadNetworkBuilder::operator()() cons
   auto [traffic_light_book, traffic_sign_book, road_object_book, road_marking_book] =
       TrafficControlDeviceBooksBuilder(rg.get(), rn_config.traffic_light_book, rn_config.traffic_control_device_db,
                                        !rn_config.road_geometry_configuration.omit_nondrivable_lanes,
-                                       rn_config.road_geometry_configuration.continuous_object_samples_per_road)();
+                                       rn_config.road_geometry_configuration.continuous_object_sampling_distance)();
   maliput::log()->trace("Built TrafficControlDevice books.");
 
   maliput::log()->trace("Building RuleRegistry...");

--- a/src/maliput_malidrive/builder/road_network_builder.cc
+++ b/src/maliput_malidrive/builder/road_network_builder.cc
@@ -89,7 +89,8 @@ std::unique_ptr<maliput::api::RoadNetwork> RoadNetworkBuilder::operator()() cons
   maliput::log()->trace("Building TrafficControlDevice books...");
   auto [traffic_light_book, traffic_sign_book, road_object_book, road_marking_book] =
       TrafficControlDeviceBooksBuilder(rg.get(), rn_config.traffic_light_book, rn_config.traffic_control_device_db,
-                                       !rn_config.road_geometry_configuration.omit_nondrivable_lanes)();
+                                       !rn_config.road_geometry_configuration.omit_nondrivable_lanes,
+                                       rn_config.road_geometry_configuration.continuous_object_samples_per_road)();
   maliput::log()->trace("Built TrafficControlDevice books.");
 
   maliput::log()->trace("Building RuleRegistry...");

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -28,9 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_malidrive/builder/road_object_builder.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -64,9 +67,11 @@ class MalidriveRoadObject final : public maliput::api::objects::RoadObject {
                       bool is_dynamic, std::vector<maliput::api::LaneId> related_lanes, std::optional<std::string> name,
                       std::optional<std::string> subtype,
                       std::vector<std::unique_ptr<maliput::api::objects::Outline>> outlines,
-                      std::unordered_map<std::string, std::string> properties, bool is_movable)
+                      std::unordered_map<std::string, std::string> properties,
+                      std::vector<maliput::api::objects::ContinuousObject> continuous_properties, bool is_movable)
       : RoadObject(id, type, position, orientation, bounding_box, is_dynamic, std::move(related_lanes), std::move(name),
-                   std::move(subtype), std::move(outlines), std::move(properties), is_movable) {}
+                   std::move(subtype), std::move(outlines), std::move(properties), std::move(continuous_properties),
+                   is_movable) {}
 };
 
 std::optional<std::string> NormalizeSubtype(const std::string& subtype) {
@@ -86,38 +91,190 @@ std::optional<maliput::api::objects::RoadObjectType> StringToRoadObjectType(cons
   return std::nullopt;
 }
 
+/// Returns the step made for a linear interpolation between @p start and @p end, given the @p ratio.
+double Lerp(double start, double end, double ratio) { return start + (end - start) * ratio; }
+
+/// Clamps a scalar into [0, 1].
+double Clamp01(double value) { return std::max(0., std::min(1., value)); }
+
+/// Resolves a repeat width boundary, falling back to object-level dimensions.
+double ResolveRepeatWidthBoundary(const xodr::object::Object& object, const std::optional<double>& repeat_width_boundary) {
+  // Repeat width may be omitted in XODR. In that case, use object-level
+  // dimensions so continuous samples remain available.
+  if (repeat_width_boundary.has_value()) {
+    return repeat_width_boundary.value();
+  }
+  if (object.width.has_value()) {
+    return object.width.value();
+  }
+  if (object.radius.has_value()) {
+    return object.radius.value() * 2.;
+  }
+  return 0.;
+}
+
+/// Builds the s-sample set for a qualifying repeat.
+///
+/// Sampling uses the repeat length and the configured samples-per-road value.
+/// Repeat start and end are always present in the returned vector.
+std::vector<double> BuildSampleSCoordinates(const xodr::object::Repeat& repeat, int samples_per_road) {
+  MALIDRIVE_VALIDATE(samples_per_road > 0, maliput::common::assertion_error, "samples_per_road must be positive.");
+
+  const double start_s = repeat.s;
+  const double end_s = repeat.s + repeat.length;
+  const double min_s = std::min(start_s, end_s);
+  const double max_s = std::max(start_s, end_s);
+
+  if (std::abs(max_s - min_s) < 1e-12) {
+    return {start_s};
+  }
+
+  const double nominal_step = (max_s - min_s) / static_cast<double>(samples_per_road);
+  const double step = nominal_step > 0. ? nominal_step : (max_s - min_s);
+
+  std::vector<double> samples{start_s};
+  double sample_s = min_s + step;
+  const double kEpsilon = 1e-10;
+  while (sample_s < max_s - kEpsilon) {
+    samples.push_back(start_s <= end_s ? sample_s : (start_s - (sample_s - min_s)));
+    sample_s += step;
+  }
+  if (std::abs(samples.back() - end_s) > kEpsilon) {
+    samples.push_back(end_s);
+  }
+  return samples;
+}
+
+/// Converts qualifying XODR repeat entries into ContinuousObject samples.
+///
+/// Only repeats with distance == 0 are considered. By default, each sample is
+/// projected from OpenDRIVE road coordinates. The returned inertial position's
+/// lateral coordinate is centered on the object (so interpolated width extends
+/// width/2 to each side along the object r-axis).
+///
+/// The returned inertial position's z-coordinate is anchored at the interpolated
+/// object bottom for that s-coordinate, and the interpolated height extends upward from that point.
+/// When detachFromReferenceLine is true, the sampled points are interpolated between
+/// the repeat endpoints as a straight line.
+maliput::api::InertialPosition BuildRepeatSamplePoint(const xodr::object::Object& object,
+                                                      const xodr::object::Repeat& repeat,
+                                                      const maliput::api::RoadGeometry* road_geometry,
+                                                      const xodr::RoadHeader::Id& road_id, double sample_road_s,
+                                                      double ratio, const malidrive::RoadGeometry* mali_rg) {
+  const double t = Lerp(repeat.t_start, repeat.t_end, ratio);
+  const double z_offset = Lerp(repeat.z_offset_start, repeat.z_offset_end, ratio);
+  const double width_start = ResolveRepeatWidthBoundary(object, repeat.width_start);
+  const double width_end = ResolveRepeatWidthBoundary(object, repeat.width_end);
+  const double width = Lerp(width_start, width_end, ratio);
+  const double height = Lerp(repeat.height_start, repeat.height_end, ratio);
+
+  const double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry, road_id, sample_road_s, object.id.string());
+  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_position{std::stoi(road_id.string()), adjusted_s,
+                                                                       t};
+  const maliput::api::RoadPosition sample_road_position =
+      mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_position, true);
+
+  maliput::api::InertialPosition sample_point = sample_road_position.ToInertialPosition();
+  sample_point.set_z(sample_point.z() + z_offset);
+  return sample_point;
+}
+
+std::vector<maliput::api::objects::ContinuousObject> BuildContinuousProperties(
+    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id, const maliput::api::RoadGeometry* road_geometry,
+    int samples_per_road) {
+  std::vector<maliput::api::objects::ContinuousObject> continuous_properties;
+  if (object.repeats.empty()) {
+    return continuous_properties;
+  }
+
+  const auto* mali_rg = dynamic_cast<const malidrive::RoadGeometry*>(road_geometry);
+  MALIDRIVE_VALIDATE(mali_rg != nullptr, maliput::common::assertion_error,
+                     "RoadGeometry cannot be cast to malidrive::RoadGeometry.");
+
+  for (const auto& repeat : object.repeats) {
+    // Current scope: only repeats that model one continuous object instance.
+    // Discrete object repeats are treated as separate RoadObjects.
+    if (repeat.distance != 0.) {
+      continue;
+    }
+    const auto sample_s_coordinates = BuildSampleSCoordinates(repeat, samples_per_road);
+    const bool detach_from_reference_line = repeat.detach_from_reference_line.value_or(false);
+    std::optional<maliput::api::InertialPosition> detached_start_point;
+    std::optional<maliput::api::InertialPosition> detached_end_point;
+    if (detach_from_reference_line) {
+      detached_start_point =
+          BuildRepeatSamplePoint(object, repeat, road_geometry, road_id, repeat.s, 0., mali_rg);
+      detached_end_point =
+          BuildRepeatSamplePoint(object, repeat, road_geometry, road_id, repeat.s + repeat.length, 1., mali_rg);
+    }
+    for (const double sample_road_s : sample_s_coordinates) {
+      const double span = repeat.length;
+      const double ratio = std::abs(span) < 1e-12 ? 0. : Clamp01((sample_road_s - repeat.s) / span);
+
+      const double width_start = ResolveRepeatWidthBoundary(object, repeat.width_start);
+      const double width_end = ResolveRepeatWidthBoundary(object, repeat.width_end);
+      const double width = Lerp(width_start, width_end, ratio);
+      const double height = Lerp(repeat.height_start, repeat.height_end, ratio);
+
+      std::optional<maliput::api::InertialPosition> sample_point;
+      // When detachFromReferenceLine is true, the sample point is interpolated between the repeat endpoints as a straight line.
+      if (detach_from_reference_line) {
+        MALIDRIVE_VALIDATE(detached_start_point.has_value() && detached_end_point.has_value(),
+                           std::logic_error, "Detached repeat endpoints are not initialized.");
+        sample_point = maliput::api::InertialPosition{
+            Lerp(detached_start_point->x(), detached_end_point->x(), ratio),
+            Lerp(detached_start_point->y(), detached_end_point->y(), ratio),
+            Lerp(detached_start_point->z(), detached_end_point->z(), ratio),
+        };
+      } else {
+        sample_point = BuildRepeatSamplePoint(object, repeat, road_geometry, road_id, sample_road_s, ratio, mali_rg);
+      }
+      continuous_properties.emplace_back(width, height, *sample_point);
+    }
+  }
+  return continuous_properties;
+}
+
 }  // namespace
 
 RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::object::Object& object,
                                      const xodr::RoadHeader::Id& road_id,
                                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                                      const maliput::api::RoadGeometry* road_geometry,
-                                     std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references)
+                                     std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references,
+                                     int continuous_object_samples_per_road)
     : source_type_(source_type),
       object_(&object),
       road_id_(road_id),
       loader_(loader),
       road_geometry_(road_geometry),
-      object_references_(std::move(object_references)) {
+      object_references_(std::move(object_references)),
+      continuous_object_samples_per_road_(continuous_object_samples_per_road) {
   MALIDRIVE_VALIDATE(source_type_ == SourceType::kObject, std::invalid_argument,
                      "RoadObjectBuilder object constructor requires SourceType::kObject.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
+  MALIDRIVE_VALIDATE(continuous_object_samples_per_road_ > 0, std::invalid_argument,
+                     "continuous_object_samples_per_road must be positive.");
 }
 
 RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::signal::Signal& signal,
                                      const xodr::RoadHeader::Id& road_id,
                                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                                      const maliput::api::RoadGeometry* road_geometry,
-                                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references)
+                                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references,
+                                     int continuous_object_samples_per_road)
     : source_type_(source_type),
       signal_(&signal),
       road_id_(road_id),
       loader_(loader),
       road_geometry_(road_geometry),
-      signal_references_(std::move(signal_references)) {
+      signal_references_(std::move(signal_references)),
+      continuous_object_samples_per_road_(continuous_object_samples_per_road) {
   MALIDRIVE_VALIDATE(source_type_ == SourceType::kSignal, std::invalid_argument,
                      "RoadObjectBuilder signal constructor requires SourceType::kSignal.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
+  MALIDRIVE_VALIDATE(continuous_object_samples_per_road_ > 0, std::invalid_argument,
+                     "continuous_object_samples_per_road must be positive.");
 }
 
 std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()() const {
@@ -149,7 +306,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
       maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
-      inertial_pos.set_z(inertial_pos.z() + object.z_offset);
+      inertial_pos.set_z(inertial_pos.z() + object.z_offset)
       const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
 
       // --- Orientation ---
@@ -181,6 +338,9 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       auto related_lanes = ResolveLaneIds(object, adjusted_s, road_id_, object_references_, road_geometry_);
       // --- Outlines ---
       auto outlines = BuildOutlines(object, road_id_, road_geometry_, inertial_pos, orientation);
+      // Repeats with distance == 0 are represented as sampled continuous properties.
+      auto continuous_properties =
+          BuildContinuousProperties(object, road_id_, road_geometry_, continuous_object_samples_per_road_);
 
       std::unordered_map<std::string, std::string> properties;
       if (!object.materials.empty()) {
@@ -195,7 +355,8 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       return std::make_unique<MalidriveRoadObject>(maliput::api::objects::RoadObject::Id(object.id.string()), type,
                                                    position, orientation, bounding_box, object.dynamic.value_or(false),
                                                    std::move(related_lanes), object.name, object.subtype,
-                                                   std::move(outlines), std::move(properties), is_movable);
+                                                   std::move(outlines), std::move(properties),
+                                                   std::move(continuous_properties), is_movable);
     }
     case SourceType::kSignal: {
       MALIDRIVE_VALIDATE(signal_ != nullptr, maliput::common::assertion_error,
@@ -259,7 +420,8 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
           maliput::api::objects::RoadObject::Id(signal.id.string()), type, position, orientation, bounding_box,
           signal.dynamic, std::move(related_lanes), signal.name, NormalizeSubtype(signal.subtype),
           std::vector<std::unique_ptr<maliput::api::objects::Outline>>{},
-          std::unordered_map<std::string, std::string>{}, is_movable);
+          std::unordered_map<std::string, std::string>{}, std::vector<maliput::api::objects::ContinuousObject>{},
+          is_movable);
     }
   }
 

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -98,7 +98,8 @@ double Lerp(double start, double end, double ratio) { return start + (end - star
 double Clamp01(double value) { return std::max(0., std::min(1., value)); }
 
 /// Resolves a repeat width boundary, falling back to object-level dimensions.
-double ResolveRepeatWidthBoundary(const xodr::object::Object& object, const std::optional<double>& repeat_width_boundary) {
+double ResolveRepeatWidthBoundary(const xodr::object::Object& object,
+                                  const std::optional<double>& repeat_width_boundary) {
   // Repeat width may be omitted in XODR. In that case, use object-level
   // dimensions so continuous samples remain available.
   if (repeat_width_boundary.has_value()) {
@@ -165,12 +166,9 @@ maliput::api::InertialPosition BuildRepeatSamplePoint(const xodr::object::Object
   const double z_offset = Lerp(repeat.z_offset_start, repeat.z_offset_end, ratio);
   const double width_start = ResolveRepeatWidthBoundary(object, repeat.width_start);
   const double width_end = ResolveRepeatWidthBoundary(object, repeat.width_end);
-  const double width = Lerp(width_start, width_end, ratio);
-  const double height = Lerp(repeat.height_start, repeat.height_end, ratio);
 
   const double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry, road_id, sample_road_s, object.id.string());
-  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_position{std::stoi(road_id.string()), adjusted_s,
-                                                                       t};
+  const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_position{std::stoi(road_id.string()), adjusted_s, t};
   const maliput::api::RoadPosition sample_road_position =
       mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_position, true);
 
@@ -180,8 +178,8 @@ maliput::api::InertialPosition BuildRepeatSamplePoint(const xodr::object::Object
 }
 
 std::vector<maliput::api::objects::ContinuousObject> BuildContinuousProperties(
-    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id, const maliput::api::RoadGeometry* road_geometry,
-    int samples_per_road) {
+    const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
+    const maliput::api::RoadGeometry* road_geometry, int samples_per_road) {
   std::vector<maliput::api::objects::ContinuousObject> continuous_properties;
   if (object.repeats.empty()) {
     return continuous_properties;
@@ -202,8 +200,7 @@ std::vector<maliput::api::objects::ContinuousObject> BuildContinuousProperties(
     std::optional<maliput::api::InertialPosition> detached_start_point;
     std::optional<maliput::api::InertialPosition> detached_end_point;
     if (detach_from_reference_line) {
-      detached_start_point =
-          BuildRepeatSamplePoint(object, repeat, road_geometry, road_id, repeat.s, 0., mali_rg);
+      detached_start_point = BuildRepeatSamplePoint(object, repeat, road_geometry, road_id, repeat.s, 0., mali_rg);
       detached_end_point =
           BuildRepeatSamplePoint(object, repeat, road_geometry, road_id, repeat.s + repeat.length, 1., mali_rg);
     }
@@ -217,10 +214,11 @@ std::vector<maliput::api::objects::ContinuousObject> BuildContinuousProperties(
       const double height = Lerp(repeat.height_start, repeat.height_end, ratio);
 
       std::optional<maliput::api::InertialPosition> sample_point;
-      // When detachFromReferenceLine is true, the sample point is interpolated between the repeat endpoints as a straight line.
+      // When detachFromReferenceLine is true, the sample point is interpolated between the repeat endpoints as a
+      // straight line.
       if (detach_from_reference_line) {
-        MALIDRIVE_VALIDATE(detached_start_point.has_value() && detached_end_point.has_value(),
-                           std::logic_error, "Detached repeat endpoints are not initialized.");
+        MALIDRIVE_VALIDATE(detached_start_point.has_value() && detached_end_point.has_value(), std::logic_error,
+                           "Detached repeat endpoints are not initialized.");
         sample_point = maliput::api::InertialPosition{
             Lerp(detached_start_point->x(), detached_end_point->x(), ratio),
             Lerp(detached_start_point->y(), detached_end_point->y(), ratio),
@@ -306,7 +304,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       const maliput::api::RoadPosition rp =
           mali_rg->OpenScenarioRoadPositionToMaliputRoadPosition(osc_road_position, true);
       maliput::api::InertialPosition inertial_pos = rp.ToInertialPosition();
-      inertial_pos.set_z(inertial_pos.z() + object.z_offset)
+      inertial_pos.set_z(inertial_pos.z() + object.z_offset);
       const maliput::api::objects::RoadObjectPosition position(inertial_pos, rp.lane->id(), rp.pos);
 
       // --- Orientation ---
@@ -352,11 +350,10 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
                             "' type=", static_cast<int>(type), " position=(", inertial_pos.x(), ", ", inertial_pos.y(),
                             ", ", inertial_pos.z(), ") related_lanes=", related_lanes.size(), ".");
 
-      return std::make_unique<MalidriveRoadObject>(maliput::api::objects::RoadObject::Id(object.id.string()), type,
-                                                   position, orientation, bounding_box, object.dynamic.value_or(false),
-                                                   std::move(related_lanes), object.name, object.subtype,
-                                                   std::move(outlines), std::move(properties),
-                                                   std::move(continuous_properties), is_movable);
+      return std::make_unique<MalidriveRoadObject>(
+          maliput::api::objects::RoadObject::Id(object.id.string()), type, position, orientation, bounding_box,
+          object.dynamic.value_or(false), std::move(related_lanes), object.name, object.subtype, std::move(outlines),
+          std::move(properties), std::move(continuous_properties), is_movable);
     }
     case SourceType::kSignal: {
       MALIDRIVE_VALIDATE(signal_ != nullptr, maliput::common::assertion_error,

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -116,10 +116,12 @@ double ResolveRepeatWidthBoundary(const xodr::object::Object& object,
 
 /// Builds the s-sample set for a qualifying repeat.
 ///
-/// Sampling uses the repeat length and the configured samples-per-road value.
-/// Repeat start and end are always present in the returned vector.
-std::vector<double> BuildSampleSCoordinates(const xodr::object::Repeat& repeat, int samples_per_road) {
-  MALIDRIVE_VALIDATE(samples_per_road > 0, maliput::common::assertion_error, "samples_per_road must be positive.");
+/// Repeat start and end are always taken verbatim from the repeat's position and
+/// length. Interior samples are added on top, spaced @p sampling_distance apart;
+/// the final segment (last interior sample to the repeat end) may be shorter than
+/// @p sampling_distance.
+std::vector<double> BuildSampleSCoordinates(const xodr::object::Repeat& repeat, double sampling_distance) {
+  MALIDRIVE_VALIDATE(sampling_distance > 0., maliput::common::assertion_error, "sampling_distance must be positive.");
 
   const double start_s = repeat.s;
   const double end_s = repeat.s + repeat.length;
@@ -130,15 +132,12 @@ std::vector<double> BuildSampleSCoordinates(const xodr::object::Repeat& repeat, 
     return {start_s};
   }
 
-  const double nominal_step = (max_s - min_s) / static_cast<double>(samples_per_road);
-  const double step = nominal_step > 0. ? nominal_step : (max_s - min_s);
-
   std::vector<double> samples{start_s};
-  double sample_s = min_s + step;
+  double sample_s = min_s + sampling_distance;
   const double kEpsilon = 1e-10;
   while (sample_s < max_s - kEpsilon) {
     samples.push_back(start_s <= end_s ? sample_s : (start_s - (sample_s - min_s)));
-    sample_s += step;
+    sample_s += sampling_distance;
   }
   if (std::abs(samples.back() - end_s) > kEpsilon) {
     samples.push_back(end_s);
@@ -177,7 +176,7 @@ maliput::api::InertialPosition BuildRepeatSamplePoint(const xodr::object::Object
 
 std::vector<maliput::api::objects::ContinuousObject> BuildContinuousProperties(
     const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
-    const maliput::api::RoadGeometry* road_geometry, int samples_per_road) {
+    const maliput::api::RoadGeometry* road_geometry, double sampling_distance) {
   std::vector<maliput::api::objects::ContinuousObject> continuous_properties;
   if (object.repeats.empty()) {
     return continuous_properties;
@@ -193,7 +192,7 @@ std::vector<maliput::api::objects::ContinuousObject> BuildContinuousProperties(
     if (repeat.distance != 0.) {
       continue;
     }
-    const auto sample_s_coordinates = BuildSampleSCoordinates(repeat, samples_per_road);
+    const auto sample_s_coordinates = BuildSampleSCoordinates(repeat, sampling_distance);
     const bool detach_from_reference_line = repeat.detach_from_reference_line.value_or(false);
     std::optional<maliput::api::InertialPosition> detached_start_point;
     std::optional<maliput::api::InertialPosition> detached_end_point;
@@ -238,19 +237,19 @@ RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::object:
                                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                                      const maliput::api::RoadGeometry* road_geometry,
                                      std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references,
-                                     int continuous_object_samples_per_road)
+                                     double continuous_object_sampling_distance)
     : source_type_(source_type),
       object_(&object),
       road_id_(road_id),
       loader_(loader),
       road_geometry_(road_geometry),
       object_references_(std::move(object_references)),
-      continuous_object_samples_per_road_(continuous_object_samples_per_road) {
+      continuous_object_sampling_distance_(continuous_object_sampling_distance) {
   MALIDRIVE_VALIDATE(source_type_ == SourceType::kObject, std::invalid_argument,
                      "RoadObjectBuilder object constructor requires SourceType::kObject.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
-  MALIDRIVE_VALIDATE(continuous_object_samples_per_road_ > 0, std::invalid_argument,
-                     "continuous_object_samples_per_road must be positive.");
+  MALIDRIVE_VALIDATE(continuous_object_sampling_distance_ > 0., std::invalid_argument,
+                     "continuous_object_sampling_distance must be positive.");
 }
 
 RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::signal::Signal& signal,
@@ -258,19 +257,19 @@ RoadObjectBuilder::RoadObjectBuilder(SourceType source_type, const xodr::signal:
                                      const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                                      const maliput::api::RoadGeometry* road_geometry,
                                      std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references,
-                                     int continuous_object_samples_per_road)
+                                     double continuous_object_sampling_distance)
     : source_type_(source_type),
       signal_(&signal),
       road_id_(road_id),
       loader_(loader),
       road_geometry_(road_geometry),
       signal_references_(std::move(signal_references)),
-      continuous_object_samples_per_road_(continuous_object_samples_per_road) {
+      continuous_object_sampling_distance_(continuous_object_sampling_distance) {
   MALIDRIVE_VALIDATE(source_type_ == SourceType::kSignal, std::invalid_argument,
                      "RoadObjectBuilder signal constructor requires SourceType::kSignal.");
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, std::invalid_argument, "road_geometry must not be nullptr.");
-  MALIDRIVE_VALIDATE(continuous_object_samples_per_road_ > 0, std::invalid_argument,
-                     "continuous_object_samples_per_road must be positive.");
+  MALIDRIVE_VALIDATE(continuous_object_sampling_distance_ > 0., std::invalid_argument,
+                     "continuous_object_sampling_distance must be positive.");
 }
 
 std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()() const {
@@ -336,7 +335,7 @@ std::unique_ptr<maliput::api::objects::RoadObject> RoadObjectBuilder::operator()
       auto outlines = BuildOutlines(object, road_id_, road_geometry_, inertial_pos, orientation);
       // Repeats with distance == 0 are represented as sampled continuous properties.
       auto continuous_properties =
-          BuildContinuousProperties(object, road_id_, road_geometry_, continuous_object_samples_per_road_);
+          BuildContinuousProperties(object, road_id_, road_geometry_, continuous_object_sampling_distance_);
 
       std::unordered_map<std::string, std::string> properties;
       if (!object.materials.empty()) {

--- a/src/maliput_malidrive/builder/road_object_builder.cc
+++ b/src/maliput_malidrive/builder/road_object_builder.cc
@@ -164,8 +164,6 @@ maliput::api::InertialPosition BuildRepeatSamplePoint(const xodr::object::Object
                                                       double ratio, const malidrive::RoadGeometry* mali_rg) {
   const double t = Lerp(repeat.t_start, repeat.t_end, ratio);
   const double z_offset = Lerp(repeat.z_offset_start, repeat.z_offset_end, ratio);
-  const double width_start = ResolveRepeatWidthBoundary(object, repeat.width_start);
-  const double width_end = ResolveRepeatWidthBoundary(object, repeat.width_end);
 
   const double adjusted_s = AdjustSCoordinateToLaneSection(road_geometry, road_id, sample_road_s, object.id.string());
   const malidrive::RoadGeometry::OpenScenarioRoadPosition osc_position{std::stoi(road_id.string()), adjusted_s, t};

--- a/src/maliput_malidrive/builder/road_object_builder.h
+++ b/src/maliput_malidrive/builder/road_object_builder.h
@@ -34,6 +34,7 @@
 #include <maliput/api/objects/road_object.h>
 #include <maliput/api/road_geometry.h>
 
+#include "maliput_malidrive/constants.h"
 #include "maliput_malidrive/traffic_control_device/traffic_control_device_database_loader.h"
 #include "maliput_malidrive/xodr/db_manager.h"
 #include "maliput_malidrive/xodr/object/object.h"
@@ -64,14 +65,14 @@ class RoadObjectBuilder {
   /// @param loader Database loader for looking up object device definitions.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
   /// @param object_references Object references from other roads that point to @p object.
-  /// @param continuous_object_samples_per_road Sampling density for continuous properties.
-  ///        A value N means nominal sample spacing lane_length / N; repeat endpoints are always sampled.
+  /// @param continuous_object_sampling_distance Distance, in meters, between consecutive
+  ///        continuous property samples; repeat endpoints are always sampled.
   /// @throws std::invalid_argument if @p source_type is not kObject or @p road_geometry is nullptr.
   RoadObjectBuilder(SourceType source_type, const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                     const maliput::api::RoadGeometry* road_geometry,
                     std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references = {},
-                    int continuous_object_samples_per_road = 10);
+                    double continuous_object_sampling_distance = constants::kContinuousObjectSamplingDistance);
 
   /// Constructs a RoadObjectBuilder.
   ///
@@ -81,13 +82,14 @@ class RoadObjectBuilder {
   /// @param loader Database loader for looking up signal device definitions.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
   /// @param signal_references Signal references from other roads that point to @p signal.
-  /// @param continuous_object_samples_per_road Sampling density for continuous properties.
+  /// @param continuous_object_sampling_distance Distance, in meters, between consecutive
+  ///        continuous property samples; repeat endpoints are always sampled.
   /// @throws std::invalid_argument if @p source_type is not kSignal or @p road_geometry is nullptr.
   RoadObjectBuilder(SourceType source_type, const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                     const maliput::api::RoadGeometry* road_geometry,
                     std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {},
-                    int continuous_object_samples_per_road = 10);
+                    double continuous_object_sampling_distance = constants::kContinuousObjectSamplingDistance);
 
   /// Builds and returns the @ref maliput::api::objects::RoadObject.
   ///
@@ -103,7 +105,7 @@ class RoadObjectBuilder {
   const maliput::api::RoadGeometry* road_geometry_;
   const std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references_;
   const std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references_;
-  const int continuous_object_samples_per_road_{10};
+  const double continuous_object_sampling_distance_{constants::kContinuousObjectSamplingDistance};
 };
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/road_object_builder.h
+++ b/src/maliput_malidrive/builder/road_object_builder.h
@@ -64,11 +64,14 @@ class RoadObjectBuilder {
   /// @param loader Database loader for looking up object device definitions.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
   /// @param object_references Object references from other roads that point to @p object.
+  /// @param continuous_object_samples_per_road Sampling density for continuous properties.
+  ///        A value N means nominal sample spacing lane_length / N; repeat endpoints are always sampled.
   /// @throws std::invalid_argument if @p source_type is not kObject or @p road_geometry is nullptr.
   RoadObjectBuilder(SourceType source_type, const xodr::object::Object& object, const xodr::RoadHeader::Id& road_id,
                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                     const maliput::api::RoadGeometry* road_geometry,
-                    std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references = {});
+                    std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references = {},
+                    int continuous_object_samples_per_road = 10);
 
   /// Constructs a RoadObjectBuilder.
   ///
@@ -78,11 +81,13 @@ class RoadObjectBuilder {
   /// @param loader Database loader for looking up signal device definitions.
   /// @param road_geometry Pointer to the road geometry. Must not be nullptr.
   /// @param signal_references Signal references from other roads that point to @p signal.
+  /// @param continuous_object_samples_per_road Sampling density for continuous properties.
   /// @throws std::invalid_argument if @p source_type is not kSignal or @p road_geometry is nullptr.
   RoadObjectBuilder(SourceType source_type, const xodr::signal::Signal& signal, const xodr::RoadHeader::Id& road_id,
                     const traffic_control_device::TrafficControlDeviceDatabaseLoader& loader,
                     const maliput::api::RoadGeometry* road_geometry,
-                    std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {});
+                    std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references = {},
+                    int continuous_object_samples_per_road = 10);
 
   /// Builds and returns the @ref maliput::api::objects::RoadObject.
   ///
@@ -98,6 +103,7 @@ class RoadObjectBuilder {
   const maliput::api::RoadGeometry* road_geometry_;
   const std::vector<xodr::DBManager::ObjectReferenceOnRoad> object_references_;
   const std::vector<xodr::DBManager::SignalReferenceOnRoad> signal_references_;
+  const int continuous_object_samples_per_road_{10};
 };
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -57,15 +57,15 @@ TrafficControlDeviceBooksBuilder::TrafficControlDeviceBooksBuilder(const maliput
                                                                    std::optional<std::string> traffic_light_book_path,
                                                                    std::optional<std::string> traffic_control_device_db,
                                                                    bool allow_non_driveable_lanes,
-                                                                   int continuous_object_samples_per_road)
+                                                                   double continuous_object_sampling_distance)
     : road_geometry_(road_geometry),
       traffic_light_book_path_(std::move(traffic_light_book_path)),
       traffic_control_device_db_(std::move(traffic_control_device_db)),
       allow_non_driveable_lanes_(allow_non_driveable_lanes),
-      continuous_object_samples_per_road_(continuous_object_samples_per_road) {
+      continuous_object_sampling_distance_(continuous_object_sampling_distance) {
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, maliput::common::assertion_error, "road_geometry must not be nullptr.");
-  MALIDRIVE_VALIDATE(continuous_object_samples_per_road_ > 0, maliput::common::assertion_error,
-                     "continuous_object_samples_per_road must be positive.");
+  MALIDRIVE_VALIDATE(continuous_object_sampling_distance_ > 0., maliput::common::assertion_error,
+                     "continuous_object_sampling_distance must be positive.");
 }
 
 TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
@@ -148,7 +148,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
         auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal, road_id, loader, road_geometry_,
-                                    std::move(refs), continuous_object_samples_per_road_)();
+                                    std::move(refs), continuous_object_sampling_distance_)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }
@@ -201,7 +201,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
                               object.id.string(), "' type='", type_str, "' subtype='", object.subtype.value_or(""),
                               "' name='", object.name.value_or(""), "'.");
         auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_,
-                                    refs, continuous_object_samples_per_road_)();
+                                    refs, continuous_object_sampling_distance_)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }
@@ -218,7 +218,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
         auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_,
-                                    std::move(refs), continuous_object_samples_per_road_)();
+                                    std::move(refs), continuous_object_sampling_distance_)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -56,12 +56,16 @@ namespace builder {
 TrafficControlDeviceBooksBuilder::TrafficControlDeviceBooksBuilder(const maliput::api::RoadGeometry* road_geometry,
                                                                    std::optional<std::string> traffic_light_book_path,
                                                                    std::optional<std::string> traffic_control_device_db,
-                                                                   bool allow_non_driveable_lanes)
+                                                                   bool allow_non_driveable_lanes,
+                                                                   int continuous_object_samples_per_road)
     : road_geometry_(road_geometry),
       traffic_light_book_path_(std::move(traffic_light_book_path)),
       traffic_control_device_db_(std::move(traffic_control_device_db)),
-      allow_non_driveable_lanes_(allow_non_driveable_lanes) {
+      allow_non_driveable_lanes_(allow_non_driveable_lanes),
+      continuous_object_samples_per_road_(continuous_object_samples_per_road) {
   MALIDRIVE_VALIDATE(road_geometry_ != nullptr, maliput::common::assertion_error, "road_geometry must not be nullptr.");
+  MALIDRIVE_VALIDATE(continuous_object_samples_per_road_ > 0, maliput::common::assertion_error,
+                     "continuous_object_samples_per_road must be positive.");
 }
 
 TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
@@ -144,7 +148,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
         auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kSignal, signal, road_id, loader, road_geometry_,
-                                    std::move(refs))();
+                                    std::move(refs), continuous_object_samples_per_road_)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }
@@ -197,7 +201,8 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
                               object.id.string(), "' type='", type_str, "' subtype='", object.subtype.value_or(""),
                               "' name='", object.name.value_or(""), "'.");
         auto ro =
-            RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_, refs)();
+            RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_, refs,
+                              continuous_object_samples_per_road_)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }
@@ -214,7 +219,7 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         }
       } else if (definition.device_type == traffic_control_device::TrafficControlDeviceType::kRoadObject) {
         auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_,
-                                    std::move(refs))();
+                                    std::move(refs), continuous_object_samples_per_road_)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.cc
@@ -200,9 +200,8 @@ TrafficControlDeviceBooks TrafficControlDeviceBooksBuilder::operator()() const {
         maliput::log()->debug("TrafficControlDeviceBooksBuilder: no definition found for object id='",
                               object.id.string(), "' type='", type_str, "' subtype='", object.subtype.value_or(""),
                               "' name='", object.name.value_or(""), "'.");
-        auto ro =
-            RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_, refs,
-                              continuous_object_samples_per_road_)();
+        auto ro = RoadObjectBuilder(RoadObjectBuilder::SourceType::kObject, object, road_id, loader, road_geometry_,
+                                    refs, continuous_object_samples_per_road_)();
         if (ro) {
           rob->AddRoadObject(std::move(ro));
         }

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.h
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.h
@@ -86,8 +86,7 @@ class TrafficControlDeviceBooksBuilder {
   /// @throws maliput::common::assertion_error When @p road_geometry is nullptr.
   TrafficControlDeviceBooksBuilder(const maliput::api::RoadGeometry* road_geometry,
                                    std::optional<std::string> traffic_light_book_path,
-                                   std::optional<std::string> traffic_control_device_db,
-                                   bool allow_non_driveable_lanes,
+                                   std::optional<std::string> traffic_control_device_db, bool allow_non_driveable_lanes,
                                    int continuous_object_samples_per_road = 10);
 
   TrafficControlDeviceBooksBuilder() = delete;

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.h
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.h
@@ -39,6 +39,7 @@
 #include <maliput/api/rules/traffic_sign_book.h>
 
 #include "maliput_malidrive/common/macros.h"
+#include "maliput_malidrive/constants.h"
 
 namespace malidrive {
 namespace builder {
@@ -81,13 +82,13 @@ class TrafficControlDeviceBooksBuilder {
   ///        @p traffic_light_book_path for the TrafficLightBook).
   /// @param allow_non_driveable_lanes If false, any XODR road without driveable lanes will
   ///        be skipped when building books.
-  /// @param continuous_object_samples_per_road Sampling density for ContinuousObject
-  ///        generation in RoadObjectBuilder.
+  /// @param continuous_object_sampling_distance Distance, in meters, between consecutive
+  ///        ContinuousObject samples generated in RoadObjectBuilder.
   /// @throws maliput::common::assertion_error When @p road_geometry is nullptr.
-  TrafficControlDeviceBooksBuilder(const maliput::api::RoadGeometry* road_geometry,
-                                   std::optional<std::string> traffic_light_book_path,
-                                   std::optional<std::string> traffic_control_device_db, bool allow_non_driveable_lanes,
-                                   int continuous_object_samples_per_road = 10);
+  TrafficControlDeviceBooksBuilder(
+      const maliput::api::RoadGeometry* road_geometry, std::optional<std::string> traffic_light_book_path,
+      std::optional<std::string> traffic_control_device_db, bool allow_non_driveable_lanes,
+      double continuous_object_sampling_distance = constants::kContinuousObjectSamplingDistance);
 
   TrafficControlDeviceBooksBuilder() = delete;
 
@@ -101,7 +102,7 @@ class TrafficControlDeviceBooksBuilder {
   const std::optional<std::string> traffic_light_book_path_;
   const std::optional<std::string> traffic_control_device_db_;
   const bool allow_non_driveable_lanes_;
-  const int continuous_object_samples_per_road_{10};
+  const double continuous_object_sampling_distance_{constants::kContinuousObjectSamplingDistance};
 };
 
 }  // namespace builder

--- a/src/maliput_malidrive/builder/traffic_control_device_books_builder.h
+++ b/src/maliput_malidrive/builder/traffic_control_device_books_builder.h
@@ -81,11 +81,14 @@ class TrafficControlDeviceBooksBuilder {
   ///        @p traffic_light_book_path for the TrafficLightBook).
   /// @param allow_non_driveable_lanes If false, any XODR road without driveable lanes will
   ///        be skipped when building books.
+  /// @param continuous_object_samples_per_road Sampling density for ContinuousObject
+  ///        generation in RoadObjectBuilder.
   /// @throws maliput::common::assertion_error When @p road_geometry is nullptr.
   TrafficControlDeviceBooksBuilder(const maliput::api::RoadGeometry* road_geometry,
                                    std::optional<std::string> traffic_light_book_path,
                                    std::optional<std::string> traffic_control_device_db,
-                                   bool allow_non_driveable_lanes);
+                                   bool allow_non_driveable_lanes,
+                                   int continuous_object_samples_per_road = 10);
 
   TrafficControlDeviceBooksBuilder() = delete;
 
@@ -99,6 +102,7 @@ class TrafficControlDeviceBooksBuilder {
   const std::optional<std::string> traffic_light_book_path_;
   const std::optional<std::string> traffic_control_device_db_;
   const bool allow_non_driveable_lanes_;
+  const int continuous_object_samples_per_road_{10};
 };
 
 }  // namespace builder

--- a/test/regression/builder/road_geometry_configuration_test.cc
+++ b/test/regression/builder/road_geometry_configuration_test.cc
@@ -55,6 +55,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
   const double kScaleLength{2.};
   const double kIntegratorAccuracyMultiplier{0.1};
   const bool kUseUserDataIntersections{true};
+  const int kContinuousObjectSamplesPerLane{12};
 
   void ExpectEqual(const RoadGeometryConfiguration& lhs, const RoadGeometryConfiguration& rhs) {
     EXPECT_EQ(lhs.id, rhs.id);
@@ -71,6 +72,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
     EXPECT_EQ(lhs.omit_nondrivable_lanes, rhs.omit_nondrivable_lanes);
     EXPECT_EQ(lhs.integrator_accuracy_multiplier, rhs.integrator_accuracy_multiplier);
     EXPECT_EQ(lhs.use_userdata_intersections, rhs.use_userdata_intersections);
+    EXPECT_EQ(lhs.continuous_object_samples_per_lane, rhs.continuous_object_samples_per_lane);
   }
 };
 
@@ -87,7 +89,8 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       kOmitNondrivableLanes,
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
-      kUseUserDataIntersections};
+      kUseUserDataIntersections,
+      kContinuousObjectSamplesPerLane};
 
   const std::map<std::string, std::string> rg_config_map{
       {params::kRoadGeometryId, kRgId},
@@ -105,6 +108,7 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       {params::kOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
       {params::kIntegratorAccuracyMultiplier, std::to_string(kIntegratorAccuracyMultiplier)},
       {params::kUseUserDataIntersections, (kUseUserDataIntersections ? "true" : "false")},
+      {params::kContinuousObjectSamplesPerLane, std::to_string(kContinuousObjectSamplesPerLane)},
   };
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(rg_config_map)};
@@ -125,7 +129,8 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapUsingMaxLinearTolerance) {
       kOmitNondrivableLanes,
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
-      kUseUserDataIntersections};
+      kUseUserDataIntersections,
+      kContinuousObjectSamplesPerLane};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);
@@ -144,7 +149,8 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapNotUsingMaxLinearTolerance) {
       kOmitNondrivableLanes,
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
-      kUseUserDataIntersections};
+      kUseUserDataIntersections,
+      kContinuousObjectSamplesPerLane};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);

--- a/test/regression/builder/road_geometry_configuration_test.cc
+++ b/test/regression/builder/road_geometry_configuration_test.cc
@@ -55,7 +55,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
   const double kScaleLength{2.};
   const double kIntegratorAccuracyMultiplier{0.1};
   const bool kUseUserDataIntersections{true};
-  const int kContinuousObjectSamplesPerRoad{12};
+  const double kContinuousObjectSamplingDistance{12.5};
 
   void ExpectEqual(const RoadGeometryConfiguration& lhs, const RoadGeometryConfiguration& rhs) {
     EXPECT_EQ(lhs.id, rhs.id);
@@ -72,7 +72,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
     EXPECT_EQ(lhs.omit_nondrivable_lanes, rhs.omit_nondrivable_lanes);
     EXPECT_EQ(lhs.integrator_accuracy_multiplier, rhs.integrator_accuracy_multiplier);
     EXPECT_EQ(lhs.use_userdata_intersections, rhs.use_userdata_intersections);
-    EXPECT_EQ(lhs.continuous_object_samples_per_road, rhs.continuous_object_samples_per_road);
+    EXPECT_EQ(lhs.continuous_object_sampling_distance, rhs.continuous_object_sampling_distance);
   }
 };
 
@@ -90,7 +90,7 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
       kUseUserDataIntersections,
-      kContinuousObjectSamplesPerRoad};
+      kContinuousObjectSamplingDistance};
 
   const std::map<std::string, std::string> rg_config_map{
       {params::kRoadGeometryId, kRgId},
@@ -108,7 +108,7 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       {params::kOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
       {params::kIntegratorAccuracyMultiplier, std::to_string(kIntegratorAccuracyMultiplier)},
       {params::kUseUserDataIntersections, (kUseUserDataIntersections ? "true" : "false")},
-      {params::kContinuousObjectSamplesPerRoad, std::to_string(kContinuousObjectSamplesPerRoad)},
+      {params::kContinuousObjectSamplingDistance, std::to_string(kContinuousObjectSamplingDistance)},
   };
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(rg_config_map)};
@@ -130,7 +130,7 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapUsingMaxLinearTolerance) {
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
       kUseUserDataIntersections,
-      kContinuousObjectSamplesPerRoad};
+      kContinuousObjectSamplingDistance};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);
@@ -150,7 +150,7 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapNotUsingMaxLinearTolerance) {
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
       kUseUserDataIntersections,
-      kContinuousObjectSamplesPerRoad};
+      kContinuousObjectSamplingDistance};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);

--- a/test/regression/builder/road_geometry_configuration_test.cc
+++ b/test/regression/builder/road_geometry_configuration_test.cc
@@ -55,7 +55,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
   const double kScaleLength{2.};
   const double kIntegratorAccuracyMultiplier{0.1};
   const bool kUseUserDataIntersections{true};
-  const int kContinuousObjectSamplesPerLane{12};
+  const int kContinuousObjectSamplesPerRoad{12};
 
   void ExpectEqual(const RoadGeometryConfiguration& lhs, const RoadGeometryConfiguration& rhs) {
     EXPECT_EQ(lhs.id, rhs.id);
@@ -72,7 +72,7 @@ class RoadGeometryConfigurationTest : public ::testing::Test {
     EXPECT_EQ(lhs.omit_nondrivable_lanes, rhs.omit_nondrivable_lanes);
     EXPECT_EQ(lhs.integrator_accuracy_multiplier, rhs.integrator_accuracy_multiplier);
     EXPECT_EQ(lhs.use_userdata_intersections, rhs.use_userdata_intersections);
-    EXPECT_EQ(lhs.continuous_object_samples_per_lane, rhs.continuous_object_samples_per_lane);
+    EXPECT_EQ(lhs.continuous_object_samples_per_road, rhs.continuous_object_samples_per_road);
   }
 };
 
@@ -90,7 +90,7 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
       kUseUserDataIntersections,
-      kContinuousObjectSamplesPerLane};
+      kContinuousObjectSamplesPerRoad};
 
   const std::map<std::string, std::string> rg_config_map{
       {params::kRoadGeometryId, kRgId},
@@ -108,7 +108,7 @@ TEST_F(RoadGeometryConfigurationTest, Constructor) {
       {params::kOmitNonDrivableLanes, (kOmitNondrivableLanes ? "true" : "false")},
       {params::kIntegratorAccuracyMultiplier, std::to_string(kIntegratorAccuracyMultiplier)},
       {params::kUseUserDataIntersections, (kUseUserDataIntersections ? "true" : "false")},
-      {params::kContinuousObjectSamplesPerLane, std::to_string(kContinuousObjectSamplesPerLane)},
+      {params::kContinuousObjectSamplesPerRoad, std::to_string(kContinuousObjectSamplesPerRoad)},
   };
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(rg_config_map)};
@@ -130,7 +130,7 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapUsingMaxLinearTolerance) {
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
       kUseUserDataIntersections,
-      kContinuousObjectSamplesPerLane};
+      kContinuousObjectSamplesPerRoad};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);
@@ -150,7 +150,7 @@ TEST_F(RoadGeometryConfigurationTest, ToStringMapNotUsingMaxLinearTolerance) {
       kIntegratorAccuracyMultiplier,
       false /* use_userdata_traffic_direction */,
       kUseUserDataIntersections,
-      kContinuousObjectSamplesPerLane};
+      kContinuousObjectSamplesPerRoad};
 
   const RoadGeometryConfiguration dut2{RoadGeometryConfiguration::FromMap(dut1.ToStringMap())};
   ExpectEqual(dut1, dut2);

--- a/test/regression/builder/road_network_builder_test.cc
+++ b/test/regression/builder/road_network_builder_test.cc
@@ -1562,7 +1562,7 @@ TEST_F(RoadObjectBookBuilderTest, FindByType) {
 }
 
 TEST_F(RoadObjectBookBuilderTest, ConstructorThrowsOnNullptrRoadGeometry) {
-  EXPECT_THROW(TrafficControlDeviceBooksBuilder(nullptr, std::nullopt, std::nullopt, true),
+  EXPECT_THROW(TrafficControlDeviceBooksBuilder(nullptr, std::nullopt, std::nullopt, true, 10),
                maliput::common::assertion_error);
 }
 

--- a/test/regression/builder/road_network_configuration_test.cc
+++ b/test/regression/builder/road_network_configuration_test.cc
@@ -63,6 +63,7 @@ class RoadNetworkConfigurationTest : public ::testing::Test {
   const double kAngularTolerance{5e-5};
   const double kScaleLength{2.};
   const bool kUseUserDataIntersections{true};
+  const int kContinuousObjectSamplesPerRoad{12};
 
   void ExpectEqual(const RoadNetworkConfiguration& lhs, const RoadNetworkConfiguration& rhs) {
     // RoadNetworkConfiguration parameters.
@@ -95,6 +96,8 @@ class RoadNetworkConfigurationTest : public ::testing::Test {
               rhs.road_geometry_configuration.omit_nondrivable_lanes);
     EXPECT_EQ(lhs.road_geometry_configuration.use_userdata_intersections,
               rhs.road_geometry_configuration.use_userdata_intersections);
+    EXPECT_EQ(lhs.road_geometry_configuration.continuous_object_samples_per_road,
+              rhs.road_geometry_configuration.continuous_object_samples_per_road);
   }
 };
 
@@ -111,7 +114,8 @@ TEST_F(RoadNetworkConfigurationTest, Constructor) {
       kOmitNondrivableLanes,
       1.0 /* integrator_accuracy_multiplier */,
       false /* use_userdata_traffic_direction */,
-      kUseUserDataIntersections};
+      kUseUserDataIntersections,
+      kContinuousObjectSamplesPerRoad};
   RoadNetworkConfiguration dut1{rg_config,      kRuleRegistry,     kRoadRuleBook,          kTrafficLightBook,
                                 kPhaseRingBook, kIntersectionBook, kTrafficControlDeviceDb};
 
@@ -135,6 +139,7 @@ TEST_F(RoadNetworkConfigurationTest, Constructor) {
       {params::kIntersectionBook, kIntersectionBook.value()},
       {params::kTrafficControlDeviceDb, kTrafficControlDeviceDb.value()},
       {params::kUseUserDataIntersections, (kUseUserDataIntersections ? "true" : "false")},
+      {params::kContinuousObjectSamplesPerRoad, std::to_string(kContinuousObjectSamplesPerRoad)},
   };
 
   const RoadNetworkConfiguration dut2{RoadNetworkConfiguration::FromMap(rn_config_map)};
@@ -148,7 +153,7 @@ TEST_F(RoadNetworkConfigurationTest, ToStringMap) {
        builder::RoadGeometryConfiguration::BuildTolerance{kLinearTolerance, kMaxLinearTolerance, kAngularTolerance},
        kScaleLength, kRandomVector, kBuildPolicy, kSimplificationPolicy, kStandardStrictnessPolicy,
        kOmitNondrivableLanes, 1.0 /* integrator_accuracy_multiplier */, false /* use_userdata_traffic_direction */,
-       kUseUserDataIntersections},
+       kUseUserDataIntersections, kContinuousObjectSamplesPerRoad},
       kRuleRegistry,
       kRoadRuleBook,
       kTrafficLightBook,

--- a/test/regression/builder/road_network_configuration_test.cc
+++ b/test/regression/builder/road_network_configuration_test.cc
@@ -63,7 +63,7 @@ class RoadNetworkConfigurationTest : public ::testing::Test {
   const double kAngularTolerance{5e-5};
   const double kScaleLength{2.};
   const bool kUseUserDataIntersections{true};
-  const int kContinuousObjectSamplesPerRoad{12};
+  const double kContinuousObjectSamplingDistance{12.5};
 
   void ExpectEqual(const RoadNetworkConfiguration& lhs, const RoadNetworkConfiguration& rhs) {
     // RoadNetworkConfiguration parameters.
@@ -96,8 +96,8 @@ class RoadNetworkConfigurationTest : public ::testing::Test {
               rhs.road_geometry_configuration.omit_nondrivable_lanes);
     EXPECT_EQ(lhs.road_geometry_configuration.use_userdata_intersections,
               rhs.road_geometry_configuration.use_userdata_intersections);
-    EXPECT_EQ(lhs.road_geometry_configuration.continuous_object_samples_per_road,
-              rhs.road_geometry_configuration.continuous_object_samples_per_road);
+    EXPECT_EQ(lhs.road_geometry_configuration.continuous_object_sampling_distance,
+              rhs.road_geometry_configuration.continuous_object_sampling_distance);
   }
 };
 
@@ -115,7 +115,7 @@ TEST_F(RoadNetworkConfigurationTest, Constructor) {
       1.0 /* integrator_accuracy_multiplier */,
       false /* use_userdata_traffic_direction */,
       kUseUserDataIntersections,
-      kContinuousObjectSamplesPerRoad};
+      kContinuousObjectSamplingDistance};
   RoadNetworkConfiguration dut1{rg_config,      kRuleRegistry,     kRoadRuleBook,          kTrafficLightBook,
                                 kPhaseRingBook, kIntersectionBook, kTrafficControlDeviceDb};
 
@@ -139,7 +139,7 @@ TEST_F(RoadNetworkConfigurationTest, Constructor) {
       {params::kIntersectionBook, kIntersectionBook.value()},
       {params::kTrafficControlDeviceDb, kTrafficControlDeviceDb.value()},
       {params::kUseUserDataIntersections, (kUseUserDataIntersections ? "true" : "false")},
-      {params::kContinuousObjectSamplesPerRoad, std::to_string(kContinuousObjectSamplesPerRoad)},
+      {params::kContinuousObjectSamplingDistance, std::to_string(kContinuousObjectSamplingDistance)},
   };
 
   const RoadNetworkConfiguration dut2{RoadNetworkConfiguration::FromMap(rn_config_map)};
@@ -153,7 +153,7 @@ TEST_F(RoadNetworkConfigurationTest, ToStringMap) {
        builder::RoadGeometryConfiguration::BuildTolerance{kLinearTolerance, kMaxLinearTolerance, kAngularTolerance},
        kScaleLength, kRandomVector, kBuildPolicy, kSimplificationPolicy, kStandardStrictnessPolicy,
        kOmitNondrivableLanes, 1.0 /* integrator_accuracy_multiplier */, false /* use_userdata_traffic_direction */,
-       kUseUserDataIntersections, kContinuousObjectSamplesPerRoad},
+       kUseUserDataIntersections, kContinuousObjectSamplingDistance},
       kRuleRegistry,
       kRoadRuleBook,
       kTrafficLightBook,

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -966,10 +966,10 @@ TEST_F(ContinuousObjectRepeatSamplingTest, SamplingDensityIsConfigurable) {
 
   const auto coarse_network =
       RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
-                                                                {params::kOpendriveFile, xodr_file_path},
-                                                                {params::kOmitNonDrivableLanes, "false"},
-                                                                {params::kContinuousObjectSamplesPerRoad, "4"},
-                                                            })
+                                                               {params::kOpendriveFile, xodr_file_path},
+                                                               {params::kOmitNonDrivableLanes, "false"},
+                                                               {params::kContinuousObjectSamplesPerRoad, "4"},
+                                                           })
                              .ToStringMap())();
   ASSERT_NE(coarse_network, nullptr);
   const auto* coarse_ro = coarse_network->road_object_book()->GetRoadObject(
@@ -989,10 +989,10 @@ TEST_F(ContinuousObjectRepeatSamplingTest, SamplingDensityIsConfigurable) {
 
   const auto fine_network =
       RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
-                                                                {params::kOpendriveFile, xodr_file_path},
-                                                                {params::kOmitNonDrivableLanes, "false"},
-                                                                {params::kContinuousObjectSamplesPerRoad, "20"},
-                                                            })
+                                                               {params::kOpendriveFile, xodr_file_path},
+                                                               {params::kOmitNonDrivableLanes, "false"},
+                                                               {params::kContinuousObjectSamplesPerRoad, "20"},
+                                                           })
                              .ToStringMap())();
   ASSERT_NE(fine_network, nullptr);
   const auto* fine_ro = fine_network->road_object_book()->GetRoadObject(

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -332,14 +332,14 @@ TEST_F(RoadObjectBuilderTest, ContinuousPropertiesSamplingDensityIsConfigurable)
       utility::FindResourceInPath("TwoRoadsWithRoadObjects.xodr", kMalidriveResourceFolder);
   const std::string tcd_db_path =
       utility::FindResourceInPath("traffic_control_device_db/road_object_test_db.yaml", kMalidriveResourceFolder);
-  const auto road_network = RoadNetworkBuilder(
-      RoadNetworkConfiguration::FromMap({
-                                        {params::kOpendriveFile, xodr_file_path},
-                                        {params::kTrafficControlDeviceDb, tcd_db_path},
-                                        {params::kOmitNonDrivableLanes, "false"},
-                                        {params::kContinuousObjectSamplesPerRoad, "20"},
-                                    })
-          .ToStringMap())();
+  const auto road_network =
+      RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                               {params::kOpendriveFile, xodr_file_path},
+                                                               {params::kTrafficControlDeviceDb, tcd_db_path},
+                                                               {params::kOmitNonDrivableLanes, "false"},
+                                                               {params::kContinuousObjectSamplesPerRoad, "20"},
+                                                           })
+                             .ToStringMap())();
   ASSERT_NE(road_network, nullptr);
 
   const auto* road_object =
@@ -805,12 +805,11 @@ class ContinuousObjectRepeatSamplingTest : public ::testing::Test {
   void SetUp() override {
     const std::string xodr_file_path =
         utility::FindResourceInPath("ArcLaneRolledAndOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
-    road_network_ = RoadNetworkBuilder(
-        RoadNetworkConfiguration::FromMap({
-                                              {params::kOpendriveFile, xodr_file_path},
-                                              {params::kOmitNonDrivableLanes, "false"},
-                                          })
-            .ToStringMap())();
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file_path},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
     ASSERT_NE(road_network_, nullptr);
     road_object_book_ = road_network_->road_object_book();
     ASSERT_NE(road_object_book_, nullptr);
@@ -821,14 +820,13 @@ class ContinuousObjectRepeatSamplingTest : public ::testing::Test {
 };
 
 TEST_F(ContinuousObjectRepeatSamplingTest, GuardRailRepeatProducesSamples) {
-  const auto* ro =
-      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
+  const auto* ro = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
   ASSERT_NE(ro, nullptr);
   EXPECT_EQ(11u, ro->continuous_properties().size());
   EXPECT_NEAR(ro->continuous_properties().front().width(), 0.3, 1e-3);
   EXPECT_NEAR(ro->continuous_properties().back().height(), 1.0, 1e-3);
-  EXPECT_NEAR(ro->continuous_properties().front().point_sample().z(), ro->continuous_properties().back().point_sample().z(),
-              1e-3);
+  EXPECT_NEAR(ro->continuous_properties().front().point_sample().z(),
+              ro->continuous_properties().back().point_sample().z(), 1e-3);
 }
 
 class RepeatDetachFromReferenceLineTest : public ::testing::Test {
@@ -836,12 +834,11 @@ class RepeatDetachFromReferenceLineTest : public ::testing::Test {
   void SetUp() override {
     const std::string xodr_file_path =
         utility::FindResourceInPath("ArcLaneRolledAndOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
-    road_network_ = RoadNetworkBuilder(
-        RoadNetworkConfiguration::FromMap({
-                                              {params::kOpendriveFile, xodr_file_path},
-                                              {params::kOmitNonDrivableLanes, "false"},
-                                          })
-            .ToStringMap())();
+    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                             {params::kOpendriveFile, xodr_file_path},
+                                                                             {params::kOmitNonDrivableLanes, "false"},
+                                                                         })
+                                           .ToStringMap())();
     ASSERT_NE(road_network_, nullptr);
     road_object_book_ = road_network_->road_object_book();
     ASSERT_NE(road_object_book_, nullptr);

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -301,22 +301,6 @@ TEST_F(RoadObjectBuilderTest, ObstacleObjectWithOutline) {
   EXPECT_GE(road_object->related_lanes().size(), 2u);
 }
 
-TEST_F(RoadObjectBuilderTest, ContinuousPropertiesFromRepeatDistanceZero) {
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
-  ASSERT_NE(road_object, nullptr);
-
-  const auto& continuous_properties = road_object->continuous_properties();
-  ASSERT_EQ(11u, continuous_properties.size());
-
-  // Repeat widthStart/widthEnd are absent; width falls back to object-level width.
-  EXPECT_NEAR(continuous_properties.front().width(), 7.0, kLinearTolerance);
-  EXPECT_NEAR(continuous_properties.back().width(), 7.0, kLinearTolerance);
-  EXPECT_NEAR(continuous_properties.front().height(), 0.05, kLinearTolerance);
-  EXPECT_NEAR(continuous_properties.back().height(), 0.15, kLinearTolerance);
-  EXPECT_NEAR(continuous_properties.front().point_sample().x(), 90.0, 0.5);
-  EXPECT_NEAR(continuous_properties.back().point_sample().x(), 98.0, 0.5);
-}
-
 TEST_F(RoadObjectBuilderTest, ContinuousPropertiesSamplingUsesRepeatLength) {
   const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
   ASSERT_NE(road_object, nullptr);
@@ -804,7 +788,7 @@ class ContinuousObjectRepeatSamplingTest : public ::testing::Test {
  protected:
   void SetUp() override {
     const std::string xodr_file_path =
-        utility::FindResourceInPath("ArcLaneRolledAndOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
+        utility::FindResourceInPath("ArcLaneOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
     road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
                                                                              {params::kOpendriveFile, xodr_file_path},
                                                                              {params::kOmitNonDrivableLanes, "false"},
@@ -817,23 +801,30 @@ class ContinuousObjectRepeatSamplingTest : public ::testing::Test {
 
   std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
   const maliput::api::objects::RoadObjectBook* road_object_book_{};
+  constexpr static double kLinearTolerance = 1e-2;
 };
 
 TEST_F(ContinuousObjectRepeatSamplingTest, GuardRailRepeatProducesSamples) {
   const auto* ro = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
   ASSERT_NE(ro, nullptr);
   EXPECT_EQ(11u, ro->continuous_properties().size());
-  EXPECT_NEAR(ro->continuous_properties().front().width(), 0.3, 1e-3);
-  EXPECT_NEAR(ro->continuous_properties().back().height(), 1.0, 1e-3);
-  EXPECT_NEAR(ro->continuous_properties().front().point_sample().z(),
-              ro->continuous_properties().back().point_sample().z(), 1e-3);
+  for (const auto& sample : ro->continuous_properties()) {
+    EXPECT_NEAR(sample.width(), 0.3, kLinearTolerance);
+    EXPECT_NEAR(sample.height(), 1.0, kLinearTolerance);
+  }
+  EXPECT_NEAR(ro->continuous_properties().front().point_sample().x(), 0., kLinearTolerance);
+  EXPECT_NEAR(ro->continuous_properties().front().point_sample().y(), -0.5, kLinearTolerance);
+  EXPECT_NEAR(ro->continuous_properties().front().point_sample().z(), 0., kLinearTolerance);
+  EXPECT_NEAR(ro->continuous_properties().back().point_sample().x(), 38.43, kLinearTolerance);
+  EXPECT_NEAR(ro->continuous_properties().back().point_sample().y(), 27.22, kLinearTolerance);
+  EXPECT_NEAR(ro->continuous_properties().back().point_sample().z(), 0.0, kLinearTolerance);
 }
 
 class RepeatDetachFromReferenceLineTest : public ::testing::Test {
  protected:
   void SetUp() override {
     const std::string xodr_file_path =
-        utility::FindResourceInPath("ArcLaneRolledAndOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
+        utility::FindResourceInPath("ArcLaneOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
     road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
                                                                              {params::kOpendriveFile, xodr_file_path},
                                                                              {params::kOmitNonDrivableLanes, "false"},

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -30,8 +30,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <maliput/api/lane_data.h>
@@ -299,37 +301,6 @@ TEST_F(RoadObjectBuilderTest, ObstacleObjectWithOutline) {
 
   // Validity spans both lanes.
   EXPECT_GE(road_object->related_lanes().size(), 2u);
-}
-
-TEST_F(RoadObjectBuilderTest, ContinuousPropertiesSamplingUsesRepeatLength) {
-  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
-  ASSERT_NE(road_object, nullptr);
-  const auto& continuous_properties = road_object->continuous_properties();
-  ASSERT_EQ(11u, continuous_properties.size());
-  EXPECT_NEAR(continuous_properties[0].point_sample().x(), 90.0, 0.5);
-  EXPECT_NEAR(continuous_properties[1].point_sample().x(), 90.8, 0.5);
-  EXPECT_NEAR(continuous_properties.back().point_sample().x(), 98.0, 0.5);
-}
-
-TEST_F(RoadObjectBuilderTest, ContinuousPropertiesSamplingDensityIsConfigurable) {
-  const std::string xodr_file_path =
-      utility::FindResourceInPath("TwoRoadsWithRoadObjects.xodr", kMalidriveResourceFolder);
-  const std::string tcd_db_path =
-      utility::FindResourceInPath("traffic_control_device_db/road_object_test_db.yaml", kMalidriveResourceFolder);
-  const auto road_network =
-      RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
-                                                               {params::kOpendriveFile, xodr_file_path},
-                                                               {params::kTrafficControlDeviceDb, tcd_db_path},
-                                                               {params::kOmitNonDrivableLanes, "false"},
-                                                               {params::kContinuousObjectSamplesPerRoad, "20"},
-                                                           })
-                             .ToStringMap())();
-  ASSERT_NE(road_network, nullptr);
-
-  const auto* road_object =
-      road_network->road_object_book()->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
-  ASSERT_NE(road_object, nullptr);
-  EXPECT_EQ(21u, road_object->continuous_properties().size());
 }
 
 TEST_F(RoadObjectBuilderTest, VegetationObjectWithCornerLocalOutline) {
@@ -784,6 +755,39 @@ TEST_F(RoadObjectBuilderDirectionFilterTest, SignalOrientationBidirectionalNoFil
   EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_1"; }));
 }
 
+// Expected inertial position of one ContinuousObject sample.
+struct ExpectedSample {
+  double x{};
+  double y{};
+};
+
+// Checks that `samples`' point_sample()s match `expected`, in order, within `tolerance`.
+// z is always 0 for this map: the arc road has no elevation profile and every repeat
+// has zOffsetStart = zOffsetEnd = 0.
+void ExpectSamplePoints(const std::vector<maliput::api::objects::ContinuousObject>& samples,
+                        const std::vector<ExpectedSample>& expected, double tolerance) {
+  ASSERT_EQ(expected.size(), samples.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    SCOPED_TRACE("sample index " + std::to_string(i));
+    EXPECT_NEAR(samples[i].point_sample().x(), expected[i].x, tolerance);
+    EXPECT_NEAR(samples[i].point_sample().y(), expected[i].y, tolerance);
+    EXPECT_NEAR(samples[i].point_sample().z(), 0., tolerance);
+  }
+}
+
+// ArcLaneOffsetWithGuardRail.xodr: road "1" is one arc, curvature = 0.025 -> R = 40 m,
+// starting at (0, 0) with hdg = 0, curving left about C = (0, 40). No elevation profile
+// and no superelevation, so z = 0 everywhere. The XODR `t` coordinate is measured from
+// the reference line (the `laneOffset a=2.0` shifts lanes, not `t`), therefore:
+//
+//   from math import sin, cos
+//   R = 40.0
+//   def pt(s, t):
+//       th = s / R
+//       return ((R - t) * sin(th), R - (R - t) * cos(th))
+//   def lerp(a, b, r): return a + (b - a) * r
+//
+// Every sample of an attached (non-detached) repeat must also satisfy |P - C| = R - t.
 class ContinuousObjectRepeatSamplingTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -807,17 +811,201 @@ class ContinuousObjectRepeatSamplingTest : public ::testing::Test {
 TEST_F(ContinuousObjectRepeatSamplingTest, GuardRailRepeatProducesSamples) {
   const auto* ro = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
   ASSERT_NE(ro, nullptr);
-  EXPECT_EQ(11u, ro->continuous_properties().size());
-  for (const auto& sample : ro->continuous_properties()) {
+  const auto& samples = ro->continuous_properties();
+  ASSERT_EQ(11u, samples.size());
+  for (const auto& sample : samples) {
     EXPECT_NEAR(sample.width(), 0.3, kLinearTolerance);
     EXPECT_NEAR(sample.height(), 1.0, kLinearTolerance);
   }
-  EXPECT_NEAR(ro->continuous_properties().front().point_sample().x(), 0., kLinearTolerance);
-  EXPECT_NEAR(ro->continuous_properties().front().point_sample().y(), -0.5, kLinearTolerance);
-  EXPECT_NEAR(ro->continuous_properties().front().point_sample().z(), 0., kLinearTolerance);
-  EXPECT_NEAR(ro->continuous_properties().back().point_sample().x(), 38.43, kLinearTolerance);
-  EXPECT_NEAR(ro->continuous_properties().back().point_sample().y(), 27.22, kLinearTolerance);
-  EXPECT_NEAR(ro->continuous_properties().back().point_sample().z(), 0.0, kLinearTolerance);
+
+  // guardrail_right_boundary: repeat s=[0, 50], t = -0.5 constant.
+  const std::vector<ExpectedSample> kExpected{
+      {0.00000, -0.50000},   // s =  0.0
+      {5.04933, -0.18401},   // s =  5.0
+      {10.01986, 0.75905},   // s = 10.0
+      {14.83404, 2.31444},   // s = 15.0
+      {19.41673, 4.45791},   // s = 20.0
+      {23.69644, 7.15599},   // s = 25.0
+      {27.60637, 10.36660},  // s = 30.0
+      {31.08551, 14.03963},  // s = 35.0
+      {34.07957, 18.11776},  // s = 40.0
+      {36.54184, 22.53735},  // s = 45.0
+      {38.43388, 27.22944},  // s = 50.0
+  };
+  ExpectSamplePoints(samples, kExpected, kLinearTolerance);
+
+  // On the arc, not a chord: |P - C| = R - t = 40.5 for every sample.
+  const maliput::api::InertialPosition kCenter{0., 40., 0.};
+  for (const auto& sample : samples) {
+    const auto& p = sample.point_sample();
+    EXPECT_NEAR(std::hypot(p.x() - kCenter.x(), p.y() - kCenter.y()), 40.5, kLinearTolerance);
+  }
+
+  // Uniform arc-length spacing between consecutive samples: 2*40.5*sin(2.5/40) ~= 5.05920.
+  for (size_t i = 1; i < samples.size(); ++i) {
+    const auto& prev = samples[i - 1].point_sample();
+    const auto& curr = samples[i].point_sample();
+    EXPECT_NEAR(std::hypot(curr.x() - prev.x(), curr.y() - prev.y()), 5.05920, kLinearTolerance);
+  }
+}
+
+TEST_F(ContinuousObjectRepeatSamplingTest, LeftGuardRailInterpolatesLateralOffset) {
+  const auto* ro = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_left_boundary"));
+  ASSERT_NE(ro, nullptr);
+  const auto& samples = ro->continuous_properties();
+  ASSERT_EQ(11u, samples.size());
+
+  // guardrail_left_boundary: repeat s=[50, 100], t: 4.5 -> 5.0 (interpolated).
+  const std::vector<ExpectedSample> kExpected{
+      {33.68895, 28.80606},  // s =  50.0, t = 4.50
+      {34.77266, 33.10328},  // s =  55.0, t = 4.55
+      {35.31132, 37.49590},  // s =  60.0, t = 4.60
+      {35.29808, 41.91516},  // s =  65.0, t = 4.65
+      {34.73470, 46.29209},  // s =  70.0, t = 4.70
+      {33.63152, 50.55856},  // s =  75.0, t = 4.75
+      {32.00727, 54.64837},  // s =  80.0, t = 4.80
+      {29.88874, 58.49826},  // s =  85.0, t = 4.85
+      {27.31037, 62.04889},  // s =  90.0, t = 4.90
+      {24.31366, 65.24576},  // s =  95.0, t = 4.95
+      {20.94653, 68.04003},  // s = 100.0, t = 5.00
+  };
+  ExpectSamplePoints(samples, kExpected, kLinearTolerance);
+
+  // |P - C| = R - t = 35.5 - 0.05*i for every sample, proving `t` is interpolated
+  // across the repeat rather than pinned to tStart.
+  const maliput::api::InertialPosition kCenter{0., 40., 0.};
+  for (size_t i = 0; i < samples.size(); ++i) {
+    SCOPED_TRACE("sample index " + std::to_string(i));
+    const auto& p = samples[i].point_sample();
+    const double expected_radius = 35.5 - 0.05 * static_cast<double>(i);
+    EXPECT_NEAR(std::hypot(p.x() - kCenter.x(), p.y() - kCenter.y()), expected_radius, kLinearTolerance);
+  }
+
+  // heightStart == heightEnd == 1.0, so height must stay constant.
+  for (const auto& sample : samples) {
+    EXPECT_NEAR(sample.height(), 1.0, kLinearTolerance);
+  }
+}
+
+TEST_F(ContinuousObjectRepeatSamplingTest, LeftGuardRailWidthInterpolatesAcrossRepeat) {
+  constexpr double kWidthTolerance{1e-9};
+
+  const auto* left = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_left_boundary"));
+  ASSERT_NE(left, nullptr);
+  const auto& left_samples = left->continuous_properties();
+  ASSERT_EQ(11u, left_samples.size());
+
+  // guardrail_left_boundary: widthStart = 0.3 -> widthEnd = 1.3, linear over the repeat.
+  const std::vector<double> kExpectedWidths{0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3};
+  ASSERT_EQ(kExpectedWidths.size(), left_samples.size());
+  for (size_t i = 0; i < kExpectedWidths.size(); ++i) {
+    SCOPED_TRACE("sample index " + std::to_string(i));
+    EXPECT_NEAR(left_samples[i].width(), kExpectedWidths[i], kWidthTolerance);
+  }
+
+  // Endpoints match the XODR attributes exactly.
+  EXPECT_NEAR(left_samples.front().width(), 0.3, kWidthTolerance);
+  EXPECT_NEAR(left_samples.back().width(), 1.3, kWidthTolerance);
+
+  // Strictly increasing, with a uniform 0.1 step: linear interpolation, not a
+  // step/nearest-neighbour scheme.
+  for (size_t i = 1; i < left_samples.size(); ++i) {
+    SCOPED_TRACE("gap " + std::to_string(i - 1) + "->" + std::to_string(i));
+    EXPECT_GT(left_samples[i].width(), left_samples[i - 1].width());
+    EXPECT_NEAR(left_samples[i].width() - left_samples[i - 1].width(), 0.1, kWidthTolerance);
+  }
+
+  // Height is untouched by the width interpolation.
+  for (const auto& sample : left_samples) {
+    EXPECT_NEAR(sample.height(), 1.0, kWidthTolerance);
+  }
+
+  // Contrast: guardrail_right_boundary has widthStart == widthEnd == 0.3, so its
+  // width must stay constant. This pins down that the ramp above comes from the
+  // repeat's widthStart/widthEnd, not from `ratio` leaking into every object.
+  const auto* right =
+      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
+  ASSERT_NE(right, nullptr);
+  for (const auto& sample : right->continuous_properties()) {
+    EXPECT_NEAR(sample.width(), 0.3, kWidthTolerance);
+  }
+}
+
+TEST_F(ContinuousObjectRepeatSamplingTest, SamplingSpansRepeatRangeNotRoadRange) {
+  const auto* right =
+      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
+  ASSERT_NE(right, nullptr);
+  const auto& right_samples = right->continuous_properties();
+  ASSERT_EQ(11u, right_samples.size());
+  EXPECT_NEAR(right_samples.front().point_sample().x(), 0.00000, kLinearTolerance);
+  EXPECT_NEAR(right_samples.front().point_sample().y(), -0.50000, kLinearTolerance);
+  EXPECT_NEAR(right_samples.back().point_sample().x(), 38.43388, kLinearTolerance);
+  EXPECT_NEAR(right_samples.back().point_sample().y(), 27.22944, kLinearTolerance);
+
+  const auto* left = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_left_boundary"));
+  ASSERT_NE(left, nullptr);
+  const auto& left_samples = left->continuous_properties();
+  ASSERT_EQ(11u, left_samples.size());
+  EXPECT_NEAR(left_samples.front().point_sample().x(), 33.68895, kLinearTolerance);
+  EXPECT_NEAR(left_samples.front().point_sample().y(), 28.80606, kLinearTolerance);
+  EXPECT_NEAR(left_samples.back().point_sample().x(), 20.94653, kLinearTolerance);
+  EXPECT_NEAR(left_samples.back().point_sample().y(), 68.04003, kLinearTolerance);
+
+  // guardrail_right_boundary's repeat only covers s=[0, 50], half of the 100 m road.
+  // If sampling were driven by the road length instead of repeat.length, its last
+  // sample would land near the road end (s=100) instead of s=50.
+  constexpr double kRoadEndX = 20.69857;
+  constexpr double kRoadEndY = 67.87251;
+  const auto& right_last = right_samples.back().point_sample();
+  EXPECT_GT(std::hypot(right_last.x() - kRoadEndX, right_last.y() - kRoadEndY), 1.0);
+}
+
+TEST_F(ContinuousObjectRepeatSamplingTest, SamplingDensityIsConfigurable) {
+  const std::string xodr_file_path =
+      utility::FindResourceInPath("ArcLaneOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
+
+  const auto coarse_network =
+      RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                {params::kOpendriveFile, xodr_file_path},
+                                                                {params::kOmitNonDrivableLanes, "false"},
+                                                                {params::kContinuousObjectSamplesPerRoad, "4"},
+                                                            })
+                             .ToStringMap())();
+  ASSERT_NE(coarse_network, nullptr);
+  const auto* coarse_ro = coarse_network->road_object_book()->GetRoadObject(
+      maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
+  ASSERT_NE(coarse_ro, nullptr);
+  const auto& coarse_samples = coarse_ro->continuous_properties();
+
+  // samples_per_road = 4 -> step = 50/4 = 12.5 -> 5 samples at s = {0, 12.5, 25, 37.5, 50}.
+  const std::vector<ExpectedSample> kExpectedCoarse{
+      {0.00000, -0.50000},   // s =  0.0
+      {12.45126, 1.46150},   // s = 12.5
+      {23.69644, 7.15599},   // s = 25.0
+      {32.64628, 16.03189},  // s = 37.5
+      {38.43388, 27.22944},  // s = 50.0
+  };
+  ExpectSamplePoints(coarse_samples, kExpectedCoarse, kLinearTolerance);
+
+  const auto fine_network =
+      RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                {params::kOpendriveFile, xodr_file_path},
+                                                                {params::kOmitNonDrivableLanes, "false"},
+                                                                {params::kContinuousObjectSamplesPerRoad, "20"},
+                                                            })
+                             .ToStringMap())();
+  ASSERT_NE(fine_network, nullptr);
+  const auto* fine_ro = fine_network->road_object_book()->GetRoadObject(
+      maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
+  ASSERT_NE(fine_ro, nullptr);
+  const auto& fine_samples = fine_ro->continuous_properties();
+  ASSERT_EQ(21u, fine_samples.size());
+
+  // Endpoints are always sampled regardless of density.
+  EXPECT_NEAR(fine_samples.front().point_sample().x(), 0.00000, kLinearTolerance);
+  EXPECT_NEAR(fine_samples.front().point_sample().y(), -0.50000, kLinearTolerance);
+  EXPECT_NEAR(fine_samples.back().point_sample().x(), 38.43388, kLinearTolerance);
+  EXPECT_NEAR(fine_samples.back().point_sample().y(), 27.22944, kLinearTolerance);
 }
 
 class RepeatDetachFromReferenceLineTest : public ::testing::Test {
@@ -840,6 +1028,8 @@ class RepeatDetachFromReferenceLineTest : public ::testing::Test {
 };
 
 TEST_F(RepeatDetachFromReferenceLineTest, DetachedRepeatSamplesAChord) {
+  constexpr double kLinearTolerance{1e-2};
+
   const auto* detached =
       road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_detached_boundary"));
   ASSERT_NE(detached, nullptr);
@@ -852,9 +1042,9 @@ TEST_F(RepeatDetachFromReferenceLineTest, DetachedRepeatSamplesAChord) {
   const auto expected_mid_x = (detached_start.x() + detached_end.x()) / 2.;
   const auto expected_mid_y = (detached_start.y() + detached_end.y()) / 2.;
   const auto expected_mid_z = (detached_start.z() + detached_end.z()) / 2.;
-  EXPECT_NEAR(detached_mid.x(), expected_mid_x, 1e-2);
-  EXPECT_NEAR(detached_mid.y(), expected_mid_y, 1e-2);
-  EXPECT_NEAR(detached_mid.z(), expected_mid_z, 1e-2);
+  EXPECT_NEAR(detached_mid.x(), expected_mid_x, kLinearTolerance);
+  EXPECT_NEAR(detached_mid.y(), expected_mid_y, kLinearTolerance);
+  EXPECT_NEAR(detached_mid.z(), expected_mid_z, kLinearTolerance);
 
   const auto* attached =
       road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
@@ -865,6 +1055,38 @@ TEST_F(RepeatDetachFromReferenceLineTest, DetachedRepeatSamplesAChord) {
 
   const double midpoint_delta = std::hypot(attached_mid.x() - expected_mid_x, attached_mid.y() - expected_mid_y);
   EXPECT_GT(midpoint_delta, 0.1);
+
+  // guardrail_detached_boundary is the same repeat as guardrail_right_boundary
+  // (t=-0.5, s=[0,50]) plus detachFromReferenceLine="true", so its samples are a
+  // straight Lerp between the arc's start and end points, not points on the arc.
+  const std::vector<ExpectedSample> kExpected{
+      {0.00000, -0.50000},   // ratio = 0.0
+      {3.84339, 2.27294},    // ratio = 0.1
+      {7.68678, 5.04589},    // ratio = 0.2
+      {11.53016, 7.81883},   // ratio = 0.3
+      {15.37355, 10.59178},  // ratio = 0.4
+      {19.21694, 13.36472},  // ratio = 0.5
+      {23.06033, 16.13767},  // ratio = 0.6
+      {26.90371, 18.91061},  // ratio = 0.7
+      {30.74710, 21.68356},  // ratio = 0.8
+      {34.59049, 24.45650},  // ratio = 0.9
+      {38.43388, 27.22944},  // ratio = 1.0
+  };
+  ExpectSamplePoints(detached_samples, kExpected, kLinearTolerance);
+
+  // Uniform spacing along the chord: 47.392879 / 10 ~= 4.739288 between consecutive
+  // samples.
+  for (size_t i = 1; i < detached_samples.size(); ++i) {
+    const auto& prev = detached_samples[i - 1].point_sample();
+    const auto& curr = detached_samples[i].point_sample();
+    EXPECT_NEAR(std::hypot(curr.x() - prev.x(), curr.y() - prev.y()), 4.739288, kLinearTolerance);
+  }
+
+  // The detached branch must not disturb the interpolated width/height dimensions.
+  for (const auto& sample : detached_samples) {
+    EXPECT_NEAR(sample.width(), 0.3, kLinearTolerance);
+    EXPECT_NEAR(sample.height(), 1.0, kLinearTolerance);
+  }
 }
 
 }  // namespace

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -301,6 +301,53 @@ TEST_F(RoadObjectBuilderTest, ObstacleObjectWithOutline) {
   EXPECT_GE(road_object->related_lanes().size(), 2u);
 }
 
+TEST_F(RoadObjectBuilderTest, ContinuousPropertiesFromRepeatDistanceZero) {
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
+  ASSERT_NE(road_object, nullptr);
+
+  const auto& continuous_properties = road_object->continuous_properties();
+  ASSERT_EQ(11u, continuous_properties.size());
+
+  // Repeat widthStart/widthEnd are absent; width falls back to object-level width.
+  EXPECT_NEAR(continuous_properties.front().width(), 7.0, kLinearTolerance);
+  EXPECT_NEAR(continuous_properties.back().width(), 7.0, kLinearTolerance);
+  EXPECT_NEAR(continuous_properties.front().height(), 0.05, kLinearTolerance);
+  EXPECT_NEAR(continuous_properties.back().height(), 0.15, kLinearTolerance);
+  EXPECT_NEAR(continuous_properties.front().point_sample().x(), 90.0, 0.5);
+  EXPECT_NEAR(continuous_properties.back().point_sample().x(), 98.0, 0.5);
+}
+
+TEST_F(RoadObjectBuilderTest, ContinuousPropertiesSamplingUsesRepeatLength) {
+  const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
+  ASSERT_NE(road_object, nullptr);
+  const auto& continuous_properties = road_object->continuous_properties();
+  ASSERT_EQ(11u, continuous_properties.size());
+  EXPECT_NEAR(continuous_properties[0].point_sample().x(), 90.0, 0.5);
+  EXPECT_NEAR(continuous_properties[1].point_sample().x(), 90.8, 0.5);
+  EXPECT_NEAR(continuous_properties.back().point_sample().x(), 98.0, 0.5);
+}
+
+TEST_F(RoadObjectBuilderTest, ContinuousPropertiesSamplingDensityIsConfigurable) {
+  const std::string xodr_file_path =
+      utility::FindResourceInPath("TwoRoadsWithRoadObjects.xodr", kMalidriveResourceFolder);
+  const std::string tcd_db_path =
+      utility::FindResourceInPath("traffic_control_device_db/road_object_test_db.yaml", kMalidriveResourceFolder);
+  const auto road_network = RoadNetworkBuilder(
+      RoadNetworkConfiguration::FromMap({
+                                        {params::kOpendriveFile, xodr_file_path},
+                                        {params::kTrafficControlDeviceDb, tcd_db_path},
+                                        {params::kOmitNonDrivableLanes, "false"},
+                                        {params::kContinuousObjectSamplesPerRoad, "20"},
+                                    })
+          .ToStringMap())();
+  ASSERT_NE(road_network, nullptr);
+
+  const auto* road_object =
+      road_network->road_object_book()->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_obstacle"));
+  ASSERT_NE(road_object, nullptr);
+  EXPECT_EQ(21u, road_object->continuous_properties().size());
+}
+
 TEST_F(RoadObjectBuilderTest, VegetationObjectWithCornerLocalOutline) {
   // obj_vegetation: vegetation at s=0, t=4, hdg=pi/3, star-shaped cornerLocal outline.
   const auto* road_object = road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("obj_vegetation"));
@@ -751,6 +798,85 @@ TEST_F(RoadObjectBuilderDirectionFilterTest, SignalOrientationBidirectionalNoFil
   const auto lane_ids = ro->related_lanes();
   EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_-1"; }));
   EXPECT_TRUE(std::any_of(lane_ids.begin(), lane_ids.end(), [](const auto& id) { return id.string() == "1_0_1"; }));
+}
+
+class ContinuousObjectRepeatSamplingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("ArcLaneRolledAndOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
+    road_network_ = RoadNetworkBuilder(
+        RoadNetworkConfiguration::FromMap({
+                                              {params::kOpendriveFile, xodr_file_path},
+                                              {params::kOmitNonDrivableLanes, "false"},
+                                          })
+            .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_object_book_ = road_network_->road_object_book();
+    ASSERT_NE(road_object_book_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::objects::RoadObjectBook* road_object_book_{};
+};
+
+TEST_F(ContinuousObjectRepeatSamplingTest, GuardRailRepeatProducesSamples) {
+  const auto* ro =
+      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
+  ASSERT_NE(ro, nullptr);
+  EXPECT_EQ(11u, ro->continuous_properties().size());
+  EXPECT_NEAR(ro->continuous_properties().front().width(), 0.3, 1e-3);
+  EXPECT_NEAR(ro->continuous_properties().back().height(), 1.0, 1e-3);
+  EXPECT_NEAR(ro->continuous_properties().front().point_sample().z(), ro->continuous_properties().back().point_sample().z(),
+              1e-3);
+}
+
+class RepeatDetachFromReferenceLineTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string xodr_file_path =
+        utility::FindResourceInPath("ArcLaneRolledAndOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
+    road_network_ = RoadNetworkBuilder(
+        RoadNetworkConfiguration::FromMap({
+                                              {params::kOpendriveFile, xodr_file_path},
+                                              {params::kOmitNonDrivableLanes, "false"},
+                                          })
+            .ToStringMap())();
+    ASSERT_NE(road_network_, nullptr);
+    road_object_book_ = road_network_->road_object_book();
+    ASSERT_NE(road_object_book_, nullptr);
+  }
+
+  std::unique_ptr<const maliput::api::RoadNetwork> road_network_;
+  const maliput::api::objects::RoadObjectBook* road_object_book_{};
+};
+
+TEST_F(RepeatDetachFromReferenceLineTest, DetachedRepeatSamplesAChord) {
+  const auto* detached =
+      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_detached_boundary"));
+  ASSERT_NE(detached, nullptr);
+  const auto& detached_samples = detached->continuous_properties();
+  ASSERT_EQ(11u, detached_samples.size());
+
+  const auto& detached_start = detached_samples.front().point_sample();
+  const auto& detached_mid = detached_samples[detached_samples.size() / 2].point_sample();
+  const auto& detached_end = detached_samples.back().point_sample();
+  const auto expected_mid_x = (detached_start.x() + detached_end.x()) / 2.;
+  const auto expected_mid_y = (detached_start.y() + detached_end.y()) / 2.;
+  const auto expected_mid_z = (detached_start.z() + detached_end.z()) / 2.;
+  EXPECT_NEAR(detached_mid.x(), expected_mid_x, 1e-2);
+  EXPECT_NEAR(detached_mid.y(), expected_mid_y, 1e-2);
+  EXPECT_NEAR(detached_mid.z(), expected_mid_z, 1e-2);
+
+  const auto* attached =
+      road_object_book_->GetRoadObject(maliput::api::objects::RoadObject::Id("guardrail_right_boundary"));
+  ASSERT_NE(attached, nullptr);
+  const auto& attached_samples = attached->continuous_properties();
+  ASSERT_EQ(11u, attached_samples.size());
+  const auto& attached_mid = attached_samples[attached_samples.size() / 2].point_sample();
+
+  const double midpoint_delta = std::hypot(attached_mid.x() - expected_mid_x, attached_mid.y() - expected_mid_y);
+  EXPECT_GT(midpoint_delta, 0.1);
 }
 
 }  // namespace

--- a/test/regression/builder/road_object_builder_test.cc
+++ b/test/regression/builder/road_object_builder_test.cc
@@ -793,11 +793,16 @@ class ContinuousObjectRepeatSamplingTest : public ::testing::Test {
   void SetUp() override {
     const std::string xodr_file_path =
         utility::FindResourceInPath("ArcLaneOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
-    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
-                                                                             {params::kOpendriveFile, xodr_file_path},
-                                                                             {params::kOmitNonDrivableLanes, "false"},
-                                                                         })
-                                           .ToStringMap())();
+    // Explicitly pin the sampling distance to 5.0 m (equivalent to the old default of
+    // 10 samples over this fixture's 50 m repeats) so the hardcoded expectations below
+    // remain valid regardless of the builder's default continuous_object_sampling_distance.
+    road_network_ =
+        RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                 {params::kOpendriveFile, xodr_file_path},
+                                                                 {params::kOmitNonDrivableLanes, "false"},
+                                                                 {params::kContinuousObjectSamplingDistance, "5.0"},
+                                                             })
+                               .ToStringMap())();
     ASSERT_NE(road_network_, nullptr);
     road_object_book_ = road_network_->road_object_book();
     ASSERT_NE(road_object_book_, nullptr);
@@ -968,7 +973,7 @@ TEST_F(ContinuousObjectRepeatSamplingTest, SamplingDensityIsConfigurable) {
       RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
                                                                {params::kOpendriveFile, xodr_file_path},
                                                                {params::kOmitNonDrivableLanes, "false"},
-                                                               {params::kContinuousObjectSamplesPerRoad, "4"},
+                                                               {params::kContinuousObjectSamplingDistance, "12.5"},
                                                            })
                              .ToStringMap())();
   ASSERT_NE(coarse_network, nullptr);
@@ -977,7 +982,7 @@ TEST_F(ContinuousObjectRepeatSamplingTest, SamplingDensityIsConfigurable) {
   ASSERT_NE(coarse_ro, nullptr);
   const auto& coarse_samples = coarse_ro->continuous_properties();
 
-  // samples_per_road = 4 -> step = 50/4 = 12.5 -> 5 samples at s = {0, 12.5, 25, 37.5, 50}.
+  // sampling_distance = 12.5 -> 5 samples at s = {0, 12.5, 25, 37.5, 50}.
   const std::vector<ExpectedSample> kExpectedCoarse{
       {0.00000, -0.50000},   // s =  0.0
       {12.45126, 1.46150},   // s = 12.5
@@ -991,7 +996,7 @@ TEST_F(ContinuousObjectRepeatSamplingTest, SamplingDensityIsConfigurable) {
       RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
                                                                {params::kOpendriveFile, xodr_file_path},
                                                                {params::kOmitNonDrivableLanes, "false"},
-                                                               {params::kContinuousObjectSamplesPerRoad, "20"},
+                                                               {params::kContinuousObjectSamplingDistance, "2.5"},
                                                            })
                              .ToStringMap())();
   ASSERT_NE(fine_network, nullptr);
@@ -1013,11 +1018,16 @@ class RepeatDetachFromReferenceLineTest : public ::testing::Test {
   void SetUp() override {
     const std::string xodr_file_path =
         utility::FindResourceInPath("ArcLaneOffsetWithGuardRail.xodr", kMalidriveResourceFolder);
-    road_network_ = RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
-                                                                             {params::kOpendriveFile, xodr_file_path},
-                                                                             {params::kOmitNonDrivableLanes, "false"},
-                                                                         })
-                                           .ToStringMap())();
+    // Explicitly pin the sampling distance to 5.0 m (equivalent to the old default of
+    // 10 samples over this fixture's 50 m repeats) so the hardcoded expectations below
+    // remain valid regardless of the builder's default continuous_object_sampling_distance.
+    road_network_ =
+        RoadNetworkBuilder(RoadNetworkConfiguration::FromMap({
+                                                                 {params::kOpendriveFile, xodr_file_path},
+                                                                 {params::kOmitNonDrivableLanes, "false"},
+                                                                 {params::kContinuousObjectSamplingDistance, "5.0"},
+                                                             })
+                               .ToStringMap())();
     ASSERT_NE(road_network_, nullptr);
     road_object_book_ = road_network_->road_object_book();
     ASSERT_NE(road_object_book_, nullptr);

--- a/test/regression/builder/traffic_control_device_books_builder_test.cc
+++ b/test/regression/builder/traffic_control_device_books_builder_test.cc
@@ -138,7 +138,7 @@ class TrafficControlDeviceBooksBuilderTest : public ::testing::Test {
 
 // Verifies that the builder rejects a nullptr RoadGeometry.
 TEST_F(TrafficControlDeviceBooksBuilderTest, ConstructorThrowsOnNullptrRoadGeometry) {
-  EXPECT_THROW(TrafficControlDeviceBooksBuilder(nullptr, std::nullopt, std::nullopt, true),
+  EXPECT_THROW(TrafficControlDeviceBooksBuilder(nullptr, std::nullopt, std::nullopt, true, 10),
                maliput::common::assertion_error);
 }
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
* Sample continuous RoadObject.
* Sampling step can be set as a `RoadGeometry` param: `continuous_object_sample_distance`, which is in meters.
  * The start and end points are always sampled.
* Sampling points are located at the bottom of the continuous objects in h-coordinate, in the middle of their width in the r-coordinate at each s-coordinate that was sampled.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
